### PR TITLE
ci: migrate to managerFilePatterns and pin Renovate validator

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,7 +37,7 @@
     {
       customType: 'regex',
       description: ['Process go install versions in CI workflows'],
-      fileMatch: ['\\.github/workflows/.*\\.ya?ml$'],
+      managerFilePatterns: ['/\\.github/workflows/.*\\.ya?ml$/'],
       matchStrings: [
         'go install github\\.com/(?<depName>[\\w-]+/[\\w-]+)/.+@v(?<currentValue>[\\d.]+)',
       ],
@@ -47,9 +47,9 @@
     {
       customType: 'regex',
       description: ['Process npx tool versions in CI workflows'],
-      fileMatch: ['\\.github/workflows/.*\\.ya?ml$'],
+      managerFilePatterns: ['/\\.github/workflows/.*\\.ya?ml$/'],
       matchStrings: [
-        'npx --yes (?<depName>[\\w-]+)@(?<currentValue>[\\d.]+)',
+        'npx --yes (?:--package )?(?<depName>[\\w-]+)@(?<currentValue>[\\d.]+)',
       ],
       datasourceTemplate: 'npm',
       versioningTemplate: 'npm',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,12 @@
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
     },
+    {
+      description: 'Rate-limit Renovate self-updates (multiple releases per day)',
+      matchPackageNames: ['renovate'],
+      schedule: ['before 2am'],
+      minimumReleaseAge: '1 day',
+    },
   ],
   customManagers: [
     {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,7 +244,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate Renovate config
-        run: npx --yes --package renovate -- renovate-config-validator --strict
+        run: npx --yes --package renovate@43.110.18 -- renovate-config-validator --strict
 
   gate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Migrate `fileMatch` to `managerFilePatterns` (canonical field name per current Renovate docs)
- Pin `renovate-config-validator` to v43.110.18 — `npx` was caching v37 which didn't recognize the new field, causing PR #10's migration to fail validation
- Update npx regex to match both `npx --yes pkg@ver` and `npx --yes --package pkg@ver`

## Test plan

- [x] `renovate` job passes with `--strict` validation
- [x] `gate` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)