### PR TITLE
feat: add Prometheus metrics endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ index/          HTML index generation (deepspace theme, client-side search, star
 publisher/      Cloudflare Pages direct upload API client + BLAKE3 hashing
 renderer/       HTML schema page renderer (collapsible property trees, type badges, constraints)
 theme/          Shared CSS/HTML/JS constants (deepspace theme, starfield, flare, toggle, toast, footer)
-watcher/        CRD informer watch loop, debounce, leader election, health server
+metrics/        Prometheus metrics (stdlib-only, atomic counters/gauges, text exposition format)
+watcher/        CRD informer watch loop, debounce, leader election, health server, metrics wiring
 ```
 
 ## Build & Test
@@ -86,6 +87,7 @@ go run ./cmd/ preview
 - **Linting** uses golangci-lint with strict linters (gocritic, gocyclo, misspell, prealloc, nolintlint) plus defaults. Config in `.golangci.yml`. Pre-commit hook in `.githooks/pre-commit`.
 - **Image signing** uses cosign keyless mode via GitHub OIDC. Production images on main are signed; PR images are not. Base images (golang, distroless) are verified before every build.
 - **Supply chain hardening**: all GitHub Actions pinned by commit SHA (not version tag), Dockerfile base images pinned by digest, `go mod verify` runs in CI.
+- **Prometheus metrics** use stdlib-only text exposition format (no `prometheus/client_golang` dependency). Atomic counters and gauges in `metrics/` package, served at `/metrics` on the health server port. Metrics are always registered in watch mode — zero overhead when not scraped. Recording methods are nil-receiver safe so callers don't need nil checks. Float gauges use `math.Float64bits`/`math.Float64frombits` with `atomic.Int64` for lock-free storage.
 
 ### Dependencies (direct only)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ All configuration is via environment variables. Variables marked *(watch)* apply
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address for preview server (preview mode) |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
 
+### Monitoring
+
+In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` (default 8080) in Prometheus text format. The deployment manifest includes `prometheus.io/*` annotations for automatic scraping.
+
+Exposed metrics:
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `crdpublisher_publish_cycle_duration_seconds` | gauge | Duration of the most recent publish cycle |
+| `crdpublisher_publish_cycle_total` | counter | Publish cycles by result (`success`, `error`) |
+| `crdpublisher_crds_discovered` | gauge | CRDs found in the most recent cycle |
+| `crdpublisher_schemas_written` | gauge | Schemas written in the most recent cycle |
+| `crdpublisher_last_successful_publish_timestamp` | gauge | Unix epoch of the last successful publish |
+| `crdpublisher_publish_skipped_total` | counter | Debounce skips (publish already in progress) |
+| `crdpublisher_leader` | gauge | Whether this pod is the current leader |
+
+The timestamp metric enables dead man's switch alerting — if `time() - crdpublisher_last_successful_publish_timestamp` exceeds your threshold, the process may be stuck.
+
 ## 📋 Using Your Schemas
 
 Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`. The published site also includes a browsable index with search and interactive HTML documentation for each schema.

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -44,6 +44,10 @@ spec:
     metadata:
       labels:
         app: kubernetes-schemas
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: kubernetes-schemas
       securityContext:

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,116 @@
+package metrics
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Metrics holds Prometheus-compatible counters and gauges for the watcher.
+// All fields use atomic operations for lock-free concurrent access.
+// A nil *Metrics is safe to use — all recording methods are no-ops on nil receiver.
+type Metrics struct {
+	publishCycleSuccess atomic.Int64
+	publishCycleError   atomic.Int64
+	publishSkipped      atomic.Int64
+	durationSeconds     atomic.Int64 // float64 bits via math.Float64bits
+	crdsDiscovered      atomic.Int64
+	schemasWritten      atomic.Int64
+	lastSuccessTime     atomic.Int64 // Unix epoch seconds
+	leader              atomic.Int64 // 0 or 1
+}
+
+// New creates a zeroed Metrics instance.
+func New() *Metrics {
+	return &Metrics{}
+}
+
+// RecordPublishCycle records the outcome of a publish cycle.
+func (m *Metrics) RecordPublishCycle(duration time.Duration, err error) {
+	if m == nil {
+		return
+	}
+	m.durationSeconds.Store(int64(math.Float64bits(duration.Seconds())))
+	if err != nil {
+		m.publishCycleError.Add(1)
+	} else {
+		m.publishCycleSuccess.Add(1)
+		m.lastSuccessTime.Store(time.Now().Unix())
+	}
+}
+
+// RecordDiscovery records CRD and schema counts from the latest cycle.
+func (m *Metrics) RecordDiscovery(crds, schemas int) {
+	if m == nil {
+		return
+	}
+	m.crdsDiscovered.Store(int64(crds))
+	m.schemasWritten.Store(int64(schemas))
+}
+
+// RecordSkip records a debounce skip (publish already in progress).
+func (m *Metrics) RecordSkip() {
+	if m == nil {
+		return
+	}
+	m.publishSkipped.Add(1)
+}
+
+// SetLeader sets the leader gauge to 1 (true) or 0 (false).
+func (m *Metrics) SetLeader(isLeader bool) {
+	if m == nil {
+		return
+	}
+	if isLeader {
+		m.leader.Store(1)
+	} else {
+		m.leader.Store(0)
+	}
+}
+
+// Handler returns an http.Handler that writes metrics in Prometheus text exposition format.
+func (m *Metrics) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+		dur := math.Float64frombits(uint64(m.durationSeconds.Load()))
+		success := m.publishCycleSuccess.Load()
+		errCount := m.publishCycleError.Load()
+		skipped := m.publishSkipped.Load()
+		crds := m.crdsDiscovered.Load()
+		schemas := m.schemasWritten.Load()
+		lastSuccess := m.lastSuccessTime.Load()
+		leader := m.leader.Load()
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_publish_cycle_duration_seconds Duration of the most recent publish cycle.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_publish_cycle_duration_seconds gauge\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_publish_cycle_duration_seconds %g\n", dur)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_publish_cycle_total Total number of publish cycles.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_publish_cycle_total counter\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_publish_cycle_total{result=\"success\"} %d\n", success)
+		_, _ = fmt.Fprintf(w, "crdpublisher_publish_cycle_total{result=\"error\"} %d\n", errCount)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_crds_discovered Number of CRDs found in the most recent publish cycle.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_crds_discovered gauge\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_crds_discovered %d\n", crds)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_schemas_written Number of schemas written in the most recent publish cycle.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_schemas_written gauge\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_schemas_written %d\n", schemas)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_last_successful_publish_timestamp Unix timestamp of the last successful publish cycle.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_last_successful_publish_timestamp gauge\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_last_successful_publish_timestamp %d\n", lastSuccess)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_publish_skipped_total Total debounce skips due to publish already in progress.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_publish_skipped_total counter\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_publish_skipped_total %d\n", skipped)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_leader Whether this pod is the current leader.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_leader gauge\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_leader %d\n", leader)
+	})
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,207 @@
+package metrics
+
+import (
+	"errors"
+	"math"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRecordPublishCycle_Success(t *testing.T) {
+	m := New()
+	m.RecordPublishCycle(2*time.Second, nil)
+
+	if got := m.publishCycleSuccess.Load(); got != 1 {
+		t.Fatalf("expected success=1, got %d", got)
+	}
+	if got := m.publishCycleError.Load(); got != 0 {
+		t.Fatalf("expected error=0, got %d", got)
+	}
+	dur := math.Float64frombits(uint64(m.durationSeconds.Load()))
+	if dur != 2.0 {
+		t.Fatalf("expected duration=2.0, got %g", dur)
+	}
+}
+
+func TestRecordPublishCycle_Error(t *testing.T) {
+	m := New()
+	m.RecordPublishCycle(500*time.Millisecond, errors.New("fail"))
+
+	if got := m.publishCycleSuccess.Load(); got != 0 {
+		t.Fatalf("expected success=0, got %d", got)
+	}
+	if got := m.publishCycleError.Load(); got != 1 {
+		t.Fatalf("expected error=1, got %d", got)
+	}
+}
+
+func TestRecordDiscovery(t *testing.T) {
+	m := New()
+	m.RecordDiscovery(42, 100)
+
+	if got := m.crdsDiscovered.Load(); got != 42 {
+		t.Fatalf("expected crds=42, got %d", got)
+	}
+	if got := m.schemasWritten.Load(); got != 100 {
+		t.Fatalf("expected schemas=100, got %d", got)
+	}
+}
+
+func TestRecordSkip(t *testing.T) {
+	m := New()
+	m.RecordSkip()
+	m.RecordSkip()
+
+	if got := m.publishSkipped.Load(); got != 2 {
+		t.Fatalf("expected skipped=2, got %d", got)
+	}
+}
+
+func TestSetLeader(t *testing.T) {
+	m := New()
+	if got := m.leader.Load(); got != 0 {
+		t.Fatalf("expected leader=0 initially, got %d", got)
+	}
+
+	m.SetLeader(true)
+	if got := m.leader.Load(); got != 1 {
+		t.Fatalf("expected leader=1, got %d", got)
+	}
+
+	m.SetLeader(false)
+	if got := m.leader.Load(); got != 0 {
+		t.Fatalf("expected leader=0 after unset, got %d", got)
+	}
+}
+
+func TestNilReceiver(t *testing.T) {
+	var m *Metrics
+	// Must not panic
+	m.RecordPublishCycle(time.Second, nil)
+	m.RecordPublishCycle(time.Second, errors.New("x"))
+	m.RecordDiscovery(1, 1)
+	m.RecordSkip()
+	m.SetLeader(true)
+}
+
+func TestHandler_PrometheusFormat(t *testing.T) {
+	m := New()
+	m.RecordPublishCycle(1500*time.Millisecond, nil)
+	m.RecordPublishCycle(200*time.Millisecond, errors.New("fail"))
+	m.RecordDiscovery(10, 25)
+	m.RecordSkip()
+	m.SetLeader(true)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+
+	if ct := rec.Header().Get("Content-Type"); ct != "text/plain; version=0.0.4; charset=utf-8" {
+		t.Fatalf("unexpected Content-Type: %s", ct)
+	}
+
+	body := rec.Body.String()
+
+	checks := []string{
+		"# TYPE crdpublisher_publish_cycle_duration_seconds gauge",
+		"crdpublisher_publish_cycle_duration_seconds 0.2",
+		"# TYPE crdpublisher_publish_cycle_total counter",
+		`crdpublisher_publish_cycle_total{result="success"} 1`,
+		`crdpublisher_publish_cycle_total{result="error"} 1`,
+		"# TYPE crdpublisher_crds_discovered gauge",
+		"crdpublisher_crds_discovered 10",
+		"# TYPE crdpublisher_schemas_written gauge",
+		"crdpublisher_schemas_written 25",
+		"# TYPE crdpublisher_last_successful_publish_timestamp gauge",
+		"# TYPE crdpublisher_publish_skipped_total counter",
+		"crdpublisher_publish_skipped_total 1",
+		"# TYPE crdpublisher_leader gauge",
+		"crdpublisher_leader 1",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing in output: %q\nbody:\n%s", want, body)
+		}
+	}
+
+	// Verify timestamp is a recent Unix epoch (set by the successful RecordPublishCycle call)
+	if !strings.Contains(body, "crdpublisher_last_successful_publish_timestamp") {
+		t.Error("missing last_successful_publish_timestamp in output")
+	}
+}
+
+func TestHandler_ZeroValues(t *testing.T) {
+	m := New()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+
+	checks := []string{
+		"crdpublisher_publish_cycle_duration_seconds 0",
+		`crdpublisher_publish_cycle_total{result="success"} 0`,
+		`crdpublisher_publish_cycle_total{result="error"} 0`,
+		"crdpublisher_crds_discovered 0",
+		"crdpublisher_schemas_written 0",
+		"crdpublisher_last_successful_publish_timestamp 0",
+		"crdpublisher_publish_skipped_total 0",
+		"crdpublisher_leader 0",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing in output: %q\nbody:\n%s", want, body)
+		}
+	}
+}
+
+func TestConcurrentRecording(t *testing.T) {
+	m := New()
+	var wg sync.WaitGroup
+	const n = 100
+
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		for range n {
+			m.RecordPublishCycle(time.Millisecond, nil)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range n {
+			m.RecordPublishCycle(time.Millisecond, errors.New("x"))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range n {
+			m.RecordSkip()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range n {
+			m.RecordDiscovery(1, 2)
+			m.SetLeader(true)
+		}
+	}()
+
+	wg.Wait()
+
+	if got := m.publishCycleSuccess.Load(); got != n {
+		t.Fatalf("expected success=%d, got %d", n, got)
+	}
+	if got := m.publishCycleError.Load(); got != n {
+		t.Fatalf("expected error=%d, got %d", n, got)
+	}
+	if got := m.publishSkipped.Load(); got != n {
+		t.Fatalf("expected skipped=%d, got %d", n, got)
+	}
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/index"
+	"github.com/sholdee/crd-schema-publisher/metrics"
 	"github.com/sholdee/crd-schema-publisher/publisher"
 	"github.com/sholdee/crd-schema-publisher/renderer"
 
@@ -39,6 +40,7 @@ type Config struct {
 	LeaseName  string
 	PodName    string
 	HealthPort string
+	Metrics    *metrics.Metrics    // nil = no metrics recording
 	CRDLister  extractor.CRDLister // nil = derive from Client
 }
 
@@ -54,7 +56,8 @@ func Run(ctx context.Context, cfg Config) error {
 	)
 	// Start health server before leader election
 	healthReady := &atomic.Bool{}
-	healthServer := startHealthServer(cfg.HealthPort, healthReady)
+	cfg.Metrics = metrics.New()
+	healthServer := startHealthServer(cfg.HealthPort, healthReady, cfg.Metrics)
 
 	kubeClient, err := kubernetes.NewForConfig(cfg.KubeConfig)
 	if err != nil {
@@ -88,9 +91,11 @@ func Run(ctx context.Context, cfg Config) error {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				slog.Info("acquired leadership, starting watch loop")
+				cfg.Metrics.SetLeader(true)
 				runLeader(ctx, cfg)
 			},
 			OnStoppedLeading: func() {
+				cfg.Metrics.SetLeader(false)
 				// Distinguish graceful shutdown (context cancelled) from unexpected lease loss.
 				// On unexpected loss, exit immediately — standard controller pattern.
 				// On graceful shutdown, return normally so Run() can drain.
@@ -159,7 +164,7 @@ func runLeader(ctx context.Context, cfg Config) {
 
 	debounceLoop(trigger, cfg.Debounce, func() error {
 		return publishCycle(cfg)
-	}, ctx.Done())
+	}, cfg.Metrics, ctx.Done())
 }
 
 func signalTrigger(ch chan struct{}) {
@@ -175,7 +180,7 @@ func signalTrigger(ch chan struct{}) {
 // to leave time for health server shutdown and process cleanup.
 const drainTimeout = 25 * time.Second
 
-func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func() error, done <-chan struct{}) {
+func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func() error, m *metrics.Metrics, done <-chan struct{}) {
 	var timer *time.Timer
 	var timerC <-chan time.Time
 	var publishing atomic.Bool
@@ -217,6 +222,7 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 			timerC = nil
 			if !publishing.CompareAndSwap(false, true) {
 				slog.Warn("publish already in progress, skipping")
+				m.RecordSkip()
 				continue
 			}
 			wg.Add(1)
@@ -232,8 +238,14 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 	}
 }
 
-func publishCycle(cfg Config) error {
+func publishCycle(cfg Config) (retErr error) {
 	start := time.Now()
+	defer func() {
+		cfg.Metrics.RecordPublishCycle(time.Since(start), retErr)
+	}()
+	// Reset discovery gauges so they reflect each cycle, not stale previous values
+	cfg.Metrics.RecordDiscovery(0, 0)
+
 	// Clean output dir
 	if err := cleanDir(cfg.OutputDir); err != nil {
 		return fmt.Errorf("cleaning output dir: %w", err)
@@ -259,6 +271,7 @@ func publishCycle(cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("writing schemas: %w", err)
 	}
+	cfg.Metrics.RecordDiscovery(len(crds), count)
 	slog.Info("wrote schemas", "count", count)
 
 	if os.Getenv("SKIP_RENDER") != "true" {
@@ -301,7 +314,7 @@ func cleanDir(dir string) error {
 	return nil
 }
 
-func startHealthServer(port string, ready *atomic.Bool) *http.Server {
+func startHealthServer(port string, ready *atomic.Bool, m *metrics.Metrics) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -316,6 +329,7 @@ func startHealthServer(port string, ready *atomic.Bool) *http.Server {
 			_, _ = w.Write([]byte("not ready"))
 		}
 	})
+	mux.Handle("/metrics", m.Handler())
 	server := &http.Server{Addr: ":" + port, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sholdee/crd-schema-publisher/metrics"
 	"github.com/sholdee/crd-schema-publisher/publisher"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -64,7 +65,7 @@ func TestDebounce_CoalescesRapidEvents(t *testing.T) {
 	go debounceLoop(trigger, 100*time.Millisecond, func() error {
 		count.Add(1)
 		return nil
-	}, done)
+	}, nil, done)
 
 	// Send 5 events in rapid succession
 	for range 5 {
@@ -83,6 +84,7 @@ func TestDebounce_CoalescesRapidEvents(t *testing.T) {
 
 func TestDebounce_SkipsWhenPublishInProgress(t *testing.T) {
 	var count atomic.Int32
+	m := metrics.New()
 	trigger := make(chan struct{}, 10)
 	done := make(chan struct{})
 
@@ -91,7 +93,7 @@ func TestDebounce_SkipsWhenPublishInProgress(t *testing.T) {
 		// Simulate slow publish
 		time.Sleep(300 * time.Millisecond)
 		return nil
-	}, done)
+	}, m, done)
 
 	// First event triggers publish
 	trigger <- struct{}{}
@@ -108,6 +110,14 @@ func TestDebounce_SkipsWhenPublishInProgress(t *testing.T) {
 	// Only 1 publish should have run (second was skipped)
 	if c := count.Load(); c != 1 {
 		t.Fatalf("expected 1 publish cycle (second skipped), got %d", c)
+	}
+
+	// Verify skip was recorded in metrics
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "crdpublisher_publish_skipped_total 1") {
+		t.Fatalf("expected publish_skipped_total=1 in:\n%s", rec.Body.String())
 	}
 }
 
@@ -126,7 +136,7 @@ func TestDebounce_DrainsInFlightPublishOnShutdown(t *testing.T) {
 			// Simulate slow publish
 			time.Sleep(500 * time.Millisecond)
 			return nil
-		}, done)
+		}, nil, done)
 	}()
 
 	// Trigger a publish
@@ -246,6 +256,62 @@ func TestPublishCycle_UploadError(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "publishing") {
 		t.Fatalf("expected error containing 'publishing', got: %s", got)
+	}
+}
+
+// --- metrics integration tests ---
+
+func TestHealthServer_MetricsEndpoint(t *testing.T) {
+	m := metrics.New()
+	m.RecordPublishCycle(2*time.Second, nil)
+	m.RecordDiscovery(5, 12)
+	m.SetLeader(true)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", m.Handler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/plain") {
+		t.Fatalf("unexpected Content-Type: %s", ct)
+	}
+}
+
+func TestPublishCycle_RecordsMetrics(t *testing.T) {
+	t.Setenv("SKIP_RENDER", "true")
+	dir := t.TempDir()
+	m := metrics.New()
+
+	cfg := Config{
+		OutputDir: dir,
+		CRDLister: &fakeLister{crds: []apiextensionsv1.CustomResourceDefinition{testCRD()}},
+		Metrics:   m,
+	}
+
+	if err := publishCycle(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify metrics were recorded
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "crdpublisher_crds_discovered 1") {
+		t.Errorf("expected crds_discovered=1 in:\n%s", body)
+	}
+	if !strings.Contains(body, `crdpublisher_publish_cycle_total{result="success"} 1`) {
+		t.Errorf("expected success=1 in:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `/metrics` endpoint to the watcher health server exposing publish cycle stats in Prometheus text format
- Stdlib-only implementation (no `prometheus/client_golang`) — preserves the project's minimal dependency philosophy
- 7 metrics: cycle duration, success/error counts, CRD/schema counts, last successful publish timestamp (dead man's switch), debounce skips, leader status
- All atomic, nil-receiver safe, zero overhead when not scraped

## Changes

- **New:** `metrics/` package — `Metrics` struct with atomic fields, recording methods, HTTP handler
- **Modified:** `watcher/watcher.go` — wire metrics through Config, Run, publishCycle, debounceLoop, leader callbacks
- **Modified:** `deploy/deployment.yaml` — `prometheus.io/*` annotations for automatic scraping
- **Modified:** `README.md` — Monitoring subsection with metrics table and alerting guidance
- **Modified:** `CLAUDE.md` — document metrics package and design decisions

## Test plan

- [x] `go test -race ./...` passes (10 new tests across `metrics/` and `watcher/`)
- [x] `golangci-lint run` — 0 issues
- [x] CI passes
- [ ] After deploy: `kubectl port-forward` to health port, `curl /metrics` returns valid Prometheus text format

🤖 Generated with [Claude Code](https://claude.com/claude-code)