### PR TITLE
fix(docs): remove stale persistence references from stateless examples

### DIFF
--- a/examples/git-push/values.yaml
+++ b/examples/git-push/values.yaml
@@ -2,8 +2,8 @@
 #
 # This example runs crd-schema-publisher in extract-only mode (no Cloudflare
 # credentials) with an alpine/git sidecar that periodically commits and pushes
-# schema changes to a GitHub repository. A persistent volume keeps schemas
-# available across pod restarts.
+# schema changes to a GitHub repository. No persistence is needed — the publisher
+# re-extracts on startup and the sidecar re-syncs the full set.
 #
 # This works well with GitHub Pages — set the target repo's Pages source to
 # the gh-pages branch and your schemas are automatically published as a static
@@ -38,7 +38,7 @@ extraVolumes:
     emptyDir: {}
 
 # alpine/git sidecar — commits and pushes the shared output volume to GitHub.
-# The "output" volume is created by the chart's persistence block above.
+# The "output" volume is the chart's default emptyDir.
 extraContainers:
   - name: git-push
     image: alpine/git:2.49.1

--- a/examples/rclone-s3/values.yaml
+++ b/examples/rclone-s3/values.yaml
@@ -2,8 +2,8 @@
 #
 # This example runs crd-schema-publisher in extract-only mode (no Cloudflare
 # credentials) with an rclone sidecar that syncs schemas to an S3-compatible
-# bucket every 60 seconds. A persistent volume keeps schemas available across
-# pod restarts.
+# bucket every 60 seconds. No persistence is needed — the publisher re-extracts
+# on startup and the sidecar re-syncs the full set.
 #
 # rclone sync is one-way and DELETES files on the destination that don't exist
 # on the source. If you want additive-only behavior (never delete remote files),
@@ -38,7 +38,7 @@ extraVolumes:
     emptyDir: {}
 
 # rclone sidecar — syncs the shared output volume to S3-compatible storage.
-# The "output" volume is created by the chart's persistence block above.
+# The "output" volume is the chart's default emptyDir.
 extraContainers:
   - name: rclone
     image: ghcr.io/rclone/rclone:1.73.4


### PR DESCRIPTION
## Summary
- Updated comments in `examples/rclone-s3/values.yaml` and `examples/git-push/values.yaml` to reflect that these examples are stateless (emptyDir, no persistence)
- Previous comments still referenced persistence from an earlier iteration where all examples used a PVC

## Test plan
- [x] `helm template` passes for all three examples
- [x] No remaining stale persistence references in stateless examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)