### PR TITLE
fix: upgrade setup-helm to v5.0.0 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,7 +254,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v4.2.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Lint chart
         run: helm lint charts/crd-schema-publisher --set existingSecret.name=test
@@ -372,7 +372,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v4.2.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1


### PR DESCRIPTION
## Summary

- Upgrades `azure/setup-helm` from v4.2.0 to v5.0.0 in both `helm-lint` and `helm-package` jobs
- Resolves Node.js 20 deprecation warning (v5 runs on Node.js 24)
- Resolves `GITHUB_TOKEN` warning (v5 defaults `token` to `github.token`)

## Test plan

- [x] CI passes — this is a CI-only change (no app or chart changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)