### PR TITLE
feat: add watchdog heartbeat metric and Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` 
 | `crdpublisher_crds_discovered` | gauge | CRDs found in the most recent cycle |
 | `crdpublisher_schemas_written` | gauge | Schemas written in the most recent cycle |
 | `crdpublisher_last_successful_publish_timestamp` | gauge | Unix epoch of the last successful publish |
+| `crdpublisher_watchdog_timestamp` | gauge | Unix epoch of the last debounce loop tick |
 | `crdpublisher_publish_skipped_total` | counter | Debounce skips (publish already in progress) |
 | `crdpublisher_leader` | gauge | Whether this pod is the current leader |
 
-The timestamp metric enables dead man's switch alerting — if `time() - crdpublisher_last_successful_publish_timestamp` exceeds your threshold, the process may be stuck.
+The watchdog timestamp enables dead man's switch alerting — it updates on every debounce loop tick (regardless of whether a publish occurs), so `time() - crdpublisher_watchdog_timestamp` staying fresh proves the watcher is alive. The publish timestamp separately tracks when content was last pushed.
 
 To scrape with [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), create a PodMonitor:
 

--- a/deploy/grafana-dashboard.json
+++ b/deploy/grafana-dashboard.json
@@ -1,0 +1,1019 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource for CRD Schema Publisher metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "id": null,
+  "uid": "crd-schema-publisher",
+  "title": "CRD Schema Publisher",
+  "tags": [
+    "kubernetes",
+    "crd-schema-publisher"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "style": "dark",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Health at a Glance",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": []
+    },
+    {
+      "id": 1,
+      "title": "Watchdog",
+      "description": "Time since last debounce loop tick. Proves the watcher is alive and looping. Green < 60s, yellow < 120s, red > 120s.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 120
+              }
+            ]
+          },
+          "color": {
+            "mode": "background"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "time() - crdpublisher_watchdog_timestamp",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Leader",
+      "description": "Leader election status. Active = this instance holds the lease.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "Active",
+                  "color": "green",
+                  "index": 0
+                },
+                "0": {
+                  "text": "Standby",
+                  "color": "text",
+                  "index": 1
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "background"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_leader",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Cycle Duration",
+      "description": "Duration of the last publish cycle.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 60
+              }
+            ]
+          },
+          "color": {
+            "mode": "value"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_publish_cycle_duration_seconds",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "CRDs",
+      "description": "Number of CRDs discovered in the last publish cycle.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_crds_discovered",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Schemas",
+      "description": "Number of JSON schemas written in the last publish cycle.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_schemas_written",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Last Publish",
+      "description": "Time since last successful publish. Long gaps are normal when no CRDs change.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "time() - crdpublisher_last_successful_publish_timestamp",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Errors (1h)",
+      "description": "Number of failed publish cycles in the last hour.",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "background"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "floor(increase(crdpublisher_publish_cycle_total{result=\"error\"}[1h]))",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Publish Activity",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 101,
+      "panels": []
+    },
+    {
+      "id": 7,
+      "title": "Publish Cycles",
+      "description": "Success and error publish cycles over time.",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "Cycles",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showValues": "auto",
+          "calcs": []
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "increase(crdpublisher_publish_cycle_total{result=\"success\"}[5m])",
+          "legendFormat": "Success",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "increase(crdpublisher_publish_cycle_total{result=\"error\"}[5m])",
+          "legendFormat": "Error",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Cycle Duration",
+      "description": "Publish cycle duration over time.",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "Duration",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showValues": "auto",
+          "calcs": []
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_publish_cycle_duration_seconds",
+          "legendFormat": "Duration",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Operational Detail",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 102,
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "CRD & Schema Counts",
+      "description": "CRDs discovered and schemas written per cycle, tracked over time.",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "Count",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CRDs"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Schemas"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "super-light-blue"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showValues": "auto",
+          "calcs": []
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_crds_discovered",
+          "legendFormat": "CRDs",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "crdpublisher_schemas_written",
+          "legendFormat": "Schemas",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Debounce Skips",
+      "description": "Publish cycles skipped because the debounce timer was still active.",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "Skips",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showValues": "auto",
+          "calcs": []
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "increase(crdpublisher_publish_skipped_total[5m])",
+          "legendFormat": "Skips",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	crdsDiscovered      atomic.Int64
 	schemasWritten      atomic.Int64
 	lastSuccessTime     atomic.Int64 // Unix epoch seconds
+	watchdogTime        atomic.Int64 // Unix epoch seconds, updated every debounce tick
 	leader              atomic.Int64 // 0 or 1
 }
 
@@ -58,6 +59,15 @@ func (m *Metrics) RecordSkip() {
 	m.publishSkipped.Add(1)
 }
 
+// Heartbeat updates the watchdog timestamp to the current time.
+// Call on every debounce loop iteration to prove the watcher is alive.
+func (m *Metrics) Heartbeat() {
+	if m == nil {
+		return
+	}
+	m.watchdogTime.Store(time.Now().Unix())
+}
+
 // SetLeader sets the leader gauge to 1 (true) or 0 (false).
 func (m *Metrics) SetLeader(isLeader bool) {
 	if m == nil {
@@ -82,6 +92,7 @@ func (m *Metrics) Handler() http.Handler {
 		crds := m.crdsDiscovered.Load()
 		schemas := m.schemasWritten.Load()
 		lastSuccess := m.lastSuccessTime.Load()
+		watchdog := m.watchdogTime.Load()
 		leader := m.leader.Load()
 
 		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_publish_cycle_duration_seconds Duration of the most recent publish cycle.\n")
@@ -104,6 +115,10 @@ func (m *Metrics) Handler() http.Handler {
 		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_last_successful_publish_timestamp Unix timestamp of the last successful publish cycle.\n")
 		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_last_successful_publish_timestamp gauge\n")
 		_, _ = fmt.Fprintf(w, "crdpublisher_last_successful_publish_timestamp %d\n", lastSuccess)
+
+		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_watchdog_timestamp Unix timestamp of the last debounce loop tick.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_watchdog_timestamp gauge\n")
+		_, _ = fmt.Fprintf(w, "crdpublisher_watchdog_timestamp %d\n", watchdog)
 
 		_, _ = fmt.Fprintf(w, "# HELP crdpublisher_publish_skipped_total Total debounce skips due to publish already in progress.\n")
 		_, _ = fmt.Fprintf(w, "# TYPE crdpublisher_publish_skipped_total counter\n")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -85,6 +85,23 @@ func TestNilReceiver(t *testing.T) {
 	m.RecordDiscovery(1, 1)
 	m.RecordSkip()
 	m.SetLeader(true)
+	m.Heartbeat()
+}
+
+func TestHeartbeat(t *testing.T) {
+	m := New()
+	if got := m.watchdogTime.Load(); got != 0 {
+		t.Fatalf("expected watchdog=0 initially, got %d", got)
+	}
+
+	before := time.Now().Unix()
+	m.Heartbeat()
+	after := time.Now().Unix()
+
+	got := m.watchdogTime.Load()
+	if got < before || got > after {
+		t.Fatalf("expected watchdog between %d and %d, got %d", before, after, got)
+	}
 }
 
 func TestHandler_PrometheusFormat(t *testing.T) {
@@ -94,6 +111,7 @@ func TestHandler_PrometheusFormat(t *testing.T) {
 	m.RecordDiscovery(10, 25)
 	m.RecordSkip()
 	m.SetLeader(true)
+	m.Heartbeat()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/metrics", nil)
@@ -116,6 +134,7 @@ func TestHandler_PrometheusFormat(t *testing.T) {
 		"# TYPE crdpublisher_schemas_written gauge",
 		"crdpublisher_schemas_written 25",
 		"# TYPE crdpublisher_last_successful_publish_timestamp gauge",
+		"# TYPE crdpublisher_watchdog_timestamp gauge",
 		"# TYPE crdpublisher_publish_skipped_total counter",
 		"crdpublisher_publish_skipped_total 1",
 		"# TYPE crdpublisher_leader gauge",
@@ -150,6 +169,7 @@ func TestHandler_ZeroValues(t *testing.T) {
 		"crdpublisher_crds_discovered 0",
 		"crdpublisher_schemas_written 0",
 		"crdpublisher_last_successful_publish_timestamp 0",
+		"crdpublisher_watchdog_timestamp 0",
 		"crdpublisher_publish_skipped_total 0",
 		"crdpublisher_leader 0",
 	}
@@ -190,6 +210,7 @@ func TestConcurrentRecording(t *testing.T) {
 		for range n {
 			m.RecordDiscovery(1, 2)
 			m.SetLeader(true)
+			m.Heartbeat()
 		}
 	}()
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -185,6 +185,9 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 	var timerC <-chan time.Time
 	var publishing atomic.Bool
 	var wg sync.WaitGroup
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+	m.Heartbeat() // initial heartbeat on loop entry
 
 	for {
 		select {
@@ -205,6 +208,7 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 			}
 			return
 		case <-trigger:
+			m.Heartbeat()
 			if timer == nil {
 				timer = time.NewTimer(duration)
 				timerC = timer.C
@@ -217,7 +221,10 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 				}
 				timer.Reset(duration)
 			}
+		case <-heartbeat.C:
+			m.Heartbeat()
 		case <-timerC:
+			m.Heartbeat()
 			timer = nil
 			timerC = nil
 			if !publishing.CompareAndSwap(false, true) {


### PR DESCRIPTION
## Summary
- Add `crdpublisher_watchdog_timestamp` metric — updates every 30s via ticker + on CRD events, proving the watcher is alive regardless of publish activity
- Separates liveness monitoring (watchdog) from content freshness (last successful publish timestamp)
- Add Grafana dashboard JSON (`deploy/grafana-dashboard.json`) with 3 rows: Health at a Glance, Publish Activity, Operational Detail
- Update README metrics table and alerting guidance

## Test plan
- [x] `go test -race ./...` passes
- [x] `golangci-lint run` — zero issues
- [x] New `TestHeartbeat` validates timestamp correctness
- [x] Nil-receiver, format, zero-value, and concurrent tests updated
- [ ] Import dashboard JSON in Grafana — verify Watchdog panel shows green with 60s/120s thresholds
- [ ] Verify watchdog stays fresh in quiet cluster (no CRD changes for >2 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)