### PR TITLE
docs: add rclone-s3 and git-push sidecar examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,23 @@ The default remote ref points to a `crd-schema-publisher-cloudflare` key with `a
 
 Persistent output volume (`persistence`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
 
-#### Example: Local serving with a web server sidecar
+#### Examples: Alternative backends via sidecar pattern
 
-Serve schemas from your cluster without Cloudflare using a web server sidecar. This runs in extract-only mode — schemas are written to a persistent volume and served directly by the sidecar. The example uses Caddy but can be adapted to nginx or any web server.
+The chart's `extraContainers` and `extraObjects` values let you wire up any backend without changes to the tool. Each example runs in extract-only mode (no Cloudflare credentials) — schemas are written to a persistent volume and a sidecar handles serving or syncing.
 
 ```bash
 helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
   --namespace crd-schema-publisher --create-namespace \
-  -f examples/caddy-sidecar/values.yaml
+  -f examples/<example>/values.yaml
 ```
 
-The example creates a Caddy sidecar, a Service, and a Gateway API HTTPRoute. Edit the HTTPRoute's `parentRefs` and `hostnames` to match your gateway. See [`examples/caddy-sidecar/values.yaml`](examples/caddy-sidecar/values.yaml) for the full configuration.
+| Example | Backend | Description |
+| ------- | ------- | ----------- |
+| [`caddy-sidecar`](examples/caddy-sidecar/values.yaml) | Local HTTP | Caddy serves schemas directly from the cluster with directory browsing and a Gateway API HTTPRoute. Adaptable to nginx or any web server. |
+| [`rclone-s3`](examples/rclone-s3/values.yaml) | S3-compatible storage | rclone syncs schemas to any S3-compatible provider (AWS S3, Backblaze B2, MinIO, Cloudflare R2, GCS) on a 60-second interval. Provider-specific configuration documented in the file header. |
+| [`git-push`](examples/git-push/values.yaml) | Git repository | Commits and pushes schema changes to a GitHub repository for GitHub Pages hosting. Works with any git host (GitLab, Gitea, Bitbucket) by adjusting the remote URL. |
+
+Each example is a self-contained values file — copy it, fill in your credentials, and install. See the comments in each file for what to customize.
 
 #### Verification
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Persistent output volume (`persistence`), extra volumes/volume mounts/containers
 
 #### Examples: Alternative backends via sidecar pattern
 
-The chart's `extraContainers` and `extraObjects` values let you wire up any backend without changes to the tool. Each example runs in extract-only mode (no Cloudflare credentials) — schemas are written to a persistent volume and a sidecar handles serving or syncing.
+The chart's `extraContainers` and `extraObjects` values let you wire up any backend without changes to the tool. Each example runs in extract-only mode (no Cloudflare credentials) — schemas are written to the output directory and a sidecar handles serving or syncing. Examples that push to external storage run stateless with an emptyDir; the caddy example uses a persistent volume since it serves directly from the cluster.
 
 ```bash
 helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \

