### PR TITLE
docs: add caddy sidecar example for local schema serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most CRD schema solutions rely on static catalogs — community-maintained repos
 This tool reads schemas directly from your cluster's API server and publishes them to infrastructure you control.
 
 - **Always accurate** — schemas reflect exactly what's installed in your cluster, including custom and internal CRDs, updated automatically when CRDs change
-- **Self-hosted** — published to your own Cloudflare Pages site, removing third-party dependencies from your validation pipeline
+- **Self-hosted** — published to your own Cloudflare Pages site, or run in extract-only mode and serve schemas however you like (Caddy, nginx, S3 sync, rclone — any sidecar that reads files from a directory)
 - **Single static binary** — no runtime dependencies, no interpreters, no package managers. One binary in a distroless nonroot container with no shell
 - **Kubernetes-native** — watch mode uses the controller pattern with informers, leader election, debounced publish cycles, and health probes. It's a proper workload, not a script on a timer
 
@@ -61,6 +61,18 @@ The default remote ref points to a `crd-schema-publisher-cloudflare` key with `a
 #### Optional features
 
 Persistent output volume (`persistence`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
+
+#### Example: Local serving with a web server sidecar
+
+Serve schemas from your cluster without Cloudflare using a web server sidecar. This runs in extract-only mode — schemas are written to a persistent volume and served directly by the sidecar. The example uses Caddy but can be adapted to nginx or any web server.
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher --create-namespace \
+  -f examples/caddy-sidecar/values.yaml
+```
+
+The example creates a Caddy sidecar, a Service, and a Gateway API HTTPRoute. Edit the HTTPRoute's `parentRefs` and `hostnames` to match your gateway. See [`examples/caddy-sidecar/values.yaml`](examples/caddy-sidecar/values.yaml) for the full configuration.
 
 #### Verification
 

--- a/examples/caddy-sidecar/values.yaml
+++ b/examples/caddy-sidecar/values.yaml
@@ -1,0 +1,138 @@
+# Caddy sidecar example — serve CRD schemas locally without Cloudflare
+#
+# This example runs crd-schema-publisher in extract-only mode (no Cloudflare
+# credentials) with a Caddy sidecar that serves the schemas and interactive
+# documentation pages over HTTP. A persistent volume keeps schemas available
+# across pod restarts.
+#
+# Customize:
+#   - persistence.storageClass: your cluster's StorageClass (omit for default)
+#   - HTTPRoute parentRefs: your Gateway name and namespace
+#   - HTTPRoute hostnames: your desired hostname
+#
+# Install:
+#   helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+#     --namespace crd-schema-publisher --create-namespace \
+#     -f values.yaml
+
+# No Cloudflare secret — extract-only mode. The publisher writes schemas to
+# the output directory and the caddy sidecar serves them.
+
+# Recreate strategy is required with ReadWriteOnce persistence — RollingUpdate
+# deadlocks because the new pod cannot mount the PVC until the old pod releases it.
+strategy:
+  type: Recreate
+
+# Persistent volume for the output directory so schemas survive pod restarts.
+persistence:
+  enabled: true
+  # storageClass: ""  # Uncomment and set for a specific StorageClass
+  size: 512Mi
+
+# Caddy configuration volume and scratch space for caddy's internal state.
+extraVolumes:
+  - name: caddy-config
+    configMap:
+      name: '{{ include "crd-schema-publisher.fullname" . }}-caddyfile'
+  - name: caddy-tmp
+    emptyDir: {}
+
+# Caddy sidecar — mounts the shared output volume as its document root.
+# The "output" volume is created by the chart's persistence block above.
+extraContainers:
+  - name: caddy
+    image: caddy:2.11.2@sha256:1e40b251ca9639ead7b5cd2cedcc8765adfbabb99450fe23f130eefabf50f4bc
+    ports:
+      - containerPort: 80
+        protocol: TCP
+        name: http
+    volumeMounts:
+      - name: output
+        mountPath: /srv
+        readOnly: true
+      - name: caddy-config
+        mountPath: /etc/caddy
+      - name: caddy-tmp
+        mountPath: /config/caddy
+        subPath: conf
+      - name: caddy-tmp
+        mountPath: /data/caddy
+        subPath: data
+    resources:
+      requests:
+        cpu: 5m
+        memory: 10Mi
+      limits:
+        memory: 50Mi
+    livenessProbe: &caddy-probe
+      httpGet:
+        path: /
+        port: http
+    readinessProbe: *caddy-probe
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+        add: ["NET_BIND_SERVICE"]
+
+# Supporting objects: Caddyfile ConfigMap, Service for the sidecar, and an
+# HTTPRoute for ingress. All use chart template helpers for consistent naming.
+extraObjects:
+  # Caddyfile — serves the output directory with directory browsing enabled.
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "crd-schema-publisher.fullname" . }}-caddyfile'
+    data:
+      Caddyfile: |
+        :80 {
+            log {
+                output stdout
+                format json
+            }
+            root * /srv
+            file_server browse
+        }
+
+  # Service targeting the caddy sidecar port.
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: '{{ include "crd-schema-publisher.fullname" . }}-caddy'
+    spec:
+      selector:
+        app.kubernetes.io/name: '{{ include "crd-schema-publisher.name" . }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+      ports:
+        - protocol: TCP
+          port: 80
+          name: http
+      type: ClusterIP
+
+  # HTTPRoute — adjust parentRefs and hostnames for your gateway.
+  # All fields are fully specified to prevent ArgoCD drift from server-side
+  # defaulting (group, kind, weight, matches are set explicitly).
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: '{{ include "crd-schema-publisher.fullname" . }}'
+    spec:
+      parentRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: my-gateway       # <-- your Gateway name
+          namespace: gateway     # <-- your Gateway namespace
+      hostnames:
+        - kube-schemas.example.com  # <-- your hostname
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          backendRefs:
+            - group: ""
+              kind: Service
+              name: '{{ include "crd-schema-publisher.fullname" . }}-caddy'
+              port: 80
+              weight: 1


### PR DESCRIPTION
## Summary
- Adds `examples/caddy-sidecar/values.yaml` — a complete, cluster-tested example for serving CRD schemas locally via a Caddy sidecar in extract-only mode (no Cloudflare credentials)
- Adds "Example: Local serving with a web server sidecar" section to the README with install command and link to the values file
- Updates the "Self-hosted" bullet in the Why section to highlight extract-only mode and sidecar extensibility

## What the example includes
- Persistent volume for schema output (survives pod restarts)
- Recreate strategy (required for ReadWriteOnce PVC)
- Caddy sidecar with `file_server browse` serving from the shared output volume
- Hardened security context (readOnlyRootFilesystem, drop ALL, nonroot)
- Supporting extraObjects: Caddyfile ConfigMap, Service, Gateway API HTTPRoute
- HTTPRoute with fully-specified fields to prevent ArgoCD drift from server-side defaulting
- Commented placeholders for gateway name, namespace, and hostname

## Test plan
- [x] Deployed as a standalone ArgoCD Application to a live K3s cluster
- [x] Verified 2/2 containers running, PVC bound, schemas extracted (177 CRDs)
- [x] Verified Caddy serving index.html and schema files via HTTPRoute
- [x] Verified ArgoCD Synced/Healthy after adding explicit HTTPRoute defaults
- [x] `helm template` renders all 12 resources cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)