### PR TITLE
ci: decouple releases from CI with manual workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,61 +42,17 @@ jobs:
               - '.github/renovate.json5'
 
   test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
-      - name: Lint workflows
-        run: |
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
-          actionlint -shellcheck="shellcheck"
-
-      - name: Lint markdown
-        run: npx --yes markdownlint-cli2@0.22.0 '**/*.md' '#node_modules'
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-
-      - name: Verify dependencies
-        run: go mod verify
-
-      - name: Check go.mod tidiness
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum
-
-      - name: Run tests
-        run: go test -race ./... -v -coverprofile=coverage.txt -covermode=atomic
-
-      - name: Coverage summary
-        run: go tool cover -func=coverage.txt
-
-      - name: Run vet
-        run: go vet ./...
-
-      - name: Vulnerability check
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-          govulncheck ./...
+    uses: ./.github/workflows/test.yml
 
   build:
     needs: [test, detect]
-    if: needs.detect.outputs.app == 'true'
+    if: github.event_name == 'pull_request' && needs.detect.outputs.app == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-      date-tag: ${{ steps.tags.outputs.date }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -128,26 +84,14 @@ jobs:
       - name: Generate tags
         id: tags
         env:
-          EVENT_NAME: ${{ github.event_name }}
           FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ "${EVENT_NAME}" == "push" ]]; then
-            DATE_TAG="v$(date -u +'%Y.%-m%d.%-H%M%S')"
-            echo "date=${DATE_TAG}" >> "$GITHUB_OUTPUT"
-            {
-              echo 'tags<<TAGS_EOF'
-              echo "${FULL_IMAGE}:${DATE_TAG}"
-              echo "${FULL_IMAGE}:latest"
-              echo 'TAGS_EOF'
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo 'tags<<TAGS_EOF'
-              echo "${FULL_IMAGE}:pr-${PR_NUMBER}"
-              echo 'TAGS_EOF'
-            } >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo 'tags<<TAGS_EOF'
+            echo "${FULL_IMAGE}:pr-${PR_NUMBER}"
+            echo 'TAGS_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build
@@ -163,74 +107,10 @@ jobs:
             index:org.opencontainers.image.licenses=MIT
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.tags.outputs.date || 'dev' }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at }}
+            org.opencontainers.image.version=dev
+            org.opencontainers.image.created=${{ github.event.pull_request.updated_at }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  sign:
-    needs: build
-    if: github.event_name == 'push' && needs.build.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      packages: write
-    steps:
-      - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sign image with cosign
-        env:
-          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DATE_TAG: ${{ needs.build.outputs.date-tag }}
-          DIGEST: ${{ needs.build.outputs.digest }}
-        run: |
-          cosign sign --yes "${FULL_IMAGE}:${DATE_TAG}@${DIGEST}"
-          cosign sign --yes "${FULL_IMAGE}:latest@${DIGEST}"
-
-  release:
-    needs: [detect, build, sign, helm-package]
-    if: >-
-      github.event_name == 'push' &&
-      needs.detect.outputs.app == 'true' &&
-      needs.sign.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DATE_TAG: ${{ needs.build.outputs.date-tag }}
-          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ needs.build.outputs.digest }}
-        run: |
-          git tag "${DATE_TAG}"
-          git push origin "${DATE_TAG}"
-
-          NOTES=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="${DATE_TAG}" \
-            --jq '.body')
-
-          IMAGE_LINE="**Image:** \`${FULL_IMAGE}:${DATE_TAG}@${DIGEST}\`"
-          CHART_LINE="**Chart:** \`oci://${REGISTRY}/sholdee/charts/crd-schema-publisher:${DATE_TAG#v}\`"
-          printf '%s\n\n---\n\n%s\n%s\n' "${NOTES}" "${IMAGE_LINE}" "${CHART_LINE}" \
-            | gh release create "${DATE_TAG}" \
-              --verify-tag \
-              --title "${DATE_TAG}" \
-              --notes-file -
 
   renovate:
     needs: detect
@@ -246,205 +126,14 @@ jobs:
         run: npx --yes --package renovate@43.113.0 -- renovate-config-validator --strict
 
   helm-lint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-
