### PR TITLE
feat: add interactive HTML schema renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ converter/      OpenAPI v3 -> JSON Schema transforms (ported from openapi2jsonsc
 extractor/      client-go CRD listing, schema extraction, file writing, config builder
 index/          HTML index generation (deepspace theme, client-side search, starfield/flare effects)
 publisher/      Cloudflare Pages direct upload API client + BLAKE3 hashing
+renderer/       HTML schema page renderer (collapsible property trees, type badges, constraints)
+theme/          Shared CSS/HTML/JS constants (deepspace theme, starfield, flare, toggle, toast, footer)
 watcher/        CRD informer watch loop, debounce, leader election, health server
 ```
 
@@ -59,6 +61,7 @@ go run ./cmd/ preview
 | `POD_NAMESPACE` | Yes (watch) | — | Namespace for leader lease (set via downward API) |
 | `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
+| `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address (preview mode) |
 
 ### Key Design Decisions
@@ -67,8 +70,10 @@ go run ./cmd/ preview
 - **Cloudflare Pages direct upload API** is undocumented. Implementation reverse-engineered from wrangler source (`cloudflare/workers-sdk`). The upload flow uses JWT auth for asset operations and API token auth for deployment creation. See `publisher/publisher.go` for the full 6-step flow.
 - **BLAKE3 file hashing** exactly matches wrangler's `hashFile`: `hex(blake3(base64(content) + extension))[0:32]`. Do not change this algorithm without verifying against wrangler source.
 - **OpenAPI v3 to JSON Schema conversion** is a faithful port of `openapi2jsonschema.py` from datreeio/CRDs-catalog. Three transforms applied in order: additionalProperties, replaceIntOrString, allowNullOptionalFields.
-- **Output format** produces two directory structures: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility).
-- **Concurrency**: extractor uses 10 goroutines (buffered channel semaphore), publisher uses 3 concurrent upload workers. These match the original tools' behavior.
+- **Schema renderer** generates interactive HTML documentation pages (collapsible `<details>`/`<summary>` property trees, type/required badges, YAML boilerplate). Uses `html/template` with recursive `{{define "properties"}}` for nested schemas. Enabled by default; disable with `SKIP_RENDER=true`.
+- **Theme package** (`theme/`) holds shared CSS, HTML fragments, and JS used by both index and renderer templates. CSS custom properties are the union of both pages' needs. The deepspace theme (starfield, flare, light/dark toggle) is defined once here.
+- **Output format** produces two directory structures: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility). Each JSON schema also gets a sibling `.html` documentation page.
+- **Concurrency**: extractor uses 10 goroutines (buffered channel semaphore), publisher uses 3 concurrent upload workers, renderer uses 10 goroutines. These match the original tools' behavior.
 - **Watch mode uses full re-extract.** Simpler than incremental. Upload is already incremental via check-missing. Extraction of <200 CRDs is sub-second.
 - **Leader election uses standard client-go leaderelection.** LeaseLock with 15s/10s/2s timings. Leader exits on lease loss (standard controller pattern).
 - **All replicas report ready.** Readiness is not gated on leadership. Standard controller pattern — leadership is an internal concern.
@@ -99,5 +104,6 @@ Kubernetes manifests live in the `home-ops` repo under `apps/kubernetes-schemas/
 - Adding CGO dependencies — breaks static compilation and distroless compatibility
 - Modifying the CF Pages upload flow without checking current wrangler source — the API is undocumented and may change
 - Forgetting to update both output directory formats (primary + master-standalone) when changing schema file naming
+- When modifying shared CSS or HTML fragments, edit `theme/theme.go` — do not duplicate changes across `index/index.go` and `renderer/renderer.go`
 - The index template uses a deepspace-inspired theme (starfield via coprime-tiled radial gradients, light flare via stripe/rainbow interference). Both effects are pure CSS, dark-mode only, hidden in light mode via `.light body::before, .light .flare { display: none }` (`.light` class is on `<html>`, set in a `<head>` script to prevent FOUC)
 - The flare uses `filter: opacity(50%)` AND `opacity: 0.25` intentionally — these multiply to ~12.5% effective opacity. Do not "simplify" by removing one.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Extracts CRD JSON schemas from a Kubernetes cluster and publishes them to a Clou
 
 - Extracts OpenAPI v3 schemas from all CustomResourceDefinitions in a cluster
 - Converts to standard JSON Schema (ports [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) transforms)
+- Renders interactive HTML documentation pages for each schema with collapsible property trees, type badges, and constraints
 - Generates a browsable HTML index page with search, dark/light mode, and visual effects inspired by the Scalar deepspace theme
 - Uploads directly to Cloudflare Pages using the direct upload API
 - Creates the CF Pages project automatically if it doesn't exist
@@ -40,6 +41,7 @@ Commands:
 | `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address for preview server (preview mode) |
+| `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
 
 ### Run in Kubernetes
 
@@ -117,10 +119,12 @@ docker buildx build --platform linux/amd64,linux/arm64 -t crd-schema-publisher .
 ```
 <output-dir>/
   <apigroup>/
-    <kind>_<version>.json          # Primary format
+    <kind>_<version>.json          # JSON schema
+    <kind>_<version>.html          # Interactive documentation page
   master-standalone/
     <apigroup>-<kind>-stable-<version>.json  # kubeval-compatible format
   index.html                       # Browsable schema index
+  favicon.svg                      # Constellation icon
 ```
 
 ## How It Works
@@ -132,8 +136,9 @@ docker buildx build --platform linux/amd64,linux/arm64 -t crd-schema-publisher .
    - Replaces `int-or-string` format with `oneOf [string, integer]`
    - Allows null for optional fields
 4. Writes schemas to both primary and kubeval-compatible directory formats
-5. Generates an HTML index grouped by API group with client-side search, stats, and yaml-language-server usage examples
-6. Uploads to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
+5. Renders an interactive HTML documentation page for each schema with collapsible property trees
+6. Generates an HTML index grouped by API group with client-side search, stats, and yaml-language-server usage examples
+7. Uploads to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
 
 ## License
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/index"
 	"github.com/sholdee/crd-schema-publisher/publisher"
+	"github.com/sholdee/crd-schema-publisher/renderer"
 	"github.com/sholdee/crd-schema-publisher/watcher"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 )
@@ -98,6 +99,13 @@ func runExtract() error {
 		return err
 	}
 	fmt.Printf("Wrote %d JSON schemas to %s\n", count, outputDir)
