### PR TITLE
fix(renovate): enable automerge for all CI tools

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,15 +28,17 @@
     },
     {
       description: 'Automerge minor/patch CI tool updates',
-      matchPackageNames: ['rhysd/actionlint', 'markdownlint-cli2'],
+      matchPackageNames: ['rhysd/actionlint', 'markdownlint-cli2', 'golang/vuln', 'yannh/kubeconform'],
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
     },
     {
-      description: 'Rate-limit Renovate self-updates (multiple releases per day)',
+      description: 'Rate-limit and automerge Renovate self-updates (multiple releases per day)',
       matchPackageNames: ['renovate'],
+      matchUpdateTypes: ['minor', 'patch'],
       schedule: ['before 2am'],
       minimumReleaseAge: '1 day',
+      automerge: true,
     },
   ],
   customManagers: [


### PR DESCRIPTION
## Summary
- Add `automerge: true` to the renovate self-update rate-limiting rule (was rate-limited but not automerging)
- Add `matchUpdateTypes: ['minor', 'patch']` to the renovate rule for consistency
- Add `golang/vuln` (govulncheck) and `yannh/kubeconform` to the CI tools automerge rule

## Why
PR #25 (renovate self-update) didn't automerge because the rate-limiting rule didn't set `automerge: true`, and no other rule matched it (npm datasource, not covered by docker/github-actions/gomod rules). Similarly, govulncheck and kubeconform are discovered by custom regex managers with `github-releases` datasource, but weren't listed in the CI tools `matchPackageNames`.

## Test plan
- [x] Audited all dependencies against all package rules — every dependency now has a matching automerge rule for minor/patch
- [x] Renovate config validation passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)