-      - name: Lint chart
-        run: helm lint charts/crd-schema-publisher --set existingSecret.name=test
-
-      - name: Template (controller mode)
-        run: helm template test charts/crd-schema-publisher --set existingSecret.name=test
-
-      - name: Template (cronjob mode)
-        run: helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test
-
-      - name: Template (all features)
-        run: |
-          helm template test charts/crd-schema-publisher \
-            --set existingSecret.name=test \
-            --set metrics.podMonitor.enabled=true \
-            --set metrics.prometheusRule.enabled=true \
-            --set grafana.dashboard.enabled=true \
-            --set podDisruptionBudget.enabled=true \
-            --set podDisruptionBudget.minAvailable=1 \
-            --set networkPolicy.enabled=true \
-            --set replicaCount=3 \
-            --set podAntiAffinityPreset=soft \
-            --set persistence.enabled=true
-
-      - name: Verify mode isolation
-        run: |
-          # Cronjob mode must not produce controller-only resources
-          ROLE_COUNT=$(helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test | grep -c "^kind: Role$" || true)
-          if [[ "${ROLE_COUNT}" -ne 0 ]]; then
-            echo "ERROR: cronjob mode should not produce Role resources"
-            exit 1
-          fi
-
-          # Controller mode must not produce CronJob
-          CRON_COUNT=$(helm template test charts/crd-schema-publisher --set existingSecret.name=test | grep -c "^kind: CronJob$" || true)
-          if [[ "${CRON_COUNT}" -ne 0 ]]; then
-            echo "ERROR: controller mode should not produce CronJob resources"
-            exit 1
-          fi
-
-      - name: Verify schema validation
-        run: |
-          helm template test charts/crd-schema-publisher > /dev/null
-          echo "Schema accepts no secret (extract-only mode)"
-
-          if helm template test charts/crd-schema-publisher --set existingSecret.name=s --set externalSecret.enabled=true 2>/dev/null; then
-            echo "ERROR: schema should reject both secret options set simultaneously"
-            exit 1
-          fi
-          echo "Schema correctly enforces mutual exclusivity"
-
-          if helm template test charts/crd-schema-publisher --set existingSecret.name=s --set networkPolicy.enabled=true --set ciliumNetworkPolicy.enabled=true 2>/dev/null; then
-            echo "ERROR: should reject both networkPolicy and ciliumNetworkPolicy enabled"
-            exit 1
-          fi
-          echo "Network policy mutual exclusivity enforced"
-
-      - name: Verify dashboard embedding
-        run: |
-          DASHBOARD=$(helm template test charts/crd-schema-publisher \
-            --set existingSecret.name=test \
-            --set grafana.dashboard.enabled=true \
-            | yq 'select(.kind == "ConfigMap") | .data["crd-schema-publisher.json"]')
-          if [[ -z "${DASHBOARD}" ]]; then
-            echo "ERROR: dashboard ConfigMap data is empty"
-            exit 1
-          fi
-          echo "${DASHBOARD}" | python3 -m json.tool > /dev/null
-          echo "Dashboard JSON embedded and valid"
-
-      - name: Verify existingClaim suppresses PVC creation
-        run: |
-          PVC_COUNT=$(helm template test charts/crd-schema-publisher \
-            --set existingSecret.name=test \
-            --set persistence.enabled=true \
-            --set persistence.existingClaim=my-pvc \
-            | grep -c "^kind: PersistentVolumeClaim$" || true)
-          if [[ "${PVC_COUNT}" -ne 0 ]]; then
-            echo "ERROR: existingClaim should suppress PVC creation"
-            exit 1
-          fi
-          echo "existingClaim correctly suppresses PVC creation"
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
-      - name: Validate manifests with kubeconform
-        run: |
-          go install github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0
-          SCHEMA_ARGS=(
-            -strict
-            -ignore-missing-schemas
-            -schema-location default
-            -schema-location 'https://kube-schemas.shold.io/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
-          )
-
-          echo "Validating controller mode..."
-          helm template test charts/crd-schema-publisher \
-            --set existingSecret.name=test \
-            | kubeconform "${SCHEMA_ARGS[@]}"
-
-          echo "Validating cronjob mode..."
-          helm template test charts/crd-schema-publisher \
-            --set mode=cronjob \
-            --set existingSecret.name=test \
-            | kubeconform "${SCHEMA_ARGS[@]}"
-
-  helm-package:
-    needs: [detect, helm-lint, build, sign]
-    if: |
-      always() &&
-      github.event_name == 'push' &&
-      (needs.detect.outputs.chart == 'true' || needs.detect.outputs.app == 'true') &&
-      needs.helm-lint.result == 'success' &&
-      (needs.build.result == 'success' || needs.build.result == 'skipped') &&
-      (needs.sign.result == 'success' || needs.sign.result == 'skipped')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute chart version
-        id: version
-        env:
-          DATE_TAG: ${{ needs.build.outputs.date-tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [[ -n "${DATE_TAG}" ]]; then
-            # App change: chart version and appVersion both align with the new image tag
-            SEMVER="${DATE_TAG#v}"
-            APP_VERSION="${DATE_TAG}"
-          else
-            # Chart-only change: bump chart version, appVersion = latest released image tag.
-            # Reading from Chart.yaml is not reliable (CI never commits back), so we query
-            # the releases API which is the authoritative record of what image tags exist.
-            SEMVER="$(date -u +'%Y.%-m%d.%-H%M%S')"
-            API_RESPONSE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" 2>&1) || API_EXIT=$?
-            if [[ -n "${API_EXIT:-}" ]]; then
-              if echo "${API_RESPONSE}" | grep -q 'HTTP 404'; then
-                echo "ERROR: No app release found. A chart-only publish requires at least one prior app release so that appVersion points to a real image. Merge an app change first, or combine this chart change with an app change."
-              else
-                echo "ERROR: Failed to fetch latest release from GitHub API. Check that GITHUB_TOKEN has contents:read scope."
-                echo "${API_RESPONSE}"
-              fi
-              exit 1
-            fi
-            APP_VERSION=$(echo "${API_RESPONSE}" | jq -r '.tag_name')
-          fi
-          echo "semver=${SEMVER}" >> "$GITHUB_OUTPUT"
-          echo "app-version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Package chart
-        env:
-          SEMVER: ${{ steps.version.outputs.semver }}
-          APP_VERSION: ${{ steps.version.outputs.app-version }}
-        run: helm package charts/crd-schema-publisher --version "${SEMVER}" --app-version "${APP_VERSION}"
-
-      - name: Push chart to GHCR
-        env:
-          SEMVER: ${{ steps.version.outputs.semver }}
-        run: helm push "crd-schema-publisher-${SEMVER}.tgz" "oci://${REGISTRY}/sholdee/charts"
-
-      - name: Sign chart with cosign
-        env:
-          SEMVER: ${{ steps.version.outputs.semver }}
-        run: cosign sign --yes "${REGISTRY}/sholdee/charts/crd-schema-publisher:${SEMVER}"
+    needs: detect
+    if: needs.detect.outputs.chart == 'true'
+    uses: ./.github/workflows/helm-lint.yml
 
   gate:
     runs-on: ubuntu-latest
     if: always()
-    needs: [detect, test, build, sign, release, renovate, helm-lint, helm-package]
+    needs: [detect, test, build, renovate, helm-lint]
     permissions: {}
     steps:
       - name: Evaluate results
@@ -452,15 +141,12 @@ jobs:
           DETECT: ${{ needs.detect.result }}
           TEST: ${{ needs.test.result }}
           BUILD: ${{ needs.build.result }}
-          SIGN: ${{ needs.sign.result }}
-          RELEASE: ${{ needs.release.result }}
           RENOVATE: ${{ needs.renovate.result }}
           HELM_LINT: ${{ needs.helm-lint.result }}
-          HELM_PACKAGE: ${{ needs.helm-package.result }}
         run: |
-          echo "detect=${DETECT} test=${TEST} build=${BUILD} sign=${SIGN} release=${RELEASE} renovate=${RENOVATE} helm-lint=${HELM_LINT} helm-package=${HELM_PACKAGE}"
+          echo "detect=${DETECT} test=${TEST} build=${BUILD} renovate=${RENOVATE} helm-lint=${HELM_LINT}"
 
-          for result in "${DETECT}" "${TEST}" "${BUILD}" "${SIGN}" "${RELEASE}" "${RENOVATE}" "${HELM_LINT}" "${HELM_PACKAGE}"; do
+          for result in "${DETECT}" "${TEST}" "${BUILD}" "${RENOVATE}" "${HELM_LINT}"; do
             if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
               echo "CI failed: job returned ${result}"
               exit 1

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,126 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Helm Lint
+
+on:
+  workflow_call:
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Lint chart
+        run: helm lint charts/crd-schema-publisher --set existingSecret.name=test
+
+      - name: Template (controller mode)
+        run: helm template test charts/crd-schema-publisher --set existingSecret.name=test
+
+      - name: Template (cronjob mode)
+        run: helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test
+
+      - name: Template (all features)
+        run: |
+          helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set metrics.podMonitor.enabled=true \
+            --set metrics.prometheusRule.enabled=true \
+            --set grafana.dashboard.enabled=true \
+            --set podDisruptionBudget.enabled=true \
+            --set podDisruptionBudget.minAvailable=1 \
+            --set networkPolicy.enabled=true \
+            --set replicaCount=3 \
+            --set podAntiAffinityPreset=soft \
+            --set persistence.enabled=true
+
+      - name: Verify mode isolation
+        run: |
+          # Cronjob mode must not produce controller-only resources
+          ROLE_COUNT=$(helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test | grep -c "^kind: Role$" || true)
+          if [[ "${ROLE_COUNT}" -ne 0 ]]; then
+            echo "ERROR: cronjob mode should not produce Role resources"
+            exit 1
+          fi
+
+          # Controller mode must not produce CronJob
+          CRON_COUNT=$(helm template test charts/crd-schema-publisher --set existingSecret.name=test | grep -c "^kind: CronJob$" || true)
+          if [[ "${CRON_COUNT}" -ne 0 ]]; then
+            echo "ERROR: controller mode should not produce CronJob resources"
+            exit 1
+          fi
+
+      - name: Verify schema validation
+        run: |
+          helm template test charts/crd-schema-publisher > /dev/null
+          echo "Schema accepts no secret (extract-only mode)"
+
+          if helm template test charts/crd-schema-publisher --set existingSecret.name=s --set externalSecret.enabled=true 2>/dev/null; then
+            echo "ERROR: schema should reject both secret options set simultaneously"
+            exit 1
+          fi
+          echo "Schema correctly enforces mutual exclusivity"
+
+          if helm template test charts/crd-schema-publisher --set existingSecret.name=s --set networkPolicy.enabled=true --set ciliumNetworkPolicy.enabled=true 2>/dev/null; then
+            echo "ERROR: should reject both networkPolicy and ciliumNetworkPolicy enabled"
+            exit 1
+          fi
+          echo "Network policy mutual exclusivity enforced"
+
+      - name: Verify dashboard embedding
+        run: |
+          DASHBOARD=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.enabled=true \
+            | yq 'select(.kind == "ConfigMap") | .data["crd-schema-publisher.json"]')
+          if [[ -z "${DASHBOARD}" ]]; then
+            echo "ERROR: dashboard ConfigMap data is empty"
+            exit 1
+          fi
+          echo "${DASHBOARD}" | python3 -m json.tool > /dev/null
+          echo "Dashboard JSON embedded and valid"
+
+      - name: Verify existingClaim suppresses PVC creation
+        run: |
+          PVC_COUNT=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set persistence.enabled=true \
+            --set persistence.existingClaim=my-pvc \
+            | grep -c "^kind: PersistentVolumeClaim$" || true)
+          if [[ "${PVC_COUNT}" -ne 0 ]]; then
+            echo "ERROR: existingClaim should suppress PVC creation"
+            exit 1
+          fi
+          echo "existingClaim correctly suppresses PVC creation"
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Validate manifests with kubeconform
+        run: |
+          go install github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0
+          SCHEMA_ARGS=(
+            -strict
+            -ignore-missing-schemas
+            -schema-location default
+            -schema-location 'https://kube-schemas.shold.io/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+          )
+
+          echo "Validating controller mode..."
+          helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            | kubeconform "${SCHEMA_ARGS[@]}"
+
+          echo "Validating cronjob mode..."
+          helm template test charts/crd-schema-publisher \
+            --set mode=cronjob \
+            --set existingSecret.name=test \
+            | kubeconform "${SCHEMA_ARGS[@]}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,201 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  helm-lint:
+    uses: ./.github/workflows/helm-lint.yml
+
+  build:
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      date-tag: ${{ steps.tags.outputs.date }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Verify base images
+        run: |
+          DISTROLESS_REF=$(grep '^FROM gcr.io/distroless/' Dockerfile | awk '{print $2}')
+          echo "Verifying ${DISTROLESS_REF}"
+          cosign verify "${DISTROLESS_REF}" \
+            --certificate-oidc-issuer https://accounts.google.com \
+            --certificate-identity keyless@distroless.iam.gserviceaccount.com
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate version
+        id: tags
+        env:
+          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          DATE_TAG="v$(date -u +'%Y.%-m%d.%-H%M%S')"
+          CREATED="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          {
+            echo "date=${DATE_TAG}"
+            echo "created=${CREATED}"
+            echo 'tags<<TAGS_EOF'
+            echo "${FULL_IMAGE}:${DATE_TAG}"
+            echo "${FULL_IMAGE}:latest"
+            echo 'TAGS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          annotations: |
+            index:org.opencontainers.image.description=Extracts CRD JSON schemas from Kubernetes and publishes to Cloudflare Pages
+            index:org.opencontainers.image.source=https://github.com/sholdee/crd-schema-publisher
+            index:org.opencontainers.image.licenses=MIT
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tags.outputs.date }}
+            org.opencontainers.image.created=${{ steps.tags.outputs.created }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  sign:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        env:
+          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DATE_TAG: ${{ needs.build.outputs.date-tag }}
+          DIGEST: ${{ needs.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${FULL_IMAGE}:${DATE_TAG}@${DIGEST}"
+          cosign sign --yes "${FULL_IMAGE}:latest@${DIGEST}"
+
+  helm-package:
+    needs: [helm-lint, build, sign]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute chart version
+        id: version
+        env:
+          DATE_TAG: ${{ needs.build.outputs.date-tag }}
+        run: |
+          SEMVER="${DATE_TAG#v}"
+          echo "semver=${SEMVER}" >> "$GITHUB_OUTPUT"
+          echo "app-version=${DATE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Package chart
+        env:
+          SEMVER: ${{ steps.version.outputs.semver }}
+          APP_VERSION: ${{ steps.version.outputs.app-version }}
+        run: helm package charts/crd-schema-publisher --version "${SEMVER}" --app-version "${APP_VERSION}"
+
+      - name: Push chart to GHCR
+        env:
+          SEMVER: ${{ steps.version.outputs.semver }}
+        run: helm push "crd-schema-publisher-${SEMVER}.tgz" "oci://${REGISTRY}/sholdee/charts"
+
+      - name: Sign chart with cosign
+        env:
+          SEMVER: ${{ steps.version.outputs.semver }}
+        run: cosign sign --yes "${REGISTRY}/sholdee/charts/crd-schema-publisher:${SEMVER}"
+
+  release:
+    needs: [build, sign, helm-package]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATE_TAG: ${{ needs.build.outputs.date-tag }}
+          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ needs.build.outputs.digest }}
+        run: |
+          git tag "${DATE_TAG}"
+          git push origin "${DATE_TAG}"
+
+          NOTES=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="${DATE_TAG}" \
+            --jq '.body')
+
+          IMAGE_LINE="**Image:** \`${FULL_IMAGE}:${DATE_TAG}@${DIGEST}\`"
+          CHART_LINE="**Chart:** \`oci://${REGISTRY}/sholdee/charts/crd-schema-publisher:${DATE_TAG#v}\`"
+          printf '%s\n\n---\n\n%s\n%s\n' "${NOTES}" "${IMAGE_LINE}" "${CHART_LINE}" \
+            | gh release create "${DATE_TAG}" \
+              --verify-tag \
+              --title "${DATE_TAG}" \
+              --notes-file -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Test
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Lint workflows
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          actionlint -shellcheck="shellcheck"
+
+      - name: Lint markdown
+        run: npx --yes markdownlint-cli2@0.22.0 '**/*.md' '#node_modules'
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Check go.mod tidiness
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: Run tests
+        run: go test -race ./... -v -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Coverage summary
+        run: go tool cover -func=coverage.txt
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Vulnerability check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          govulncheck ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ go run ./cmd/ preview
 - **Image signing** uses cosign keyless mode via GitHub OIDC. Production images on main are signed; PR images are not. Base images (golang, distroless) are verified before every build.
 - **Supply chain hardening**: all GitHub Actions pinned by commit SHA (not version tag), Dockerfile base images pinned by digest, `go mod verify` runs in CI.
 - **Prometheus metrics** use stdlib-only text exposition format (no `prometheus/client_golang` dependency). Atomic counters and gauges in `metrics/` package, served at `/metrics` on the health server port. Metrics are always registered in watch mode — zero overhead when not scraped. Recording methods are nil-receiver safe so callers don't need nil checks. Float gauges use `math.Float64bits`/`math.Float64frombits` with `atomic.Int64` for lock-free storage.
