### PR TITLE
feat(chart): add optional persistence and extra volumes/containers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,7 +276,8 @@ jobs:
             --set podDisruptionBudget.minAvailable=1 \
             --set networkPolicy.enabled=true \
             --set replicaCount=3 \
-            --set podAntiAffinityPreset=soft
+            --set podAntiAffinityPreset=soft \
+            --set persistence.enabled=true
 
       - name: Verify mode isolation
         run: |
@@ -326,6 +327,19 @@ jobs:
           fi
           echo "${DASHBOARD}" | python3 -m json.tool > /dev/null
           echo "Dashboard JSON embedded and valid"
+
+      - name: Verify existingClaim suppresses PVC creation
+        run: |
+          PVC_COUNT=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set persistence.enabled=true \
+            --set persistence.existingClaim=my-pvc \
+            | grep -c "^kind: PersistentVolumeClaim$" || true)
+          if [[ "${PVC_COUNT}" -ne 0 ]]; then
+            echo "ERROR: existingClaim should suppress PVC creation"
+            exit 1
+          fi
+          echo "existingClaim correctly suppresses PVC creation"
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/charts/crd-schema-publisher/templates/cronjob.yaml
+++ b/charts/crd-schema-publisher/templates/cronjob.yaml
@@ -59,9 +59,26 @@ spec:
               volumeMounts:
                 - name: output
                   mountPath: {{ .Values.config.outputDir }}
+                {{- with .Values.extraVolumeMounts }}
+                {{- tpl (toYaml .) $ | nindent 16 }}
+                {{- end }}
+          {{- with .Values.extraContainers }}
+          {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           volumes:
             - name: output
+              {{- if .Values.persistence.existingClaim }}
+              persistentVolumeClaim:
+                claimName: {{ .Values.persistence.existingClaim }}
+              {{- else if .Values.persistence.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ include "crd-schema-publisher.fullname" . }}
+              {{- else }}
               emptyDir: {}
+              {{- end }}
+            {{- with .Values.extraVolumes }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/crd-schema-publisher/templates/deployment.yaml
+++ b/charts/crd-schema-publisher/templates/deployment.yaml
@@ -87,9 +87,26 @@ spec:
           volumeMounts:
             - name: output
               mountPath: {{ .Values.config.outputDir }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+      {{- with .Values.extraContainers }}
+      {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       volumes:
         - name: output
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+          {{- else if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "crd-schema-publisher.fullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/crd-schema-publisher/templates/pvc.yaml
+++ b/charts/crd-schema-publisher/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "crd-schema-publisher.fullname" . }}
+  labels:
+    {{- include "crd-schema-publisher.labels" . | nindent 4 }}
+    {{- with .Values.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if and .Values.persistence.storageClass (ne .Values.persistence.storageClass "-") }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- else if eq .Values.persistence.storageClass "-" }}
+  storageClassName: ""
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -54,7 +54,22 @@
           "description": "Create an ExternalSecret resource"
         }
       }
-    }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Use a PVC for the output directory" },
+        "existingClaim": { "type": "string", "description": "Name of an existing PVC" },
+        "storageClass": { "type": "string", "description": "Storage class name" },
+        "accessModes": { "type": "array", "items": { "type": "string" }, "description": "PVC access modes" },
+        "size": { "type": "string", "description": "PVC storage size" },
+        "annotations": { "type": "object", "description": "PVC annotations" },
+        "labels": { "type": "object", "description": "PVC labels" }
+      }
+    },
+    "extraVolumes": { "type": "array", "description": "Additional volumes" },
+    "extraVolumeMounts": { "type": "array", "description": "Additional volume mounts" },
+    "extraContainers": { "type": "array", "description": "Additional containers" }
   },
   "oneOf": [
     {

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -269,6 +269,39 @@ ciliumNetworkPolicy:
   extraIngress: []
 
 # ---------------------------------------------------------------------------
+# Persistence (output directory volume)
+# ---------------------------------------------------------------------------
+persistence:
+  # -- Use a PersistentVolumeClaim for the output directory instead of emptyDir
+  enabled: false
+  # -- Use an existing PVC (skips PVC creation when set)
+  existingClaim: ""
+  # -- Storage class ("" = cluster default, "-" = no dynamic provisioning)
+  storageClass: ""
+  # -- Access modes for the PVC
+  accessModes:
+    - ReadWriteOnce
+  # -- Storage size
+  size: 1Gi
+  # -- Additional annotations on the PVC
+  annotations: {}
+  # -- Additional labels on the PVC
+  labels: {}
+
+# ---------------------------------------------------------------------------
+# Extra pod customization
+# ---------------------------------------------------------------------------
+
+# -- Additional volumes to add to pods (supports Go templating)
+extraVolumes: []
+
+# -- Additional volume mounts to add to the main container (supports Go templating)
+extraVolumeMounts: []
+
+# -- Additional containers to add to pods (supports Go templating)
+extraContainers: []
+
+# ---------------------------------------------------------------------------
 # Extra objects
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add Bitnami-style `persistence` block for the output directory — toggle between emptyDir (default), a chart-managed PVC, or an existing PVC via `existingClaim`
- Add `extraVolumes`, `extraVolumeMounts`, and `extraContainers` passthrough arrays with `tpl` support for Go template expressions
- Both `deployment.yaml` and `cronjob.yaml` templates wired up with correct nesting depth
- **Cloudflare credentials are now optional** — without them, watch mode gracefully extracts schemas without publishing (extract-only mode for local serving via nginx sidecar, etc.)
- CI coverage: all-features template exercises PVC rendering, existingClaim suppression test, schema validation updated for optional secrets
- README and CLAUDE.md updated

## Motivation

Users who want to serve schemas locally (e.g., via an nginx sidecar) or persist output across pod restarts had no way to customize the output volume or inject containers into the pod spec. The existing `extraObjects` value can create arbitrary K8s resources but cannot modify the publisher's own pod spec. Additionally, the chart required Cloudflare credentials even when the user only wanted to extract schemas locally.

## Test plan

- [x] `helm lint` passes (with and without secrets)
- [x] `helm template` renders correctly in all modes: default (emptyDir), `persistence.enabled=true`, `persistence.existingClaim=<name>`, `mode=cronjob`, no secret (extract-only)
- [x] `kubeconform` validates rendered manifests (controller, cronjob, persistence, no-secret)
- [x] Schema validation rejects dual-secret configs but accepts no-secret
- [x] `existingClaim` suppresses PVC creation when set alongside `persistence.enabled=true`
- [x] `storageClass` handling: omitted when empty, `""` when `"-"`, literal otherwise
- [x] `extraVolumeMounts`, `extraContainers`, `extraVolumes` render in both deployment and cronjob
- [x] Cloudflare env vars omitted when no secret configured
- [x] Full nginx sidecar example templates correctly (persistence + extraContainers + extraVolumes + extraObjects with Service and HTTPRoute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>