+
+	if os.Getenv("SKIP_RENDER") != "true" {
+		fmt.Println("Rendering schema pages...")
+		if err := renderer.RenderAll(outputDir); err != nil {
+			return fmt.Errorf("rendering schemas: %w", err)
+		}
+	}
 
 	fmt.Println("Generating index.html...")
 	if err := index.Generate(outputDir); err != nil {
@@ -209,6 +217,16 @@ func runPreview() error {
 		fmt.Printf("Using sample data in %s\n", dir)
 	} else {
 		fmt.Printf("Using existing output at %s\n", dir)
+	}
+
+	if os.Getenv("SKIP_RENDER") != "true" {
+		fmt.Println("Rendering schema pages...")
+		if err := renderer.RenderAll(dir); err != nil {
+			if isTempDir {
+				os.RemoveAll(dir)
+			}
+			return fmt.Errorf("rendering schemas: %w", err)
+		}
 	}
 
 	fmt.Println("Generating index.html...")

--- a/index/index.go
+++ b/index/index.go
@@ -11,8 +11,9 @@ import (
 )
 
 type schemaEntry struct {
-	Name string
-	Path string
+	Name     string
+	Path     string
+	HtmlPath string
 }
 
 type groupData struct {
@@ -345,7 +346,7 @@ metadata:
 <details class="group" data-group="{{.Name}}">
 <summary><span class="group-name">{{.Name}}</span> <span class="badge">{{len .Schemas}}</span></summary>
 <div class="schemas">
-{{range .Schemas}}<a href="/{{.Path}}" data-schema="{{.Name}}" data-url="/{{.Path}}">{{.Name}}<span class="copy-hint">copy URL</span></a>
+{{range .Schemas}}<a href="/{{.HtmlPath}}" data-schema="{{.Name}}" data-url="/{{.Path}}">{{.Name}}<span class="copy-hint">copy URL</span></a>
 {{end}}</div>
 </details>
 {{end}}
@@ -509,9 +510,16 @@ func Generate(outputDir string) error {
 			if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
 				continue
 			}
+			jsonPath := groupName + "/" + f.Name()
+			htmlPath := jsonPath
+			htmlFile := strings.TrimSuffix(f.Name(), ".json") + ".html"
+			if _, err := os.Stat(filepath.Join(groupDir, htmlFile)); err == nil {
+				htmlPath = groupName + "/" + htmlFile
+			}
 			groups[groupName] = append(groups[groupName], schemaEntry{
-				Name: f.Name(),
-				Path: groupName + "/" + f.Name(),
+				Name:     f.Name(),
+				Path:     jsonPath,
+				HtmlPath: htmlPath,
 			})
 			totalCount++
 		}

--- a/index/index.go
+++ b/index/index.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/sholdee/crd-schema-publisher/theme"
 )
 
 type schemaEntry struct {
@@ -56,109 +58,20 @@ func writeFavicon(outputDir string) error {
 	return os.WriteFile(filepath.Join(outputDir, "favicon.svg"), []byte(faviconSVG), 0o644)
 }
 
-const indexTemplate = `<!DOCTYPE html>
+var indexTemplate = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Kubernetes CRD Schemas</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<style>
-  :root {
-    --bg: #09090b;
-    --bg-surface: rgba(24, 24, 27, 0.6);
-    --bg-hover: rgba(24, 24, 27, 0.8);
-    --fg: #fafafa;
-    --fg-muted: #a1a1aa;
-    --accent: #6bc1fe;
-    --accent-dim: rgba(107, 193, 254, 0.15);
-    --border: rgba(255, 255, 255, 0.1);
-    --border-active: #6bc1fe;
-    --stat-fg: #fafafa;
-    --stripes-dark: repeating-linear-gradient(100deg, #000 0%, #000 7%, transparent 10%, transparent 12%, #000 16%);
-    --rainbow: repeating-linear-gradient(100deg, #fff 10%, #fff 16%, #fff 22%, #fff 30%);
-  }
-  .light {
-    --bg: #f5f7fa;
-    --bg-surface: #ffffff;
-    --bg-hover: #edf0f4;
-    --fg: #18181b;
-    --fg-muted: #6b7785;
-    --accent: #2563b0;
-    --accent-dim: rgba(37, 99, 176, 0.08);
-    --border: #d8dde4;
-    --border-active: #2563b0;
-    --stat-fg: #18181b;
-    --stripes-dark: none;
-    --rainbow: none;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    background: var(--bg); color: var(--fg);
-    max-width: 920px; margin: 0 auto; padding: 2.5rem 1.25rem;
-    position: relative; z-index: 1;
-    transition: background 0.2s, color 0.2s;
-  }
-  body::before {
-    content: '';
-    position: fixed; inset: 0; z-index: -2;
-    pointer-events: none;
-    background-image:
-      radial-gradient(1.5px 1.5px at 31px 47px, rgba(255,255,255,1), transparent),
-      radial-gradient(1px 1px at 212px 23px, rgba(255,255,255,0.7), transparent),
-      radial-gradient(1.5px 1.5px at 68px 289px, rgba(255,255,255,0.84), transparent),
-      radial-gradient(1px 1px at 313px 151px, rgba(255,255,255,0.56), transparent),
-      radial-gradient(1px 1px at 157px 371px, rgba(255,255,255,0.6), transparent),
-      radial-gradient(2px 2px at 19px 83px, rgba(255,255,255,0.96), transparent),
-      radial-gradient(1px 1px at 301px 41px, rgba(255,255,255,0.6), transparent),
-      radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent),
-      radial-gradient(1px 1px at 443px 237px, rgba(255,255,255,0.5), transparent),
-      radial-gradient(1.5px 1.5px at 67px 491px, rgba(255,255,255,0.72), transparent),
-      radial-gradient(1px 1px at 11px 37px, rgba(255,255,255,0.72), transparent),
-      radial-gradient(1.5px 1.5px at 191px 213px, rgba(255,255,255,0.9), transparent),
-      radial-gradient(1px 1px at 53px 7px, rgba(255,255,255,0.5), transparent),
-      radial-gradient(1px 1px at 271px 103px, rgba(255,255,255,0.64), transparent);
-    background-size:
-      397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px,
-      509px 509px, 509px 509px, 509px 509px, 509px 509px, 509px 509px,
-      311px 311px, 311px 311px, 311px 311px, 311px 311px;
-    mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
-    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
-  }
-  .flare {
-    position: fixed; top: 0; right: 0;
-    width: 100vw; height: 450px; z-index: -1;
-    pointer-events: none;
-    background-image: var(--stripes-dark), var(--rainbow);
-    background-size: 300% 200%;
-    background-position: 50% 50%;
-    filter: opacity(50%) saturate(200%);
-    opacity: 0.25;
-    mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
-    -webkit-mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
-  }
-  .flare::after {
-    content: '';
-    position: absolute; inset: 0;
-    background-image: var(--stripes-dark), var(--rainbow);
-    background-size: 200% 100%;
-    background-attachment: fixed;
-    mix-blend-mode: difference;
-  }
-  .light body::before, .light .flare { display: none; }
+<style>` + theme.CSSVars + theme.CSSBase + `
   header { margin-bottom: 2rem; }
   .title-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.25rem; }
   .title-group { display: flex; align-items: center; gap: 0.6rem; }
   .title-icon { width: 28px; height: 28px; flex-shrink: 0; }
   h1 { font-size: 1.6rem; font-weight: 700; letter-spacing: -0.02em; }
   .subtitle { color: var(--fg-muted); font-size: 0.85rem; margin-bottom: 1.5rem; }
-  .theme-toggle {
-    background: none; border: 1px solid var(--border); border-radius: 6px;
-    color: var(--fg-muted); cursor: pointer; padding: 0.35rem 0.6rem; font-size: 0.85rem;
-    transition: border-color 0.2s, color 0.2s;
-  }
-  .theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
   .stats {
     display: flex; gap: 1.5rem; margin-bottom: 1.5rem;
     flex-wrap: wrap;
@@ -252,21 +165,6 @@ const indexTemplate = `<!DOCTYPE html>
   }
   .schemas a:hover .copy-hint { display: inline; }
   .schemas a .copy-hint:hover { background: var(--accent-dim); color: var(--accent); }
-  .copied-toast {
-    position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
-    background: var(--accent); color: #09090b; padding: 0.4rem 1rem;
-    border-radius: 6px; font-size: 0.8rem; font-weight: 600;
-    opacity: 0; transition: opacity 0.2s;
-    pointer-events: none; z-index: 10;
-  }
-  .copied-toast.show { opacity: 1; }
-  footer {
-    margin-top: 3rem; padding-top: 1.5rem;
-    border-top: 1px solid var(--border);
-    text-align: center; font-size: 0.8rem; color: var(--fg-muted);
-  }
-  footer a { color: var(--accent); text-decoration: none; }
-  footer a:hover { text-decoration: underline; }
   .back-to-top {
     position: fixed; bottom: 1.5rem; right: 1.5rem;
     background: var(--bg-surface); color: var(--fg-muted);
@@ -279,10 +177,10 @@ const indexTemplate = `<!DOCTYPE html>
   .back-to-top:hover { color: var(--accent); border-color: var(--accent); }
   .back-to-top.visible { display: flex; }
 </style>
-<script>if(localStorage.getItem('theme')==='light')document.documentElement.className='light';</script>
+` + theme.HeadScript + `
 </head>
 <body>
-<div class="flare"></div>
+` + theme.FlareDiv + `
 <header>
   <div class="title-row">
     <div class="title-group">
@@ -311,7 +209,7 @@ const indexTemplate = `<!DOCTYPE html>
       </svg>
       <h1>Kubernetes CRD Schemas</h1>
     </div>
-    <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀/☾</button>
+    ` + theme.ThemeToggleButton + `
   </div>
   <p class="subtitle">JSON schemas extracted from live CRD definitions</p>
   <div class="stats">
@@ -355,10 +253,8 @@ metadata:
 {{end}}
 </div>
 <p class="no-results" id="no-results">No matching groups or schemas.</p>
-<div class="copied-toast" id="toast">Copied!</div>
-<footer>
-  Generated by <a href="https://github.com/sholdee/crd-schema-publisher">crd-schema-publisher</a>
-</footer>
+` + theme.ToastDiv + `
+` + theme.FooterHTML + `
 <button class="back-to-top" id="back-to-top" title="Back to top" aria-label="Back to top">&#8593;</button>
 <script>
 (function(){
@@ -433,11 +329,12 @@ metadata:
         if (hadOpen) {
           allExpanded = false;
           toggleAll.textContent = 'Expand all';
+        } else {
+          window.scrollTo({top: 0, behavior: 'smooth'});
         }
         if (document.activeElement && document.activeElement !== document.body) {
           document.activeElement.blur();
         }
-        window.scrollTo({top: 0, behavior: 'smooth'});
       }
     }
     if (e.key === '/' && !e.ctrlKey && !e.metaKey && document.activeElement !== input) {
@@ -532,10 +429,7 @@ metadata:
   }
 })();
 
-function toggleTheme(){
-  document.documentElement.classList.toggle('light');
-  localStorage.setItem('theme', document.documentElement.classList.contains('light') ? 'light' : 'dark');
-}
+` + theme.ThemeToggleJS + `
 </script>
 </body>
 </html>`

--- a/index/index.go
+++ b/index/index.go
@@ -13,7 +13,7 @@ import (
 type schemaEntry struct {
 	Name     string
 	Path     string
-	HtmlPath string
+	HTMLPath string
 }
 
 type groupData struct {
@@ -346,7 +346,7 @@ metadata:
 <details class="group" data-group="{{.Name}}">
 <summary><span class="group-name">{{.Name}}</span> <span class="badge">{{len .Schemas}}</span></summary>
 <div class="schemas">
-{{range .Schemas}}<a href="/{{.HtmlPath}}" data-schema="{{.Name}}" data-url="/{{.Path}}">{{.Name}}<span class="copy-hint">copy URL</span></a>
+{{range .Schemas}}<a href="/{{.HTMLPath}}" data-schema="{{.Name}}" data-url="/{{.Path}}">{{.Name}}<span class="copy-hint">copy URL</span></a>
 {{end}}</div>
 </details>
 {{end}}
@@ -519,7 +519,7 @@ func Generate(outputDir string) error {
 			groups[groupName] = append(groups[groupName], schemaEntry{
 				Name:     f.Name(),
 				Path:     jsonPath,
-				HtmlPath: htmlPath,
+				HTMLPath: htmlPath,
 			})
 			totalCount++
 		}

--- a/index/index.go
+++ b/index/index.go
@@ -247,8 +247,11 @@ const indexTemplate = `<!DOCTYPE html>
   .schemas a .copy-hint {
     display: none; margin-left: 0.5rem;
     font-size: 0.65rem; color: var(--fg-muted); font-family: inherit;
+    padding: 0.1rem 0.4rem; border-radius: 4px;
+    transition: background 0.15s, color 0.15s;
   }
   .schemas a:hover .copy-hint { display: inline; }
+  .schemas a .copy-hint:hover { background: var(--accent-dim); color: var(--accent); }
   .copied-toast {
     position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
     background: var(--accent); color: #09090b; padding: 0.4rem 1rem;
@@ -417,15 +420,26 @@ metadata:
     history.replaceState(null, '', q ? '#q=' + encodeURIComponent(q) : location.pathname);
   });
 
