### PR TITLE
fix: eliminate redundant double-publish on watcher startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ go run ./cmd/ preview
 - **Theme package** (`theme/`) holds shared CSS, HTML fragments, and JS used by both index and renderer templates. CSS custom properties are the union of both pages' needs. The deepspace theme (starfield, flare, light/dark toggle) is defined once here.
 - **Output format** produces two directory structures: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility). Each JSON schema also gets a sibling `.html` documentation page.
 - **Concurrency**: extractor uses 10 goroutines (buffered channel semaphore), publisher uses 3 concurrent upload workers, renderer uses 10 goroutines. These match the original tools' behavior.
+- **Watch mode uses first-trigger-immediate debounce.** The informer's initial List fires AddFunc for all existing CRDs, which signals the debounce loop. The first trigger fires immediately (zero delay), subsequent triggers are debounced. This produces exactly one publish cycle on startup — no explicit initial publish in runLeader.
 - **Watch mode uses full re-extract.** Simpler than incremental. Upload is already incremental via check-missing. Extraction of <200 CRDs is sub-second.
 - **Leader election uses standard client-go leaderelection.** LeaseLock with 15s/10s/2s timings. Leader exits on lease loss (standard controller pattern).
 - **All replicas report ready.** Readiness is not gated on leadership. Standard controller pattern — leadership is an internal concern.

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -126,12 +126,6 @@ func Run(ctx context.Context, cfg Config) error {
 }
 
 func runLeader(ctx context.Context, cfg Config) {
-	// Initial publish on becoming leader
-	slog.Info("running initial publish cycle")
-	if err := publishCycle(cfg); err != nil {
-		slog.Error("initial publish failed", "error", err)
-	}
-
 	// Set up CRD informer
 	trigger := make(chan struct{}, 1)
 	lw := &cache.ListWatch{
@@ -185,6 +179,7 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 	var timerC <-chan time.Time
 	var publishing atomic.Bool
 	var wg sync.WaitGroup
+	first := true
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 	m.Heartbeat() // initial heartbeat on loop entry
@@ -209,8 +204,13 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 			return
 		case <-trigger:
 			m.Heartbeat()
+			d := duration
+			if first {
+				d = 0
+				first = false
+			}
 			if timer == nil {
-				timer = time.NewTimer(duration)
+				timer = time.NewTimer(d)
 				timerC = timer.C
 			} else {
 				if !timer.Stop() {
@@ -219,7 +219,7 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 					default:
 					}
 				}
-				timer.Reset(duration)
+				timer.Reset(d)
 			}
 		case <-heartbeat.C:
 			m.Heartbeat()
@@ -236,7 +236,7 @@ func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func(
 			go func() {
 				defer wg.Done()
 				defer publishing.Store(false)
-				slog.Info("debounce timer fired, running publish cycle")
+				slog.Info("running publish cycle")
 				if err := publish(); err != nil {
 					slog.Error("publish cycle failed", "error", err)
 				}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -55,7 +55,59 @@ func testCRD() apiextensionsv1.CustomResourceDefinition {
 	}
 }
 
-// --- debounce tests (existing) ---
+// --- debounce tests ---
+
+func TestDebounce_FirstTriggerFiresImmediately(t *testing.T) {
+	var fired atomic.Bool
+	trigger := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	go debounceLoop(trigger, 200*time.Millisecond, func() error {
+		fired.Store(true)
+		return nil
+	}, nil, done)
+
+	trigger <- struct{}{}
+
+	// First trigger should fire well before the 200ms debounce duration
+	time.Sleep(50 * time.Millisecond)
+	if !fired.Load() {
+		t.Fatal("expected first trigger to fire immediately, but it did not")
+	}
+	close(done)
+}
+
+func TestDebounce_SubsequentTriggerIsDebounced(t *testing.T) {
+	var count atomic.Int32
+	trigger := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	go debounceLoop(trigger, 200*time.Millisecond, func() error {
+		count.Add(1)
+		return nil
+	}, nil, done)
+
+	// First trigger — fires immediately
+	trigger <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
+	if c := count.Load(); c != 1 {
+		t.Fatalf("expected 1 publish after first trigger, got %d", c)
+	}
+
+	// Second trigger — should be debounced
+	trigger <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
+	if c := count.Load(); c != 1 {
+		t.Fatalf("expected second trigger to be debounced (still 1), got %d", c)
+	}
+
+	// Wait for debounce to fire
+	time.Sleep(300 * time.Millisecond)
+	if c := count.Load(); c != 2 {
+		t.Fatalf("expected 2 publishes after debounce, got %d", c)
+	}
+	close(done)
+}
 
 func TestDebounce_CoalescesRapidEvents(t *testing.T) {
 	var count atomic.Int32
@@ -67,8 +119,12 @@ func TestDebounce_CoalescesRapidEvents(t *testing.T) {
 		return nil
 	}, nil, done)
 
-	// Send 5 events in rapid succession
-	for range 5 {
+	// First trigger fires immediately
+	trigger <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
+
+	// Send 4 more events in rapid succession — these should coalesce into 1 debounced publish
+	for range 4 {
 		trigger <- struct{}{}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -77,8 +133,9 @@ func TestDebounce_CoalescesRapidEvents(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	close(done)
 
-	if c := count.Load(); c != 1 {
-		t.Fatalf("expected 1 publish cycle, got %d", c)
+	// 1 immediate + 1 debounced = 2 total (not 5)
+	if c := count.Load(); c != 2 {
+		t.Fatalf("expected 2 publish cycles (1 immediate + 1 debounced), got %d", c)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove explicit `publishCycle()` call from `runLeader()` — was causing a second publish cycle on every pod startup
- Make `debounceLoop` fire immediately on first trigger (zero-duration timer), then debounce normally
- Add tests for first-trigger-immediate and subsequent-trigger-debounced behavior

## Context
Every pod startup produced two back-to-back publish cycles in the logs: one explicit call in `runLeader`, then a debounced one triggered by the informer's initial List. Idempotent but janky. Now there's a single publish path — first trigger is immediate, rest are debounced.

## Test plan
- [x] `go test -race ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] Manual: run watcher and confirm logs show exactly one "running publish cycle" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)