### PR TITLE
fix: exclude charts, docs, examples from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,12 @@
 .golangci.yml
 .gitignore
 .markdownlint-cli2.yaml
+charts
 deploy
+docs
+examples
 output
+artifacthub-repo.yml
 CLAUDE.md
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md


### PR DESCRIPTION
## Summary
- Added `charts`, `docs`, `examples`, and `artifacthub-repo.yml` to `.dockerignore`
- These were added to the repo after the original `.dockerignore` was written and don't belong in the Docker build context

## Test plan
- [x] No impact on final image (multi-stage build copies only the compiled binary)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)