--- a/examples/git-push/values.yaml
+++ b/examples/git-push/values.yaml
@@ -1,0 +1,136 @@
+# git-push sidecar example — push CRD schemas to a GitHub repository
+#
+# This example runs crd-schema-publisher in extract-only mode (no Cloudflare
+# credentials) with an alpine/git sidecar that periodically commits and pushes
+# schema changes to a GitHub repository. A persistent volume keeps schemas
+# available across pod restarts.
+#
+# This works well with GitHub Pages — set the target repo's Pages source to
+# the gh-pages branch and your schemas are automatically published as a static
+# site. The sidecar handles both fresh repos (init + first push) and existing
+# repos (clone + incremental updates).
+#
+# This pattern works with any git hosting (GitLab, Gitea, Bitbucket) by
+# adjusting the remote URL format in the sidecar command.
+#
+# Customize:
+#   - Secret credentials (github-token, github-repo)
+#   - GIT_BRANCH: change from gh-pages if needed
+#   - sync interval: adjust the sleep duration in the sidecar command
+#
+# Install:
+#   helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+#     --namespace crd-schema-publisher --create-namespace \
+#     -f values.yaml
+
+# No Cloudflare secret — extract-only mode. The publisher writes schemas to
+# the output directory and the git-push sidecar commits and pushes them.
+# No persistence needed — the publisher re-extracts on startup and the sidecar
+# re-syncs the full set. The default emptyDir volume is sufficient.
+
+# Scratch space for git operations.
+extraVolumes:
+  - name: git-workspace
+    emptyDir: {}
+  - name: git-home
+    emptyDir: {}
+  - name: git-tmp
+    emptyDir: {}
+
+# alpine/git sidecar — commits and pushes the shared output volume to GitHub.
+# The "output" volume is created by the chart's persistence block above.
+extraContainers:
+  - name: git-push
+    image: alpine/git:2.49.1
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        # Configure git identity
+        # Wait for the publisher to complete its first extraction
+        while [ ! -f /data/index.html ]; do sleep 5; done
+
+        git config --global user.name "crd-schema-publisher"
+        git config --global user.email "crd-schema-publisher@users.noreply.github.com"
+        git config --global --add safe.directory /repo
+
+        # Clone or init the repo
+        if [ -z "$(ls -A /repo)" ]; then
+          git clone --branch "${GIT_BRANCH}" --single-branch \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GIT_REPO}.git" /repo || {
+            git init /repo
+            cd /repo
+            git checkout -b "${GIT_BRANCH}"
+            git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GIT_REPO}.git"
+          }
+        fi
+
+        cd /repo
+        while true; do
+          sleep 30  # Can be lowered to 15s safely; no-op cycles are near-zero cost
+          # Sync schemas from output volume to repo working copy
+          cp -r /data/. /repo/ || continue
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "update schemas $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          # Push any unpushed commits (retries failed pushes from previous cycles)
+          git push origin "${GIT_BRANCH}" 2>/dev/null || true
+        done
+    env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "crd-schema-publisher.fullname" . }}-git-push'
+            key: github-token
+      - name: GIT_REPO
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "crd-schema-publisher.fullname" . }}-git-push'
+            key: github-repo
+      - name: GIT_BRANCH
+        value: "gh-pages"  # Change if your Pages branch differs
+      - name: HOME
+        value: "/home/git"  # Writable home for .gitconfig
+    volumeMounts:
+      - name: output
+        mountPath: /data
+        readOnly: true
+      - name: git-workspace
+        mountPath: /repo
+      - name: git-home
+        mountPath: /home/git
+      - name: git-tmp
+        mountPath: /tmp
+    # Memory usage scales with CRD count — the initial git commit stages all
+    # files at once. 256Mi handles ~200 CRDs; increase for larger clusters.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+    securityContext:
+      runAsUser: 1000
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+
+# Supporting objects: Secret for GitHub credentials.
+# All use chart template helpers for consistent naming.
+extraObjects:
+  # GitHub credentials — create a fine-grained personal access token (PAT) with
+  # contents:write permission scoped to the target repository. Replace placeholder
+  # values with your actual credentials, or use your preferred secret management
+  # (ExternalSecret, SealedSecret, etc.) instead of this inline Secret. You can
+  # also reference a pre-created secret by changing the secretKeyRef names above
+  # to point to your existing secret.
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: '{{ include "crd-schema-publisher.fullname" . }}-git-push'
+    type: Opaque
+    stringData:
+      github-token: "REPLACE_ME"
+      github-repo: "owner/repo"

