### PR TITLE
ci: restrict release workflow to main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,22 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify branch
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "ERROR: Release workflow must run on main branch, got ${GITHUB_REF}"
+          exit 1
+
   test:
+    needs: [guard]
     uses: ./.github/workflows/test.yml
 
   helm-lint:
+    needs: [guard]
     uses: ./.github/workflows/helm-lint.yml
 
   build:


### PR DESCRIPTION
## Summary
- Add `guard` job to `release.yaml` that fails fast if `workflow_dispatch` is triggered from any branch other than `main`
- `workflow_dispatch` doesn't support a `branches` filter natively, so this is a runtime check
- All downstream jobs depend on `guard` through the dependency chain

## Test plan
- [ ] Release workflow dropdown still shows branch selector, but selecting non-main fails immediately with clear error
- [ ] Selecting `main` runs the full pipeline as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)