### PR TITLE
fix: Grafana 12.3+ dashboard compatibility and UX improvements

### DIFF
--- a/charts/crd-schema-publisher/dashboards/grafana-dashboard.json
+++ b/charts/crd-schema-publisher/dashboards/grafana-dashboard.json
@@ -161,7 +161,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "time() - crdpublisher_watchdog_timestamp",
+          "expr": "max(time() - crdpublisher_watchdog_timestamp)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -237,7 +237,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_leader",
+          "expr": "max(crdpublisher_leader)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -305,7 +305,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_publish_cycle_duration_seconds",
+          "expr": "max(crdpublisher_publish_cycle_duration_seconds)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -366,7 +366,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_crds_discovered",
+          "expr": "max(crdpublisher_crds_discovered)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -427,7 +427,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_schemas_written",
+          "expr": "max(crdpublisher_schemas_written)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -488,7 +488,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "time() - crdpublisher_last_successful_publish_timestamp",
+          "expr": "max(time() - crdpublisher_last_successful_publish_timestamp)",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -553,7 +553,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "floor(increase(crdpublisher_publish_cycle_total{result=\"error\"}[1h]))",
+          "expr": "max(floor(increase(crdpublisher_publish_cycle_total{result=\"error\"}[1h])))",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -595,7 +595,7 @@
             "lineInterpolation": "linear",
             "barAlignment": 0,
             "lineWidth": 1,
-            "fillOpacity": 80,
+            "fillOpacity": 100,
             "gradientMode": "none",
             "spanNulls": false,
             "insertNulls": false,
@@ -682,7 +682,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "increase(crdpublisher_publish_cycle_total{result=\"success\"}[5m])",
+          "expr": "max(increase(crdpublisher_publish_cycle_total{result=\"success\"}[5m]))",
           "legendFormat": "Success",
           "refId": "A"
         },
@@ -691,7 +691,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "increase(crdpublisher_publish_cycle_total{result=\"error\"}[5m])",
+          "expr": "max(increase(crdpublisher_publish_cycle_total{result=\"error\"}[5m]))",
           "legendFormat": "Error",
           "refId": "B"
         }
@@ -720,12 +720,12 @@
             "lineInterpolation": "linear",
             "barAlignment": 0,
             "lineWidth": 2,
-            "fillOpacity": 20,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "spanNulls": false,
             "insertNulls": false,
-            "showPoints": "never",
-            "pointSize": 5,
+            "showPoints": "always",
+            "pointSize": 6,
             "stacking": {
               "mode": "none",
               "group": "A"
@@ -779,7 +779,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_publish_cycle_duration_seconds",
+          "expr": "max(crdpublisher_publish_cycle_duration_seconds)",
           "legendFormat": "Duration",
           "refId": "A"
         }
@@ -907,7 +907,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_crds_discovered",
+          "expr": "max(crdpublisher_crds_discovered)",
           "legendFormat": "CRDs",
           "refId": "A"
         },
@@ -916,7 +916,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "crdpublisher_schemas_written",
+          "expr": "max(crdpublisher_schemas_written)",
           "legendFormat": "Schemas",
           "refId": "B"
         }
@@ -945,7 +945,7 @@
             "lineInterpolation": "linear",
             "barAlignment": 0,
             "lineWidth": 1,
-            "fillOpacity": 80,
+            "fillOpacity": 100,
             "gradientMode": "none",
             "spanNulls": false,
             "insertNulls": false,
@@ -1004,7 +1004,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "increase(crdpublisher_publish_skipped_total[5m])",
+          "expr": "max(increase(crdpublisher_publish_skipped_total[5m]))",
           "legendFormat": "Skips",
           "refId": "A"
         }

--- a/charts/crd-schema-publisher/dashboards/grafana-dashboard.json
+++ b/charts/crd-schema-publisher/dashboards/grafana-dashboard.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.0.0"
+      "version": "12.0.0"
     },
     {
       "type": "datasource",
@@ -46,8 +46,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "schemaVersion": 39,
-  "style": "dark",
+  "schemaVersion": 42,
   "time": {
     "from": "now-6h",
     "to": "now"
@@ -137,7 +136,7 @@
             ]
           },
           "color": {
-            "mode": "background"
+            "mode": "thresholds"
           }
         },
         "overrides": []
@@ -213,7 +212,7 @@
             ]
           },
           "color": {
-            "mode": "background"
+            "mode": "thresholds"
           }
         },
         "overrides": []
@@ -281,7 +280,7 @@
             ]
           },
           "color": {
-            "mode": "value"
+            "mode": "thresholds"
           }
         },
         "overrides": []
@@ -529,7 +528,7 @@
             ]
           },
           "color": {
-            "mode": "background"
+            "mode": "thresholds"
           }
         },
         "overrides": []
@@ -674,7 +673,6 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showValues": "auto",
           "calcs": []
         }
       },
@@ -772,7 +770,6 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showValues": "auto",
           "calcs": []
         }
       },
@@ -901,7 +898,6 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showValues": "auto",
           "calcs": []
         }
       },
@@ -999,7 +995,6 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showValues": "auto",
           "calcs": []
         }
       },


### PR DESCRIPTION
## Summary
- Replace invalid `fieldConfig.defaults.color.mode` values (`"background"`, `"value"`) with `"thresholds"` — fixes dashboard rendering on Grafana 12.3.0
- Wrap all PromQL queries in `max()` to prevent duplicate stat values and legend entries during pod restarts
- Use solid bars for event counters (Publish Cycles, Debounce Skips), line+points for sparse duration gauge (Cycle Duration)
- Clean up vestigial fields (`style`, `showValues`), bump `schemaVersion` to 42

## Test plan
- [x] Reproduced bug on standalone Grafana 12.3.0 (Docker) — confirmed error
- [x] Applied fix — confirmed all panels render, zero console errors
- [x] Reproduced bug on live cluster (kube-prometheus-stack pinned to 12.3.0) — confirmed error
- [x] Applied fix on live cluster — confirmed all panels render correctly
- [x] Verified `max()` queries produce single legend entries
- [x] Helm template and JSON validation pass locally

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)