-- **Helm chart** in `charts/crd-schema-publisher/` distributed as OCI artifact via GHCR. Two modes (`controller`/`cronjob`) with mode-isolated templates. Two-tier secret management: `existingSecret`, `externalSecret` (ESO) — or no secret at all for extract-only mode (watch gracefully degrades without Cloudflare creds). `values.schema.json` enforces secret mutual exclusivity via `if/then` (not `oneOf`, which breaks yaml-language-server with `additionalProperties: false`); template precedence in `_helpers.tpl` handles runtime resolution (`existingSecret.name` wins, else chart fullname). NetworkPolicy and CiliumNetworkPolicy are mutually exclusive (enforced via `fail` guard in `_helpers.tpl`). PrometheusRule only renders in controller mode. Chart version is CalVer SemVer: `YYYY.MDD.HMMSS` (no leading zeros on month or hour — e.g. `2026.413.65435`). On app changes, `appVersion` aligns with the new image tag. On chart-only changes, `appVersion` is fetched from the GitHub releases API so it always points to a real, pullable image (fails fast if no prior app release exists). `Chart.yaml` version/appVersion fields are placeholder `0.0.0` — both overridden by CI at package time. Dashboard embedded via `.Files.Get`. Pod anti-affinity presets in `_helpers.tpl`.
+- **Helm chart** in `charts/crd-schema-publisher/` distributed as OCI artifact via GHCR. Two modes (`controller`/`cronjob`) with mode-isolated templates. Two-tier secret management: `existingSecret`, `externalSecret` (ESO) — or no secret at all for extract-only mode (watch gracefully degrades without Cloudflare creds). `values.schema.json` enforces secret mutual exclusivity via `if/then` (not `oneOf`, which breaks yaml-language-server with `additionalProperties: false`); template precedence in `_helpers.tpl` handles runtime resolution (`existingSecret.name` wins, else chart fullname). NetworkPolicy and CiliumNetworkPolicy are mutually exclusive (enforced via `fail` guard in `_helpers.tpl`). PrometheusRule only renders in controller mode. Chart version is CalVer SemVer: `YYYY.MDD.HMMSS` (no leading zeros on month or hour — e.g. `2026.413.65435`). Image and chart are always released together with the same CalVer version — both `version` and `appVersion` match the image tag. `Chart.yaml` version/appVersion fields are placeholder `0.0.0` — both overridden by the release workflow at package time. Dashboard embedded via `.Files.Get`. Pod anti-affinity presets in `_helpers.tpl`.
 
 ### Dependencies (direct only)
 