-  input.addEventListener('keydown', function(e){
-    if (e.key === 'Escape') {
-      this.value = '';
-      this.dispatchEvent(new Event('input'));
-      this.blur();
-    }
-  });
-
   document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      if (input.value) {
+        input.value = '';
+        input.dispatchEvent(new Event('input'));
+        input.blur();
+      } else {
+        var hadOpen = false;
+        groups.forEach(function(g){ if (g.hasAttribute('open')) { hadOpen = true; g.removeAttribute('open'); } });
+        if (hadOpen) {
+          allExpanded = false;
+          toggleAll.textContent = 'Expand all';
+        }
+        if (document.activeElement && document.activeElement !== document.body) {
+          document.activeElement.blur();
+        }
+        window.scrollTo({top: 0, behavior: 'smooth'});
+      }
+    }
     if (e.key === '/' && !e.ctrlKey && !e.metaKey && document.activeElement !== input) {
       e.preventDefault();
       input.focus();
@@ -477,6 +491,45 @@ metadata:
   document.querySelectorAll('.usage-content code').forEach(function(el){
     el.textContent = el.textContent.replace(/https:\/\/YOUR_DOMAIN/g, location.origin);
   });
+
+  // Save view state before navigating to a schema page
+  document.getElementById('groups').addEventListener('click', function(e){
+    var link = e.target.closest('.schemas a');
+    if (!link || e.target.classList.contains('copy-hint')) return;
+    var expanded = [];
+    groups.forEach(function(g){ if (g.hasAttribute('open')) expanded.push(g.dataset.group); });
+    sessionStorage.setItem('indexState', JSON.stringify({
+      expanded: expanded,
+      scroll: window.scrollY,
+      toggleAll: allExpanded,
+      search: input.value
+    }));
+  });
+
+  // Restore view state when returning from a schema page
+  var saved = sessionStorage.getItem('indexState');
+  if (saved) {
+    sessionStorage.removeItem('indexState');
+    try {
+      var state = JSON.parse(saved);
+      if (state.search) {
+        input.value = state.search;
+        input.dispatchEvent(new Event('input'));
+      }
+      if (state.expanded && state.expanded.length) {
+        groups.forEach(function(g){
+          if (state.expanded.indexOf(g.dataset.group) !== -1) g.setAttribute('open','');
+        });
+      }
+      if (state.toggleAll) {
+        allExpanded = true;
+        toggleAll.textContent = 'Collapse all';
+      }
+      if (state.scroll) {
+        window.scrollTo(0, state.scroll);
+      }
+    } catch(e) {}
+  }
 })();
 
 function toggleTheme(){

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -163,6 +163,46 @@ func TestGenerate_CreatesFavicon(t *testing.T) {
 	}
 }
 
+func TestGenerate_LinksToHTMLWhenPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{}`), 0o644)
+	os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.html"), []byte(`<html></html>`), 0o644)
+
+	err := Generate(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "index.html"))
+	html := string(data)
+
+	if !strings.Contains(html, `href="/example.io/thing_v1.html"`) {
+		t.Error("schema link should point to .html when HTML file exists")
+	}
+	if !strings.Contains(html, `data-url="/example.io/thing_v1.json"`) {
+		t.Error("data-url should always point to .json for copy behavior")
+	}
+}
+
+func TestGenerate_FallsBackToJSONWhenNoHTML(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{}`), 0o644)
+
+	err := Generate(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "index.html"))
+	html := string(data)
+
+	if !strings.Contains(html, `href="/example.io/thing_v1.json"`) {
+		t.Error("schema link should fall back to .json when no HTML file exists")
+	}
+}
+
 func TestGenerate_SkipsNonJsonFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -206,6 +207,37 @@ func renderSchemaFile(jsonPath, group, filename string) error {
 	defer f.Close()
 
 	return tmpl.Execute(f, pageData)
+}
+
+// RenderAll walks the output directory and generates an HTML page for each JSON schema.
+// Skips the master-standalone directory and non-JSON files.
+func RenderAll(outputDir string) error {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return fmt.Errorf("reading output dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "master-standalone" {
+			continue
+		}
+		groupName := entry.Name()
+		groupDir := filepath.Join(outputDir, groupName)
+		files, err := os.ReadDir(groupDir)
+		if err != nil {
+			return fmt.Errorf("reading group dir %s: %w", groupName, err)
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
+				continue
+			}
+			jsonPath := filepath.Join(groupDir, f.Name())
+			if err := renderSchemaFile(jsonPath, groupName, f.Name()); err != nil {
+				return fmt.Errorf("rendering %s/%s: %w", groupName, f.Name(), err)
+			}
+		}
+	}
+	return nil
 }
 
 const schemaTemplate = `<!DOCTYPE html>

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -152,7 +152,7 @@ type schemaPageData struct {
 }
 
 // renderSchemaFile reads a JSON schema file and writes a sibling .html file.
-func renderSchemaFile(jsonPath, group, filename string) error {
+func renderSchemaFile(tmpl *template.Template, jsonPath, group, filename string) error {
 	data, err := os.ReadFile(jsonPath)
 	if err != nil {
 		return fmt.Errorf("reading schema %s: %w", jsonPath, err)
@@ -179,6 +179,19 @@ func renderSchemaFile(jsonPath, group, filename string) error {
 		Schema:   &schema,
 	}
 
+	htmlPath := strings.TrimSuffix(jsonPath, ".json") + ".html"
+	f, err := os.Create(htmlPath)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", htmlPath, err)
+	}
+	defer f.Close()
+
+	return tmpl.Execute(f, pageData)
+}
+
+// RenderAll walks the output directory and generates an HTML page for each JSON schema.
+// Skips the master-standalone directory and non-JSON files.
+func RenderAll(outputDir string) error {
 	funcMap := template.FuncMap{
 		"childNode": func(n *SchemaNode) *SchemaNode {
 			if len(n.Properties) > 0 {
@@ -199,19 +212,6 @@ func renderSchemaFile(jsonPath, group, filename string) error {
 		return fmt.Errorf("parsing template: %w", err)
 	}
 
-	htmlPath := strings.TrimSuffix(jsonPath, ".json") + ".html"
-	f, err := os.Create(htmlPath)
-	if err != nil {
-		return fmt.Errorf("creating %s: %w", htmlPath, err)
-	}
-	defer f.Close()
-
-	return tmpl.Execute(f, pageData)
-}
-
-// RenderAll walks the output directory and generates an HTML page for each JSON schema.
-// Skips the master-standalone directory and non-JSON files.
-func RenderAll(outputDir string) error {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
 		return fmt.Errorf("reading output dir: %w", err)
@@ -232,7 +232,7 @@ func RenderAll(outputDir string) error {
 				continue
 			}
 			jsonPath := filepath.Join(groupDir, f.Name())
-			if err := renderSchemaFile(jsonPath, groupName, f.Name()); err != nil {
+			if err := renderSchemaFile(tmpl, jsonPath, groupName, f.Name()); err != nil {
 				return fmt.Errorf("rendering %s/%s: %w", groupName, f.Name(), err)
 			}
 		}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // SchemaNode represents a JSON Schema node for rendering.
@@ -212,11 +213,18 @@ func RenderAll(outputDir string) error {
 		return fmt.Errorf("parsing template: %w", err)
 	}
 
+	type renderJob struct {
+		jsonPath  string
+		groupName string
+		fileName  string
+	}
+
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
 		return fmt.Errorf("reading output dir: %w", err)
 	}
 
+	var jobs []renderJob
 	for _, entry := range entries {
 		if !entry.IsDir() || entry.Name() == "master-standalone" {
 			continue
@@ -231,11 +239,34 @@ func RenderAll(outputDir string) error {
 			if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
 				continue
 			}
-			jsonPath := filepath.Join(groupDir, f.Name())
-			if err := renderSchemaFile(tmpl, jsonPath, groupName, f.Name()); err != nil {
-				return fmt.Errorf("rendering %s/%s: %w", groupName, f.Name(), err)
-			}
+			jobs = append(jobs, renderJob{
+				jsonPath:  filepath.Join(groupDir, f.Name()),
+				groupName: groupName,
+				fileName:  f.Name(),
+			})
 		}
+	}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 10)
+	errs := make(chan error, len(jobs))
+
+	for _, job := range jobs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(j renderJob) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := renderSchemaFile(tmpl, j.jsonPath, j.groupName, j.fileName); err != nil {
+				errs <- fmt.Errorf("rendering %s/%s: %w", j.groupName, j.fileName, err)
+			}
+		}(job)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		return err
 	}
 	return nil
 }
@@ -339,7 +370,13 @@ const schemaTemplate = `<!DOCTYPE html>
     display: flex; align-items: center; justify-content: space-between;
     margin-bottom: 1.5rem;
   }