--- a/examples/rclone-s3/values.yaml
+++ b/examples/rclone-s3/values.yaml
@@ -1,0 +1,117 @@
+# rclone sidecar example — sync CRD schemas to S3-compatible storage
+#
+# This example runs crd-schema-publisher in extract-only mode (no Cloudflare
+# credentials) with an rclone sidecar that syncs schemas to an S3-compatible
+# bucket every 60 seconds. A persistent volume keeps schemas available across
+# pod restarts.
+#
+# rclone sync is one-way and DELETES files on the destination that don't exist
+# on the source. If you want additive-only behavior (never delete remote files),
+# replace `rclone sync` with `rclone copy` in the sidecar command.
+#
+# Customize:
+#   - RCLONE_CONFIG_S3_* env vars: set provider, endpoint, and auth for your backend
+#   - Secret credentials: access key and secret key for your provider
+#   - RCLONE_S3_BUCKET: your bucket name (and optional path prefix)
+#   - sync interval: adjust the sleep duration in the sidecar command
+#
+# Provider examples (set RCLONE_CONFIG_S3_PROVIDER and RCLONE_CONFIG_S3_ENDPOINT):
+#   AWS S3:        provider=AWS,        endpoint=(omit — uses default)
+#   Backblaze B2:  provider=Other,      endpoint=s3.us-west-002.backblazeb2.com
+#   MinIO:         provider=Minio,      endpoint=https://minio.example.com
+#   Cloudflare R2: provider=Cloudflare, endpoint=https://<account-id>.r2.cloudflarestorage.com
+#   GCS:           provider=GCS,        endpoint=https://storage.googleapis.com
+#
+# Install:
+#   helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+#     --namespace crd-schema-publisher --create-namespace \
+#     -f values.yaml
+
+# No Cloudflare secret — extract-only mode. The publisher writes schemas to
+# the output directory and the rclone sidecar syncs them to object storage.
+# No persistence needed — the publisher re-extracts on startup and the sidecar
+# re-syncs the full set. The default emptyDir volume is sufficient.
+
+# Scratch space for rclone's internal state.
+extraVolumes:
+  - name: rclone-tmp
+    emptyDir: {}
+
+# rclone sidecar — syncs the shared output volume to S3-compatible storage.
+# The "output" volume is created by the chart's persistence block above.
+extraContainers:
+  - name: rclone
+    image: ghcr.io/rclone/rclone:1.73.4
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        # Wait for the publisher to complete its first extraction
+        while [ ! -f /data/index.html ]; do sleep 5; done
+
+        while true; do
+          rclone sync /data s3:${RCLONE_S3_BUCKET} --checksum --verbose --transfers 4
+          sleep 60
+        done
+    env:
+      # -- rclone S3-compatible remote configuration via env vars.
+      # See provider examples in the header comment for provider/endpoint values.
+      - name: RCLONE_CONFIG_S3_TYPE
+        value: "s3"
+      - name: RCLONE_CONFIG_S3_PROVIDER
+        value: "Other"  # <-- your provider (AWS, Minio, Cloudflare, GCS, or Other)
+      - name: RCLONE_CONFIG_S3_ENDPOINT
+        value: "s3.us-west-002.backblazeb2.com"  # <-- your endpoint (omit for AWS)
+      # Suppress default config file lookup — all config is via RCLONE_CONFIG_* env vars
+      - name: RCLONE_CONFIG
+        value: ""
+      - name: RCLONE_CONFIG_S3_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "crd-schema-publisher.fullname" . }}-rclone-s3'
+            key: access-key-id
+      - name: RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "crd-schema-publisher.fullname" . }}-rclone-s3'
+            key: secret-access-key
+      - name: RCLONE_S3_BUCKET
+        valueFrom:
+          secretKeyRef:
+            name: '{{ include "crd-schema-publisher.fullname" . }}-rclone-s3'
+            key: bucket-name
+    volumeMounts:
+      - name: output
+        mountPath: /data
+        readOnly: true
+      - name: rclone-tmp
+        mountPath: /tmp
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+    securityContext:
+      runAsUser: 65534
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+
+# Supporting objects: Secret for S3 credentials.
+# All use chart template helpers for consistent naming.
+extraObjects:
+  # S3 credentials — replace placeholder values with your actual credentials,
+  # or use your preferred secret management (ExternalSecret, SealedSecret, etc.)
+  # instead of this inline Secret. You can also reference a pre-created secret
+  # by changing the secretKeyRef names above to point to your existing secret.
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: '{{ include "crd-schema-publisher.fullname" . }}-rclone-s3'
+    type: Opaque
+    stringData:
+      access-key-id: "REPLACE_ME"
+      secret-access-key: "REPLACE_ME"
+      bucket-name: "my-crd-schemas"


### PR DESCRIPTION
## Summary
- Adds `examples/rclone-s3/values.yaml` — rclone sidecar syncing schemas to any S3-compatible storage (AWS S3, Backblaze B2, MinIO, Cloudflare R2, GCS)
- Adds `examples/git-push/values.yaml` — alpine/git sidecar committing and pushing schemas to a git repo (GitHub Pages, GitLab, Gitea, Bitbucket)
- Replaces the single caddy example section in the README with a unified examples table covering all three sidecar patterns

## Design decisions
- **No persistence** for rclone-s3 and git-push — external backends persist data, publisher re-extracts on startup, emptyDir is sufficient. Only caddy-sidecar needs persistence (serves directly from the volume).
- **Wait-for-data guard** — sidecars wait for `index.html` (last file written per cycle) before first sync to prevent racing the publisher and pushing an empty directory
- **Generic S3** — uses `RCLONE_CONFIG_S3_*` env vars with provider/endpoint as configurable values; header documents five providers
- **git push retry** — push runs every cycle regardless of whether a new commit was made, retrying any previously failed pushes
- **Memory limits** — git-push needs 256Mi for the initial commit staging hundreds of files; rclone is fine at 64Mi (streams files)

## Test plan
- [x] rclone-s3: Deployed to live K3s cluster, synced 177 CRDs (533 files) to Backblaze B2 bucket, verified idempotent no-op on second cycle, zero restarts
- [x] git-push: Deployed to live K3s cluster, pushed 177 CRDs to GitHub Pages repo, site live at sholdee.github.io/crd-schemas-test, verified steady-state no-op cycle is silent, zero restarts
- [x] Wait-for-data guard verified — sidecars started after publisher completed extraction
- [x] All three examples pass `helm template` cleanly
- [x] Code review completed — addressed: `runAsUser` consistency, `cp -r` over `cp -a` (ownership bug), push retry pattern, `RCLONE_CONFIG` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)