@@ -103,28 +103,47 @@ No other external dependencies. Standard library for HTTP, JSON, HTML templates,
 
 ## CI/CD
 
-### Pipeline Architecture (`.github/workflows/ci.yaml`)
+### Pipeline Architecture
 
-Single workflow triggered on PRs to `main` and pushes to `main`, with nine conditional jobs:
+Four workflow files in `.github/workflows/`:
+
+| File | Trigger | Purpose |
+| --- | ------- | ------- |
+| `test.yml` | `workflow_call` | Reusable: actionlint, markdownlint-cli2, golangci-lint, go mod verify/tidy, go test, go vet, govulncheck |
+| `helm-lint.yml` | `workflow_call` | Reusable: `helm lint`, `helm template` in controller/cronjob/all-features modes, mode isolation checks, schema validation, dashboard JSON embedding, kubeconform |
+| `ci.yaml` | PR + push to `main` | Orchestrator: calls `test.yml` and `helm-lint.yml`, runs detect/build/renovate/gate |
+| `release.yaml` | `workflow_dispatch` | Orchestrator: calls `test.yml` and `helm-lint.yml`, runs build/sign/helm-package/release |
+
+**`ci.yaml`** jobs:
 
 | Job | Runs when | Purpose |
 | --- | --------- | ------- |
 | `detect` | Always | `dorny/paths-filter` classifies changes: `app` (Go, go.mod/sum, Dockerfile), `chart` (charts/**), `renovate` (config only). |
-| `test` | Always (safety net — ensures Go code compiles on every PR, even docs-only) | actionlint, markdownlint-cli2, golangci-lint, go mod verify/tidy, go test, go vet |
-| `build` | `app == true` | Multi-arch Docker build (amd64 + arm64), pushes to GHCR. PR: `pr-N` tag. Main: `vYYYY.MDD.HMMSS` + `latest`. Verifies distroless base image digest with cosign before building. |
-| `sign` | Push to main + `build` succeeded | Cosign keyless signing via GitHub OIDC |
-| `release` | Push to main + `app == true` + `sign` succeeded | Creates git tag, GitHub Release with auto-generated notes, image digest, and chart OCI reference. Waits for `helm-package`. Note: tag push will fail if the tagged commit includes workflow file changes — create the tag manually in that case. |
+| `test` | Always | Calls `test.yml` — safety net, ensures Go code compiles on every PR, even docs-only |
+| `build` | PR + `app == true` | Multi-arch Docker build (amd64 + arm64), pushes `pr-N` tag to GHCR. Verifies distroless base image digest with cosign before building. |
 | `renovate` | `renovate == true` | Validates `.github/renovate.json5` with `renovate-config-validator --strict` |
-| `helm-lint` | Always | `helm lint`, `helm template` in controller/cronjob/all-features modes, mode isolation checks, schema validation, dashboard JSON embedding, kubeconform against built-in and live CRD schemas |
-| `helm-package` | Push to main + (`chart` or `app` changed) | Package chart with CalVer SemVer. On app change: chart version = image tag, `appVersion` = image tag. On chart-only change: chart version = fresh timestamp, `appVersion` = fetched from GitHub releases API (always a real, pullable image). Fails fast if no prior app release exists. Push OCI to GHCR, cosign sign. |
+| `helm-lint` | Always | Calls `helm-lint.yml` |
 | `gate` | Always | Evaluates all job results — only `success` and `skipped` pass. Single required status check for branch protection. |
 
-Build, sign, and release only trigger on application-affecting changes (`app` filter). CI-only changes (e.g., bumping an action SHA, updating linter config) run tests but do not build images. Helm chart is packaged on any chart or app change to keep chart `appVersion` in sync with image tags.
+Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR builds produce `pr-N` images for testing.
+
+**`release.yaml`** jobs:
+
+| Job | Runs when | Purpose |
+| --- | --------- | ------- |
+| `test` | Always | Calls `test.yml` — re-runs all linting and Go tests as a safety net before building |
+| `helm-lint` | Always | Calls `helm-lint.yml` — re-runs all Helm validation before packaging |
+| `build` | After `test` passes | Multi-arch Docker build (amd64 + arm64), pushes `vYYYY.MDD.HMMSS` + `latest` to GHCR. Verifies distroless base image digest with cosign before building. |
+| `sign` | After `build` | Cosign keyless signing via GitHub OIDC |
+| `helm-package` | After `helm-lint` and `build` | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
+| `release` | After `build`, `sign`, `helm-package` | Creates git tag, GitHub Release with auto-generated notes, image digest, and chart OCI reference. Note: tag push will fail if the tagged commit includes workflow file changes — create the tag manually in that case. |
+
+App image and Helm chart are always released together with the same CalVer version. Releases are decoupled from CI — trigger the release workflow when changes warrant a new version. The release workflow re-runs all tests before building as a safety net. A concurrency group prevents simultaneous releases from racing.
 
 ### Tags
 
-- **Production:** `vYYYY.MDD.HMMSS` (UTC, no leading zeros on month/hour — e.g. `v2026.413.65435`) + `latest` — created on push to main when app code changes
-- **PR:** `pr-N` — created on every PR with code changes
+- **Production:** `vYYYY.MDD.HMMSS` (UTC, no leading zeros on month/hour — e.g. `v2026.413.65435`) + `latest` — created by manual release workflow
+- **PR:** `pr-N` — created on every PR with app code changes
 
 ### Renovate (`.github/renovate.json5`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Four workflow files in `.github/workflows/`:
 | `test` | Always | Calls `test.yml` — safety net, ensures Go code compiles on every PR, even docs-only |
 | `build` | PR + `app == true` | Multi-arch Docker build (amd64 + arm64), pushes `pr-N` tag to GHCR. Verifies distroless base image digest with cosign before building. |
 | `renovate` | `renovate == true` | Validates `.github/renovate.json5` with `renovate-config-validator --strict` |
-| `helm-lint` | Always | Calls `helm-lint.yml` |
+| `helm-lint` | `chart == true` | Calls `helm-lint.yml` |
 | `gate` | Always | Evaluates all job results — only `success` and `skipped` pass. Single required status check for branch protection. |
 
 Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR builds produce `pr-N` images for testing.
@@ -135,7 +135,7 @@ Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR
 | `helm-lint` | Always | Calls `helm-lint.yml` — re-runs all Helm validation before packaging |
 | `build` | After `test` passes | Multi-arch Docker build (amd64 + arm64), pushes `vYYYY.MDD.HMMSS` + `latest` to GHCR. Verifies distroless base image digest with cosign before building. |
 | `sign` | After `build` | Cosign keyless signing via GitHub OIDC |
-| `helm-package` | After `helm-lint` and `build` | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
+| `helm-package` | After `helm-lint`, `build`, and `sign` | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
 | `release` | After `build`, `sign`, `helm-package` | Creates git tag, GitHub Release with auto-generated notes, image digest, and chart OCI reference. Note: tag push will fail if the tagged commit includes workflow file changes — create the tag manually in that case. |
 
 App image and Helm chart are always released together with the same CalVer version. Releases are decoupled from CI — trigger the release workflow when changes warrant a new version. The release workflow re-runs all tests before building as a safety net. A concurrency group prevents simultaneous releases from racing.


### PR DESCRIPTION
## Summary
- Split monolithic `ci.yaml` (471 lines, 9 jobs) into 4 workflow files
- **`test.yml`** + **`helm-lint.yml`**: reusable `workflow_call` workflows eliminating code duplication
- **`ci.yaml`** (155 lines, 6 jobs): PR validation + push-to-main linting/testing only — no builds on push, no releases
- **`release.yaml`**: manual `workflow_dispatch` that builds image, signs with cosign, packages Helm chart, and creates GitHub Release — all with the same CalVer version, no desync possible
- CI `helm-lint` now conditional on chart changes (`charts/**`), saving ~30s on non-chart PRs
- Concurrency group on release workflow prevents simultaneous release races

## Test plan
- [ ] Push to main (after merge) triggers only `detect`, `test`, `renovate`, `gate` — no build, no release
- [ ] PR with app changes triggers `detect`, `test`, `build` (pr-N tag), `helm-lint` (if chart changes), `gate`
- [ ] Manual release workflow runs full pipeline: test → build → sign → helm-package → release
- [ ] `CI / gate` status check still passes on PRs with no app or chart changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)