-  .back-link { font-size: 0.85rem; }
+  .back-link { font-size: 0.85rem; display: flex; align-items: center; gap: 0.4rem; }
+  .back-link kbd {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 0.6rem; color: var(--fg-muted); background: var(--bg-surface);
+    border: 1px solid var(--border); border-radius: 4px;
+    padding: 0.1rem 0.35rem; line-height: 1;
+  }
   .theme-toggle {
     background: none; border: 1px solid var(--border); border-radius: 6px;
     color: var(--fg-muted); cursor: pointer; padding: 0.35rem 0.6rem; font-size: 0.85rem;
@@ -370,7 +407,7 @@ const schemaTemplate = `<!DOCTYPE html>
     background: none; border: none; color: var(--fg-muted); cursor: pointer;
     font-size: 0.8rem; padding: 0.2rem 0; transition: color 0.15s;
   }
-  .toolbar button:hover, .toolbar a:hover { color: var(--accent); text-decoration: none; }
+  .toolbar button:hover, .toolbar a:hover { color: var(--accent); text-decoration: underline; }
   .prop {
     border: 1px solid var(--border); border-radius: 6px;
     margin-bottom: 0.35rem; transition: border-color 0.2s;
@@ -440,7 +477,7 @@ const schemaTemplate = `<!DOCTYPE html>
 <body>
 <div class="flare"></div>
 <div class="nav-row">
-  <a href="/" class="back-link">← Back to index</a>
+  <a href="/" class="back-link">← Back to index <kbd>Esc</kbd></a>
   <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀/☾</button>
 </div>
 <div class="meta-cards">
@@ -510,6 +547,15 @@ metadata:
   });
   var toast = document.getElementById('toast');
   var toastTimer;
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      if (document.activeElement && document.activeElement !== document.body) {
+        document.activeElement.blur();
+      }
+      location.href = '/';
+    }
+  });
   document.getElementById('copy-url').addEventListener('click', function(){
     var url = location.origin + this.dataset.url;
     navigator.clipboard.writeText(url).then(function(){

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/sholdee/crd-schema-publisher/theme"
 )
 
 // SchemaNode represents a JSON Schema node for rendering.
@@ -271,99 +273,14 @@ func RenderAll(outputDir string) error {
 	return nil
 }
 
-const schemaTemplate = `<!DOCTYPE html>
+var schemaTemplate = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{.Kind}} {{.Version}} — {{.Group}}</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<style>
-  :root {
-    --bg: #09090b;
-    --bg-surface: rgba(24, 24, 27, 0.6);
-    --bg-hover: rgba(24, 24, 27, 0.8);
-    --fg: #fafafa;
-    --fg-muted: #a1a1aa;
-    --accent: #6bc1fe;
-    --accent-dim: rgba(107, 193, 254, 0.15);
-    --border: rgba(255, 255, 255, 0.1);
-    --border-active: #6bc1fe;
-    --required-bg: rgba(251, 191, 36, 0.15);
-    --required-fg: #fbbf24;
-    --stripes-dark: repeating-linear-gradient(100deg, #000 0%, #000 7%, transparent 10%, transparent 12%, #000 16%);
-    --rainbow: repeating-linear-gradient(100deg, #fff 10%, #fff 16%, #fff 22%, #fff 30%);
-  }
-  .light {
-    --bg: #f5f7fa;
-    --bg-surface: #ffffff;
-    --bg-hover: #edf0f4;
-    --fg: #18181b;
-    --fg-muted: #6b7785;
-    --accent: #2563b0;
-    --accent-dim: rgba(37, 99, 176, 0.08);
-    --border: #d8dde4;
-    --border-active: #2563b0;
-    --required-bg: rgba(217, 119, 6, 0.1);
-    --required-fg: #b45309;
-    --stripes-dark: none;
-    --rainbow: none;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    background: var(--bg); color: var(--fg);
-    max-width: 920px; margin: 0 auto; padding: 2.5rem 1.25rem;
-    position: relative; z-index: 1;
-    transition: background 0.2s, color 0.2s;
-  }
-  body::before {
-    content: '';
-    position: fixed; inset: 0; z-index: -2;
-    pointer-events: none;
-    background-image:
-      radial-gradient(1.5px 1.5px at 31px 47px, rgba(255,255,255,1), transparent),
-      radial-gradient(1px 1px at 212px 23px, rgba(255,255,255,0.7), transparent),
-      radial-gradient(1.5px 1.5px at 68px 289px, rgba(255,255,255,0.84), transparent),
-      radial-gradient(1px 1px at 313px 151px, rgba(255,255,255,0.56), transparent),
-      radial-gradient(1px 1px at 157px 371px, rgba(255,255,255,0.6), transparent),
-      radial-gradient(2px 2px at 19px 83px, rgba(255,255,255,0.96), transparent),
-      radial-gradient(1px 1px at 301px 41px, rgba(255,255,255,0.6), transparent),
-      radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent),
-      radial-gradient(1px 1px at 443px 237px, rgba(255,255,255,0.5), transparent),
-      radial-gradient(1.5px 1.5px at 67px 491px, rgba(255,255,255,0.72), transparent),
-      radial-gradient(1px 1px at 11px 37px, rgba(255,255,255,0.72), transparent),
-      radial-gradient(1.5px 1.5px at 191px 213px, rgba(255,255,255,0.9), transparent),
-      radial-gradient(1px 1px at 53px 7px, rgba(255,255,255,0.5), transparent),
-      radial-gradient(1px 1px at 271px 103px, rgba(255,255,255,0.64), transparent);
-    background-size:
-      397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px,
-      509px 509px, 509px 509px, 509px 509px, 509px 509px, 509px 509px,
-      311px 311px, 311px 311px, 311px 311px, 311px 311px;
-    mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
-    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
-  }
-  .flare {
-    position: fixed; top: 0; right: 0;
-    width: 100vw; height: 450px; z-index: -1;
-    pointer-events: none;
-    background-image: var(--stripes-dark), var(--rainbow);
-    background-size: 300% 200%;
-    background-position: 50% 50%;
-    filter: opacity(50%) saturate(200%);
-    opacity: 0.25;
-    mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
-    -webkit-mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
-  }
-  .flare::after {
-    content: '';
-    position: absolute; inset: 0;
-    background-image: var(--stripes-dark), var(--rainbow);
-    background-size: 200% 100%;
-    background-attachment: fixed;
-    mix-blend-mode: difference;
-  }
-  .light body::before, .light .flare { display: none; }
+<style>` + theme.CSSVars + theme.CSSBase + `
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .nav-row {
@@ -377,12 +294,6 @@ const schemaTemplate = `<!DOCTYPE html>
     border: 1px solid var(--border); border-radius: 4px;
     padding: 0.1rem 0.35rem; line-height: 1;
   }
-  .theme-toggle {
-    background: none; border: 1px solid var(--border); border-radius: 6px;
-    color: var(--fg-muted); cursor: pointer; padding: 0.35rem 0.6rem; font-size: 0.85rem;
-    transition: border-color 0.2s, color 0.2s;
-  }
-  .theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
   .meta-cards {
     display: flex; gap: 0.75rem; margin-bottom: 1.25rem; flex-wrap: wrap;
   }
@@ -456,29 +367,14 @@ const schemaTemplate = `<!DOCTYPE html>
     color: var(--fg-muted); font-size: 0.75rem; margin-top: 0.15rem;
     font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
   }
-  .copied-toast {
-    position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
-    background: var(--accent); color: #09090b; padding: 0.4rem 1rem;
-    border-radius: 6px; font-size: 0.8rem; font-weight: 600;
-    opacity: 0; transition: opacity 0.2s;
-    pointer-events: none; z-index: 10;
-  }
-  .copied-toast.show { opacity: 1; }
-  footer {
-    margin-top: 3rem; padding-top: 1.5rem;
-    border-top: 1px solid var(--border);
-    text-align: center; font-size: 0.8rem; color: var(--fg-muted);
-  }
-  footer a { color: var(--accent); text-decoration: none; }
-  footer a:hover { text-decoration: underline; }
 </style>
-<script>if(localStorage.getItem('theme')==='light')document.documentElement.className='light';</script>
+` + theme.HeadScript + `
 </head>
 <body>
-<div class="flare"></div>
+` + theme.FlareDiv + `
 <div class="nav-row">
   <a href="/" class="back-link">← Back to index <kbd>Esc</kbd></a>
-  <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀/☾</button>
+  ` + theme.ThemeToggleButton + `
 </div>
 <div class="meta-cards">
   <div class="meta-card"><div class="label">Kind</div><div class="value">{{.Kind}}</div></div>
@@ -532,10 +428,8 @@ metadata:
 <div id="properties">
 {{- template "properties" .Schema}}
 </div>
-<div class="copied-toast" id="toast">Copied!</div>
-<footer>
-  Generated by <a href="https://github.com/sholdee/crd-schema-publisher">crd-schema-publisher</a>
-</footer>
+` + theme.ToastDiv + `
+` + theme.FooterHTML + `
 <script>
 (function(){
   var props = document.querySelectorAll('.prop');
@@ -565,10 +459,7 @@ metadata:
     });
   });
 })();
-function toggleTheme(){
-  document.documentElement.classList.toggle('light');
-  localStorage.setItem('theme', document.documentElement.classList.contains('light') ? 'light' : 'dark');
-}
+` + theme.ThemeToggleJS + `
 </script>
 </body>
 </html>`

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1,6 +1,8 @@
 package renderer
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -52,6 +54,80 @@ func (n *SchemaNode) DisplayType() string {
 	}
 
 	return raw
+}
+
+// PropertyEntry is a name+node pair for sorted iteration.
+type PropertyEntry struct {
+	Name string
+	Node *SchemaNode
+}
+
+// IsRequired returns true if the given property name is in this node's required list.
+func (n *SchemaNode) IsRequired(name string) bool {
+	for _, r := range n.Required {
+		if r == name {
+			return true
+		}
+	}
+	return false
+}
+
+// HasChildren returns true if this node has nested properties to render.
+func (n *SchemaNode) HasChildren() bool {
+	if len(n.Properties) > 0 {
+		return true
+	}
+	if n.Items != nil && len(n.Items.Properties) > 0 {
+		return true
+	}
+	return false
+}
+
+// SortedProperties returns properties sorted alphabetically by name.
+func (n *SchemaNode) SortedProperties() []PropertyEntry {
+	entries := make([]PropertyEntry, 0, len(n.Properties))
+	for name, node := range n.Properties {
+		entries = append(entries, PropertyEntry{Name: name, Node: node})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries
+}
+
+// Constraints returns human-readable constraint strings for display.
+func (n *SchemaNode) Constraints() []string {
+	var cs []string
+	if len(n.Enum) > 0 {
+		vals := make([]string, len(n.Enum))
+		for i, v := range n.Enum {
+			vals[i] = fmt.Sprintf("%v", v)
+		}
+		cs = append(cs, "enum: "+strings.Join(vals, ", "))
+	}
+	if n.Pattern != "" {
+		cs = append(cs, "pattern: "+n.Pattern)
+	}
+	if n.Format != "" {
+		cs = append(cs, "format: "+n.Format)
+	}
+	if n.MinLength != nil {
+		cs = append(cs, fmt.Sprintf("minLength: %d", *n.MinLength))
+	}
+	if n.MaxLength != nil {
+		cs = append(cs, fmt.Sprintf("maxLength: %d", *n.MaxLength))
+	}
+	if n.MinItems != nil {
+		cs = append(cs, fmt.Sprintf("minItems: %d", *n.MinItems))
+	}
+	if n.MaxItems != nil {
+		cs = append(cs, fmt.Sprintf("maxItems: %d", *n.MaxItems))
+	}
+	if n.Minimum != nil {
+		cs = append(cs, fmt.Sprintf("minimum: %g", *n.Minimum))
+	}
+	if n.Maximum != nil {
+		cs = append(cs, fmt.Sprintf("maximum: %g", *n.Maximum))
+	}
+	return cs
 }
 
 // resolveType extracts the non-null type from the Type field.

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1,0 +1,70 @@
+package renderer
+
+import (
+	"strings"
+)
+
+// SchemaNode represents a JSON Schema node for rendering.
+type SchemaNode struct {
+	Type                 interface{}            `json:"type,omitempty"`
+	Description          string                 `json:"description,omitempty"`
+	Properties           map[string]*SchemaNode `json:"properties,omitempty"`
+	Items                *SchemaNode            `json:"items,omitempty"`
+	Required             []string               `json:"required,omitempty"`
+	Enum                 []interface{}          `json:"enum,omitempty"`
+	OneOf                []*SchemaNode          `json:"oneOf,omitempty"`
+	AnyOf                []*SchemaNode          `json:"anyOf,omitempty"`
+	AllOf                []*SchemaNode          `json:"allOf,omitempty"`
+	Format               string                 `json:"format,omitempty"`
+	Pattern              string                 `json:"pattern,omitempty"`
+	Minimum              *float64               `json:"minimum,omitempty"`
+	Maximum              *float64               `json:"maximum,omitempty"`
+	MinLength            *int64                 `json:"minLength,omitempty"`
+	MaxLength            *int64                 `json:"maxLength,omitempty"`
+	MinItems             *int64                 `json:"minItems,omitempty"`
+	MaxItems             *int64                 `json:"maxItems,omitempty"`
+	Default              interface{}            `json:"default,omitempty"`
+	AdditionalProperties interface{}            `json:"additionalProperties,omitempty"`
+}
+
+// DisplayType returns a human-readable type string for the schema node.
+func (n *SchemaNode) DisplayType() string {
+	if len(n.OneOf) == 2 && n.Type == nil {
+		types := make([]string, 0, 2)
+		for _, o := range n.OneOf {
+			types = append(types, o.DisplayType())
+		}
+		return strings.Join(types, " | ")
+	}
+
+	raw := n.resolveType()
+
+	if raw == "array" {
+		itemType := "object"
+		if n.Items != nil {
+			itemType = n.Items.resolveType()
+		}
+		return "[]" + itemType
+	}
+
+	if raw == "" {
+		return "object"
+	}
+
+	return raw
+}
+
+// resolveType extracts the non-null type from the Type field.
+func (n *SchemaNode) resolveType() string {
+	switch t := n.Type.(type) {
+	case string:
+		return t
+	case []interface{}:
+		for _, v := range t {
+			if s, ok := v.(string); ok && s != "null" {
+				return s
+			}
+		}
+	}
+	return ""
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1,7 +1,10 @@
 package renderer
 
 import (
+	"encoding/json"
 	"fmt"
+	"html/template"
+	"os"
 	"sort"
 	"strings"
 )
@@ -129,6 +132,368 @@ func (n *SchemaNode) Constraints() []string {
 	}
 	return cs
 }
+
+// titleCase uppercases the first letter of s.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// schemaPageData holds template data for a single schema page.
+type schemaPageData struct {
+	Kind     string
+	Group    string
+	Version  string
+	JSONPath string
+	Schema   *SchemaNode
+}
+
+// renderSchemaFile reads a JSON schema file and writes a sibling .html file.
+func renderSchemaFile(jsonPath, group, filename string) error {
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return fmt.Errorf("reading schema %s: %w", jsonPath, err)
+	}
+
+	var schema SchemaNode
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return fmt.Errorf("parsing schema %s: %w", jsonPath, err)
+	}
+
+	base := strings.TrimSuffix(filename, ".json")
+	parts := strings.SplitN(base, "_", 2)
+	kind := titleCase(parts[0])
+	version := ""
+	if len(parts) == 2 {
+		version = parts[1]
+	}
+
+	pageData := schemaPageData{
+		Kind:     kind,
+		Group:    group,
+		Version:  version,
+		JSONPath: "/" + group + "/" + filename,
+		Schema:   &schema,
+	}
+
+	funcMap := template.FuncMap{
+		"childNode": func(n *SchemaNode) *SchemaNode {
+			if len(n.Properties) > 0 {
+				return n
+			}
+			if n.Items != nil && len(n.Items.Properties) > 0 {
+				return n.Items
+			}
+			return n
+		},
+		"safeHTML": func(s string) template.HTML {
+			return template.HTML(template.HTMLEscapeString(s))
+		},
+	}
+
+	tmpl, err := template.New("schema").Funcs(funcMap).Parse(schemaTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing template: %w", err)
+	}
+
+	htmlPath := strings.TrimSuffix(jsonPath, ".json") + ".html"
+	f, err := os.Create(htmlPath)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", htmlPath, err)
+	}
+	defer f.Close()
+
+	return tmpl.Execute(f, pageData)
+}
+
+const schemaTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{.Kind}} {{.Version}} — {{.Group}}</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<style>
+  :root {
+    --bg: #09090b;
+    --bg-surface: rgba(24, 24, 27, 0.6);
+    --bg-hover: rgba(24, 24, 27, 0.8);
+    --fg: #fafafa;
+    --fg-muted: #a1a1aa;
+    --accent: #6bc1fe;
+    --accent-dim: rgba(107, 193, 254, 0.15);
+    --border: rgba(255, 255, 255, 0.1);
+    --border-active: #6bc1fe;
+    --required-bg: rgba(251, 191, 36, 0.15);
+    --required-fg: #fbbf24;
+    --stripes-dark: repeating-linear-gradient(100deg, #000 0%, #000 7%, transparent 10%, transparent 12%, #000 16%);
+    --rainbow: repeating-linear-gradient(100deg, #fff 10%, #fff 16%, #fff 22%, #fff 30%);
+  }
+  .light {
+    --bg: #f5f7fa;
+    --bg-surface: #ffffff;
+    --bg-hover: #edf0f4;
+    --fg: #18181b;
+    --fg-muted: #6b7785;
+    --accent: #2563b0;
+    --accent-dim: rgba(37, 99, 176, 0.08);
+    --border: #d8dde4;
+    --border-active: #2563b0;
+    --required-bg: rgba(217, 119, 6, 0.1);
+    --required-fg: #b45309;
+    --stripes-dark: none;
+    --rainbow: none;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg); color: var(--fg);
+    max-width: 920px; margin: 0 auto; padding: 2.5rem 1.25rem;
+    position: relative; z-index: 1;
+    transition: background 0.2s, color 0.2s;
+  }
+  body::before {
+    content: '';
+    position: fixed; inset: 0; z-index: -2;
+    pointer-events: none;
+    background-image:
+      radial-gradient(1.5px 1.5px at 31px 47px, rgba(255,255,255,1), transparent),
+      radial-gradient(1px 1px at 212px 23px, rgba(255,255,255,0.7), transparent),
+      radial-gradient(1.5px 1.5px at 68px 289px, rgba(255,255,255,0.84), transparent),
+      radial-gradient(1px 1px at 313px 151px, rgba(255,255,255,0.56), transparent),
+      radial-gradient(1px 1px at 157px 371px, rgba(255,255,255,0.6), transparent),
+      radial-gradient(2px 2px at 19px 83px, rgba(255,255,255,0.96), transparent),
+      radial-gradient(1px 1px at 301px 41px, rgba(255,255,255,0.6), transparent),
+      radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent),
+      radial-gradient(1px 1px at 443px 237px, rgba(255,255,255,0.5), transparent),
+      radial-gradient(1.5px 1.5px at 67px 491px, rgba(255,255,255,0.72), transparent),
+      radial-gradient(1px 1px at 11px 37px, rgba(255,255,255,0.72), transparent),
+      radial-gradient(1.5px 1.5px at 191px 213px, rgba(255,255,255,0.9), transparent),
+      radial-gradient(1px 1px at 53px 7px, rgba(255,255,255,0.5), transparent),
+      radial-gradient(1px 1px at 271px 103px, rgba(255,255,255,0.64), transparent);
+    background-size:
+      397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px,
+      509px 509px, 509px 509px, 509px 509px, 509px 509px, 509px 509px,
+      311px 311px, 311px 311px, 311px 311px, 311px 311px;
+    mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
+    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
+  }
+  .flare {
+    position: fixed; top: 0; right: 0;
+    width: 100vw; height: 450px; z-index: -1;
+    pointer-events: none;
+    background-image: var(--stripes-dark), var(--rainbow);
+    background-size: 300% 200%;
+    background-position: 50% 50%;
+    filter: opacity(50%) saturate(200%);
+    opacity: 0.25;
+    mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
+  }
+  .flare::after {
+    content: '';
+    position: absolute; inset: 0;
+    background-image: var(--stripes-dark), var(--rainbow);
+    background-size: 200% 100%;
+    background-attachment: fixed;
+    mix-blend-mode: difference;
+  }
+  .light body::before, .light .flare { display: none; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .nav-row {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 1.5rem;
+  }
+  .back-link { font-size: 0.85rem; }
+  .theme-toggle {
+    background: none; border: 1px solid var(--border); border-radius: 6px;
+    color: var(--fg-muted); cursor: pointer; padding: 0.35rem 0.6rem; font-size: 0.85rem;
+    transition: border-color 0.2s, color 0.2s;
+  }
+  .theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
+  .meta-cards {
+    display: flex; gap: 0.75rem; margin-bottom: 1.25rem; flex-wrap: wrap;
+  }
+  .meta-card {
+    background: var(--bg-surface); border: 1px solid var(--border);
+    border-radius: 6px; padding: 0.5rem 1rem;
+  }
+  .meta-card .label { font-size: 0.7rem; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .meta-card .value { font-size: 1rem; font-weight: 600; }
+  .yaml-block {
+    background: var(--bg-surface); border: 1px solid var(--border);
+    border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1.5rem;
+    font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+    font-size: 0.8rem; white-space: pre; overflow-x: auto; color: var(--fg);
+  }
+  .toolbar {
+    display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;
+    align-items: center; justify-content: space-between;
+  }
+  .toolbar-left { display: flex; gap: 0.75rem; }
+  .toolbar button, .toolbar a {
+    background: none; border: none; color: var(--fg-muted); cursor: pointer;
+    font-size: 0.8rem; padding: 0.2rem 0; transition: color 0.15s;
+  }
+  .toolbar button:hover, .toolbar a:hover { color: var(--accent); text-decoration: none; }
+  .prop {
+    border: 1px solid var(--border); border-radius: 6px;
+    margin-bottom: 0.35rem; transition: border-color 0.2s;
+  }
+  .prop[open] { border-color: var(--border-active); border-left-width: 2px; }
+  .prop > summary {
+    padding: 0.5rem 0.75rem; cursor: pointer;
+    font-size: 0.85rem; background: var(--bg-surface); border-radius: 6px;
+    list-style: none; display: flex; align-items: center; gap: 0.5rem;
+    transition: background 0.15s;
+  }
+  .prop > summary::-webkit-details-marker { display: none; }
+  .prop > summary::before { content: "\25B8"; color: var(--fg-muted); font-size: 0.7rem; }
+  .prop[open] > summary::before { content: "\25BE"; color: var(--accent); }
+  .prop > summary:hover { background: var(--bg-hover); }
+  .prop-content { padding: 0.5rem 0.75rem 0.75rem; padding-left: 1.5rem; }
+  .prop-leaf {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem; display: flex; align-items: flex-start; gap: 0.5rem;
+    border: 1px solid var(--border); border-radius: 6px;
+    margin-bottom: 0.35rem; background: var(--bg-surface);
+  }
+  .prop-leaf .prop-name { min-width: 0; }
+  .prop-name {
+    font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+    color: var(--accent); font-weight: 600; white-space: nowrap;
+  }
+  .type-badge {
+    background: var(--accent-dim); color: var(--accent);
+    font-size: 0.65rem; font-weight: 700; padding: 0.1rem 0.4rem;
+    border-radius: 8px; white-space: nowrap;
+  }
+  .required-badge {
+    background: var(--required-bg); color: var(--required-fg);
+    font-size: 0.65rem; font-weight: 700; padding: 0.1rem 0.4rem;
+    border-radius: 8px; white-space: nowrap;
+  }
+  .prop-desc { color: var(--fg-muted); font-size: 0.82rem; margin-top: 0.25rem; }
+  .prop-constraints {
+    color: var(--fg-muted); font-size: 0.75rem; margin-top: 0.2rem;
+    font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  }
+  .prop-children { margin-top: 0.5rem; }
+  .leaf-desc { color: var(--fg-muted); font-size: 0.82rem; flex: 1; min-width: 0; }
+  .leaf-constraints {
+    color: var(--fg-muted); font-size: 0.75rem; margin-top: 0.15rem;
+    font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  }
+  .copied-toast {
+    position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
+    background: var(--accent); color: #09090b; padding: 0.4rem 1rem;
+    border-radius: 6px; font-size: 0.8rem; font-weight: 600;
+    opacity: 0; transition: opacity 0.2s;
+    pointer-events: none; z-index: 10;
+  }
+  .copied-toast.show { opacity: 1; }
+  footer {
+    margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    text-align: center; font-size: 0.8rem; color: var(--fg-muted);
+  }
+  footer a { color: var(--accent); text-decoration: none; }
+  footer a:hover { text-decoration: underline; }
+</style>
+<script>if(localStorage.getItem('theme')==='light')document.documentElement.className='light';</script>
+</head>
+<body>
+<div class="flare"></div>
+<div class="nav-row">
+  <a href="/" class="back-link">← Back to index</a>
+  <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀/☾</button>
+</div>
+<div class="meta-cards">
+  <div class="meta-card"><div class="label">Kind</div><div class="value">{{.Kind}}</div></div>
+  <div class="meta-card"><div class="label">Group</div><div class="value">{{.Group}}</div></div>
+  <div class="meta-card"><div class="label">Version</div><div class="value">{{.Version}}</div></div>
+</div>
+<div class="yaml-block">apiVersion: {{.Group}}/{{.Version}}
+kind: {{.Kind}}
+metadata:
+  name: example</div>
+<div class="toolbar">
+  <div class="toolbar-left">
+    <button id="expand-all">Expand all</button>
+    <button id="collapse-all">Collapse all</button>
+  </div>
+  <div class="toolbar-left">
+    <a href="{{.JSONPath}}" target="_blank">View raw schema</a>
+    <button id="copy-url" data-url="{{.JSONPath}}">Copy schema URL</button>
+  </div>
+</div>
+{{- define "properties"}}
+{{- range .SortedProperties}}
+{{- if .Node.HasChildren}}
+<details class="prop">
+<summary>
+  <span class="prop-name">{{.Name}}</span>
+  <span class="type-badge">{{.Node.DisplayType}}</span>
+  {{- if $.IsRequired .Name}} <span class="required-badge">required</span>{{end}}
+</summary>
+<div class="prop-content">
+  {{- if .Node.Description}}<div class="prop-desc">{{.Node.Description}}</div>{{end}}
+  {{- range .Node.Constraints}}<div class="prop-constraints">{{safeHTML .}}</div>{{end}}
+  <div class="prop-children">
+  {{- template "properties" (childNode .Node)}}
+  </div>
+</div>
+</details>
+{{- else}}
+<div class="prop-leaf">
+  <span class="prop-name">{{.Name}}</span>
+  <span class="type-badge">{{.Node.DisplayType}}</span>
+  {{- if $.IsRequired .Name}} <span class="required-badge">required</span>{{end}}
+  <div class="leaf-desc">
+    {{- if .Node.Description}}{{.Node.Description}}{{end}}
+    {{- range .Node.Constraints}}<div class="leaf-constraints">{{safeHTML .}}</div>{{end}}
+  </div>
+</div>
+{{- end}}
+{{- end}}
+{{- end}}
+<div id="properties">
+{{- template "properties" .Schema}}
+</div>
+<div class="copied-toast" id="toast">Copied!</div>
+<footer>
+  Generated by <a href="https://github.com/sholdee/crd-schema-publisher">crd-schema-publisher</a>
+</footer>
+<script>
+(function(){
+  var props = document.querySelectorAll('.prop');
+  document.getElementById('expand-all').addEventListener('click', function(){
+    props.forEach(function(p){ p.setAttribute('open',''); });
+  });
+  document.getElementById('collapse-all').addEventListener('click', function(){
+    props.forEach(function(p){ p.removeAttribute('open'); });
+  });
+  var toast = document.getElementById('toast');
+  var toastTimer;
+  document.getElementById('copy-url').addEventListener('click', function(){
+    var url = location.origin + this.dataset.url;
+    navigator.clipboard.writeText(url).then(function(){
+      clearTimeout(toastTimer);
+      toast.classList.add('show');
+      toastTimer = setTimeout(function(){ toast.classList.remove('show'); }, 1500);
+    });
+  });
+})();
+function toggleTheme(){
+  document.documentElement.classList.toggle('light');
+  localStorage.setItem('theme', document.documentElement.classList.contains('light') ? 'light' : 'dark');
+}
+</script>
+</body>
+</html>`
 
 // resolveType extracts the non-null type from the Type field.
 func (n *SchemaNode) resolveType() string {

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -427,6 +427,68 @@ func TestRenderSchema_MinimalSchema(t *testing.T) {
 	}
 }
 
+func TestRenderAll_CreatesHTMLFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "cert-manager.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "cert-manager.io", "certificate_v1.json"),
+		[]byte(`{"type":"object","properties":{"spec":{"type":"object"}}}`), 0o644)
+	os.WriteFile(filepath.Join(tmpDir, "cert-manager.io", "issuer_v1.json"),
+		[]byte(`{"type":"object"}`), 0o644)
+	os.MkdirAll(filepath.Join(tmpDir, "monitoring.coreos.com"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "monitoring.coreos.com", "prometheus_v1.json"),
+		[]byte(`{"type":"object"}`), 0o644)
+	os.MkdirAll(filepath.Join(tmpDir, "master-standalone"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "master-standalone", "test.json"),
+		[]byte(`{"type":"object"}`), 0o644)
+
+	err := RenderAll(tmpDir)
+	if err != nil {
+		t.Fatalf("RenderAll error: %v", err)
+	}
+
+	for _, path := range []string{
+		"cert-manager.io/certificate_v1.html",
+		"cert-manager.io/issuer_v1.html",
+		"monitoring.coreos.com/prometheus_v1.html",
+	} {
+		if _, err := os.Stat(filepath.Join(tmpDir, path)); err != nil {
+			t.Errorf("expected %s to exist: %v", path, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "master-standalone", "test.html")); err == nil {
+		t.Error("master-standalone should not get HTML files")
+	}
+}
+
+func TestRenderAll_SkipsNonJsonFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{"type":"object"}`), 0o644)
+	os.WriteFile(filepath.Join(tmpDir, "example.io", "README.md"), []byte(`# hello`), 0o644)
+
+	err := RenderAll(tmpDir)
+	if err != nil {
+		t.Fatalf("RenderAll error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "example.io", "thing_v1.html")); err != nil {
+		t.Error("JSON schema should get HTML")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "example.io", "README.html")); err == nil {
+		t.Error("non-JSON file should not get HTML")
+	}
+}
+
+func TestRenderAll_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := RenderAll(tmpDir)
+	if err != nil {
+		t.Fatalf("RenderAll should handle empty dir: %v", err)
+	}
+}
+
 func TestRenderSchema_DeepNesting(t *testing.T) {
 	schema := `{
 		"type": "object",

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,11 +1,35 @@
 package renderer
 
 import (
+	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func testTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	funcMap := template.FuncMap{
+		"childNode": func(n *SchemaNode) *SchemaNode {
+			if len(n.Properties) > 0 {
+				return n
+			}
+			if n.Items != nil && len(n.Items.Properties) > 0 {
+				return n.Items
+			}
+			return n
+		},
+		"safeHTML": func(s string) template.HTML {
+			return template.HTML(template.HTMLEscapeString(s))
+		},
+	}
+	tmpl, err := template.New("schema").Funcs(funcMap).Parse(schemaTemplate)
+	if err != nil {
+		t.Fatalf("parsing template: %v", err)
+	}
+	return tmpl
+}
 
 func TestDisplayType_SimpleTypes(t *testing.T) {
 	tests := []struct {
@@ -216,7 +240,7 @@ func TestRenderSchema_BasicOutput(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "example.io", "myresource_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "example.io", "myresource_v1.json"), "example.io", "myresource_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "example.io", "myresource_v1.json"), "example.io", "myresource_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -284,7 +308,7 @@ func TestRenderSchema_LeafVsExpandable(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -325,7 +349,7 @@ func TestRenderSchema_ArrayTypes(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -356,7 +380,7 @@ func TestRenderSchema_IntOrString(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -385,7 +409,7 @@ func TestRenderSchema_EnumValues(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -408,7 +432,7 @@ func TestRenderSchema_MinimalSchema(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "test.io", "empty_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "empty_v1.json"), "test.io", "empty_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "empty_v1.json"), "test.io", "empty_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -517,7 +541,7 @@ func TestRenderSchema_DeepNesting(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	os.WriteFile(filepath.Join(tmpDir, "test.io", "deep_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "deep_v1.json"), "test.io", "deep_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "deep_v1.json"), "test.io", "deep_v1.json")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,6 +1,9 @@
 package renderer
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -176,5 +179,300 @@ func TestConstraints(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRenderSchema_BasicOutput(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"required": ["spec"],
+		"properties": {
+			"spec": {
+				"type": "object",
+				"description": "Spec defines the desired state",
+				"properties": {
+					"replicas": {
+						"type": "integer",
+						"description": "Number of replicas",
+						"minimum": 1,
+						"maximum": 10
+					},
+					"name": {
+						"type": "string",
+						"description": "Resource name",
+						"pattern": "^[a-z]+$"
+					}
+				},
+				"required": ["replicas"]
+			},
+			"status": {
+				"type": "object",
+				"description": "Status of the resource"
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "example.io", "myresource_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "example.io", "myresource_v1.json"), "example.io", "myresource_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "example.io", "myresource_v1.html"))
+	if err != nil {
+		t.Fatalf("HTML file not created: %v", err)
+	}
+
+	html := string(data)
+	checks := []struct {
+		substr string
+		desc   string
+	}{
+		{"<!DOCTYPE html>", "valid HTML document"},
+		{"Myresource v1", "page title with Kind and version"},
+		{"example.io", "group name in metadata"},
+		{"Myresource", "kind in metadata card"},
+		{"v1", "version in metadata card"},
+		{"apiVersion: example.io/v1", "YAML boilerplate"},
+		{"kind: Myresource", "YAML boilerplate kind"},
+		{"← Back to index", "back link"},
+		{"Expand all", "expand all button"},
+		{"Collapse all", "collapse all button"},
+		{"View raw schema", "raw schema link"},
+		{"myresource_v1.json", "link to JSON file"},
+		{"spec", "spec property"},
+		{"status", "status property"},
+		{"replicas", "nested property"},
+		{"Spec defines the desired state", "property description"},
+		{"Number of replicas", "nested property description"},
+		{"required", "required badge"},
+		{"integer", "type badge"},
+		{"object", "type badge for object"},
+		{"minimum: 1", "constraint display"},
+		{"maximum: 10", "constraint display"},
+		{"pattern: ^[a-z]+$", "constraint display"},
+		{"toggleTheme", "theme toggle function"},
+		{"favicon.svg", "favicon link"},
+		{"--accent", "CSS custom properties"},
+		{"body::before", "starfield CSS"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(html, c.substr) {
+			t.Errorf("HTML should contain %s (looked for %q)", c.desc, c.substr)
+		}
+	}
+}
+
+func TestRenderSchema_LeafVsExpandable(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"nested": {
+				"type": "object",
+				"properties": {
+					"inner": {"type": "string"}
+				}
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "<details") {
+		t.Error("expandable property should use <details> element")
+	}
+	if !strings.Contains(html, "prop-leaf") {
+		t.Error("leaf property should use prop-leaf class")
+	}
+}
+
+func TestRenderSchema_ArrayTypes(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"tags": {
+				"type": "array",
+				"items": {"type": "string"},
+				"description": "List of tags"
+			},
+			"servers": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"host": {"type": "string"}
+					}
+				}
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "[]string") {
+		t.Error("should show []string for string array")
+	}
+	if !strings.Contains(html, "[]object") {
+		t.Error("should show []object for object array")
+	}
+}
+
+func TestRenderSchema_IntOrString(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"port": {
+				"oneOf": [{"type": "string"}, {"type": "integer"}],
+				"description": "Port number or name"
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "string | integer") {
+		t.Error("should show 'string | integer' for oneOf int-or-string")
+	}
+}
+
+func TestRenderSchema_EnumValues(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"protocol": {
+				"type": "string",
+				"enum": ["TCP", "UDP", "SCTP"],
+				"description": "Network protocol"
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "TCP") {
+		t.Error("should show enum values")
+	}
+	if !strings.Contains(html, "enum:") {
+		t.Error("should label enum constraint")
+	}
+}
+
+func TestRenderSchema_MinimalSchema(t *testing.T) {
+	schema := `{"type":"object"}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "test.io", "empty_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "empty_v1.json"), "test.io", "empty_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "test.io", "empty_v1.html"))
+	if err != nil {
+		t.Fatalf("HTML file not created: %v", err)
+	}
+
+	html := string(data)
+	if !strings.Contains(html, "<!DOCTYPE html>") {
+		t.Error("minimal schema should still produce valid HTML")
+	}
+	if !strings.Contains(html, "Empty") {
+		t.Error("should derive Kind from filename")
+	}
+}
+
+func TestRenderSchema_DeepNesting(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"required": ["level1"],
+		"properties": {
+			"level1": {
+				"type": "object",
+				"required": ["level2"],
+				"properties": {
+					"level2": {
+						"type": "object",
+						"required": ["level3"],
+						"properties": {
+							"level3": {
+								"type": "string",
+								"description": "deeply nested"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "test.io", "deep_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(filepath.Join(tmpDir, "test.io", "deep_v1.json"), "test.io", "deep_v1.json")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "deep_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "level1") {
+		t.Error("should show level1")
+	}
+	if !strings.Contains(html, "level2") {
+		t.Error("should show level2")
+	}
+	if !strings.Contains(html, "level3") {
+		t.Error("should show level3")
+	}
+	if !strings.Contains(html, "deeply nested") {
+		t.Error("should show deeply nested description")
 	}
 }

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,0 +1,90 @@
+package renderer
+
+import (
+	"testing"
+)
+
+func TestDisplayType_SimpleTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		typVal   interface{}
+		items    *SchemaNode
+		oneOf    []*SchemaNode
+		expected string
+	}{
+		{"string", "string", nil, nil, "string"},
+		{"integer", "integer", nil, nil, "integer"},
+		{"boolean", "boolean", nil, nil, "boolean"},
+		{"number", "number", nil, nil, "number"},
+		{"object", "object", nil, nil, "object"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &SchemaNode{Type: tt.typVal, Items: tt.items, OneOf: tt.oneOf}
+			if got := n.DisplayType(); got != tt.expected {
+				t.Errorf("DisplayType() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDisplayType_NullableTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		typVal   interface{}
+		expected string
+	}{
+		{"nullable string", []interface{}{"string", "null"}, "string"},
+		{"nullable integer", []interface{}{"integer", "null"}, "integer"},
+		{"nullable object", []interface{}{"object", "null"}, "object"},
+		{"null first", []interface{}{"null", "boolean"}, "boolean"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &SchemaNode{Type: tt.typVal}
+			if got := n.DisplayType(); got != tt.expected {
+				t.Errorf("DisplayType() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDisplayType_Arrays(t *testing.T) {
+	tests := []struct {
+		name     string
+		items    *SchemaNode
+		expected string
+	}{
+		{"array of strings", &SchemaNode{Type: "string"}, "[]string"},
+		{"array of objects", &SchemaNode{Type: "object"}, "[]object"},
+		{"array of integers", &SchemaNode{Type: "integer"}, "[]integer"},
+		{"array no items", nil, "[]object"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &SchemaNode{Type: "array", Items: tt.items}
+			if got := n.DisplayType(); got != tt.expected {
+				t.Errorf("DisplayType() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDisplayType_IntOrString(t *testing.T) {
+	n := &SchemaNode{
+		OneOf: []*SchemaNode{
+			{Type: "string"},
+			{Type: "integer"},
+		},
+	}
+	if got := n.DisplayType(); got != "string | integer" {
+		t.Errorf("DisplayType() = %q, want %q", got, "string | integer")
+	}
+}
+
+func TestDisplayType_NoType(t *testing.T) {
+	n := &SchemaNode{}
+	if got := n.DisplayType(); got != "object" {
+		t.Errorf("DisplayType() = %q, want %q", got, "object")
+	}
+}

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -88,3 +88,93 @@ func TestDisplayType_NoType(t *testing.T) {
 		t.Errorf("DisplayType() = %q, want %q", got, "object")
 	}
 }
+
+func TestIsRequired(t *testing.T) {
+	parent := &SchemaNode{
+		Required: []string{"name", "spec"},
+	}
+	if !parent.IsRequired("name") {
+		t.Error("name should be required")
+	}
+	if !parent.IsRequired("spec") {
+		t.Error("spec should be required")
+	}
+	if parent.IsRequired("status") {
+		t.Error("status should not be required")
+	}
+}
+
+func TestHasChildren(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *SchemaNode
+		expected bool
+	}{
+		{"object with properties", &SchemaNode{Type: "object", Properties: map[string]*SchemaNode{"a": {}}}, true},
+		{"object no properties", &SchemaNode{Type: "object"}, false},
+		{"array with object items", &SchemaNode{Type: "array", Items: &SchemaNode{Type: "object", Properties: map[string]*SchemaNode{"a": {}}}}, true},
+		{"array with string items", &SchemaNode{Type: "array", Items: &SchemaNode{Type: "string"}}, false},
+		{"string", &SchemaNode{Type: "string"}, false},
+		{"nullable object with props", &SchemaNode{Type: []interface{}{"object", "null"}, Properties: map[string]*SchemaNode{"a": {}}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.HasChildren(); got != tt.expected {
+				t.Errorf("HasChildren() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSortedProperties(t *testing.T) {
+	node := &SchemaNode{
+		Properties: map[string]*SchemaNode{
+			"zeta":  {Type: "string"},
+			"alpha": {Type: "string"},
+			"mu":    {Type: "string"},
+		},
+	}
+	sorted := node.SortedProperties()
+	if len(sorted) != 3 {
+		t.Fatalf("expected 3 properties, got %d", len(sorted))
+	}
+	expected := []string{"alpha", "mu", "zeta"}
+	for i, p := range sorted {
+		if p.Name != expected[i] {
+			t.Errorf("property %d: got %q, want %q", i, p.Name, expected[i])
+		}
+	}
+}
+
+func TestConstraints(t *testing.T) {
+	minLen := int64(1)
+	maxLen := int64(255)
+	min := 0.0
+	max := 100.0
+
+	tests := []struct {
+		name     string
+		node     *SchemaNode
+		expected []string
+	}{
+		{"enum", &SchemaNode{Enum: []interface{}{"TCP", "UDP"}}, []string{"enum: TCP, UDP"}},
+		{"pattern", &SchemaNode{Pattern: "^[a-z]+$"}, []string{"pattern: ^[a-z]+$"}},
+		{"format", &SchemaNode{Format: "date-time"}, []string{"format: date-time"}},
+		{"min/max length", &SchemaNode{MinLength: &minLen, MaxLength: &maxLen}, []string{"minLength: 1", "maxLength: 255"}},
+		{"min/max value", &SchemaNode{Minimum: &min, Maximum: &max}, []string{"minimum: 0", "maximum: 100"}},
+		{"no constraints", &SchemaNode{Type: "string"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.node.Constraints()
+			if len(got) != len(tt.expected) {
+				t.Fatalf("Constraints() returned %d items, want %d: %v", len(got), len(tt.expected), got)
+			}
+			for i, c := range got {
+				if c != tt.expected[i] {
+					t.Errorf("constraint %d: got %q, want %q", i, c, tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -1,0 +1,139 @@
+package theme
+
+// CSSVars contains CSS custom properties for dark and light themes.
+// This is the union of variables used across all pages (index + schema renderer).
+const CSSVars = `
+  :root {
+    --bg: #09090b;
+    --bg-surface: rgba(24, 24, 27, 0.6);
+    --bg-hover: rgba(24, 24, 27, 0.8);
+    --fg: #fafafa;
+    --fg-muted: #a1a1aa;
+    --accent: #6bc1fe;
+    --accent-dim: rgba(107, 193, 254, 0.15);
+    --border: rgba(255, 255, 255, 0.1);
+    --border-active: #6bc1fe;
+    --stat-fg: #fafafa;
+    --required-bg: rgba(251, 191, 36, 0.15);
+    --required-fg: #fbbf24;
+    --stripes-dark: repeating-linear-gradient(100deg, #000 0%, #000 7%, transparent 10%, transparent 12%, #000 16%);
+    --rainbow: repeating-linear-gradient(100deg, #fff 10%, #fff 16%, #fff 22%, #fff 30%);
+  }
+  .light {
+    --bg: #f5f7fa;
+    --bg-surface: #ffffff;
+    --bg-hover: #edf0f4;
+    --fg: #18181b;
+    --fg-muted: #6b7785;
+    --accent: #2563b0;
+    --accent-dim: rgba(37, 99, 176, 0.08);
+    --border: #d8dde4;
+    --border-active: #2563b0;
+    --stat-fg: #18181b;
+    --required-bg: rgba(217, 119, 6, 0.1);
+    --required-fg: #b45309;
+    --stripes-dark: none;
+    --rainbow: none;
+  }`
+
+// CSSBase contains shared base styles: reset, body, starfield, flare, theme toggle, toast, and footer.
+const CSSBase = `
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg); color: var(--fg);
+    max-width: 920px; margin: 0 auto; padding: 2.5rem 1.25rem;
+    position: relative; z-index: 1;
+    transition: background 0.2s, color 0.2s;
+  }
+  body::before {
+    content: '';
+    position: fixed; inset: 0; z-index: -2;
+    pointer-events: none;
+    background-image:
+      radial-gradient(1.5px 1.5px at 31px 47px, rgba(255,255,255,1), transparent),
+      radial-gradient(1px 1px at 212px 23px, rgba(255,255,255,0.7), transparent),
+      radial-gradient(1.5px 1.5px at 68px 289px, rgba(255,255,255,0.84), transparent),
+      radial-gradient(1px 1px at 313px 151px, rgba(255,255,255,0.56), transparent),
+      radial-gradient(1px 1px at 157px 371px, rgba(255,255,255,0.6), transparent),
+      radial-gradient(2px 2px at 19px 83px, rgba(255,255,255,0.96), transparent),
+      radial-gradient(1px 1px at 301px 41px, rgba(255,255,255,0.6), transparent),
+      radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent),
+      radial-gradient(1px 1px at 443px 237px, rgba(255,255,255,0.5), transparent),
+      radial-gradient(1.5px 1.5px at 67px 491px, rgba(255,255,255,0.72), transparent),
+      radial-gradient(1px 1px at 11px 37px, rgba(255,255,255,0.72), transparent),
+      radial-gradient(1.5px 1.5px at 191px 213px, rgba(255,255,255,0.9), transparent),
+      radial-gradient(1px 1px at 53px 7px, rgba(255,255,255,0.5), transparent),
+      radial-gradient(1px 1px at 271px 103px, rgba(255,255,255,0.64), transparent);
+    background-size:
+      397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px,
+      509px 509px, 509px 509px, 509px 509px, 509px 509px, 509px 509px,
+      311px 311px, 311px 311px, 311px 311px, 311px 311px;
+    mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
+    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
+  }
+  .flare {
+    position: fixed; top: 0; right: 0;
+    width: 100vw; height: 450px; z-index: -1;
+    pointer-events: none;
+    background-image: var(--stripes-dark), var(--rainbow);
+    background-size: 300% 200%;
+    background-position: 50% 50%;
+    filter: opacity(50%) saturate(200%);
+    opacity: 0.25;
+    mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
+  }
+  .flare::after {
+    content: '';
+    position: absolute; inset: 0;
+    background-image: var(--stripes-dark), var(--rainbow);
+    background-size: 200% 100%;
+    background-attachment: fixed;
+    mix-blend-mode: difference;
+  }
+  .light body::before, .light .flare { display: none; }
+  .theme-toggle {
+    background: none; border: 1px solid var(--border); border-radius: 6px;
+    color: var(--fg-muted); cursor: pointer; padding: 0.35rem 0.6rem; font-size: 0.85rem;
+    transition: border-color 0.2s, color 0.2s;
+  }
+  .theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
+  .copied-toast {
+    position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
+    background: var(--accent); color: #09090b; padding: 0.4rem 1rem;
+    border-radius: 6px; font-size: 0.8rem; font-weight: 600;
+    opacity: 0; transition: opacity 0.2s;
+    pointer-events: none; z-index: 10;
+  }
+  .copied-toast.show { opacity: 1; }
+  footer {
+    margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    text-align: center; font-size: 0.8rem; color: var(--fg-muted);
+  }
+  footer a { color: var(--accent); text-decoration: none; }
+  footer a:hover { text-decoration: underline; }`
+
+// HeadScript is the FOUC prevention script placed in <head>.
+const HeadScript = `<script>if(localStorage.getItem('theme')==='light')document.documentElement.className='light';</script>`
+
+// FlareDiv is the flare background element.
+const FlareDiv = `<div class="flare"></div>`
+
+// ThemeToggleButton is the light/dark mode toggle.
+const ThemeToggleButton = `<button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀/☾</button>`
+
+// ToastDiv is the clipboard copy toast notification.
+const ToastDiv = `<div class="copied-toast" id="toast">Copied!</div>`
+
+// FooterHTML is the page footer.
+const FooterHTML = `<footer>
+  Generated by <a href="https://github.com/sholdee/crd-schema-publisher">crd-schema-publisher</a>
+</footer>`
+
+// ThemeToggleJS is the JavaScript function for toggling the theme.
+const ThemeToggleJS = `function toggleTheme(){
+  document.documentElement.classList.toggle('light');
+  localStorage.setItem('theme', document.documentElement.classList.contains('light') ? 'light' : 'dark');
+}`

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/index"
 	"github.com/sholdee/crd-schema-publisher/publisher"
+	"github.com/sholdee/crd-schema-publisher/renderer"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -239,6 +240,12 @@ func publishCycle(cfg Config) error {
 		return fmt.Errorf("writing schemas: %w", err)
 	}
 	log.Printf("Wrote %d schemas", count)
+
+	if os.Getenv("SKIP_RENDER") != "true" {
+		if err := renderer.RenderAll(cfg.OutputDir); err != nil {
+			return fmt.Errorf("rendering schemas: %w", err)
+		}
+	}
 
 	// Generate index
 	if err := index.Generate(cfg.OutputDir); err != nil {


### PR DESCRIPTION
## Summary
- Adds a full HTML documentation renderer for CRD JSON schemas, generating standalone pages with collapsible property trees, type/required badges, constraints, YAML boilerplate, and the deepspace theme
- Index page links to rendered HTML when available, falls back to raw JSON
- UX polish: sessionStorage state persistence across page navigation, progressive Escape behavior (clear search → collapse groups → scroll to top), copy-hint hover feedback, Escape hotkey on schema pages
- Concurrent rendering with 10-goroutine semaphore pool
- Shared `theme/` package deduplicates CSS/HTML/JS across index and renderer templates
- Comprehensive test coverage for schema parsing, type display, property helpers, template rendering, and RenderAll integration
- Updated README and CLAUDE.md with renderer, theme, and SKIP_RENDER documentation

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `go run ./cmd/ preview` — verify index loads with sample data, schema pages render correctly
- [x] Extract real schemas (`go run ./cmd/ extract`) and preview — verify all schema pages render with correct property trees
- [x] Verify state persistence: expand groups, search, scroll, click a schema, press back/Esc — index state is restored
- [x] Verify progressive Escape on index: type search → Esc clears → Esc collapses → Esc scrolls to top
- [x] Verify Escape hotkey on schema pages returns to index
- [x] Verify copy-hint hover styling on both index and schema pages
- [x] Verify `SKIP_RENDER=true` skips HTML generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)