### PR TITLE
chore(renovate): add gomodTidy postUpdateOptions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
     'helpers:pinGitHubActionDigests',
   ],
   platformAutomerge: true,
+  postUpdateOptions: ['gomodTidy'],
   packageRules: [
     {
       description: 'Automerge minor/patch GitHub Actions updates',


### PR DESCRIPTION
## Summary
- Adds `postUpdateOptions: ['gomodTidy']` to `.github/renovate.json5`
- Ensures Renovate runs `go mod tidy` after every Go module update, keeping `go.sum` in sync automatically
- Fixes recurring CI failure where `go.sum` is stale after Renovate bumps (e.g. PR #43)

## Test plan
- [ ] CI passes (renovate config validator will validate the updated config)
- [ ] After merge, check the rebase box on PR #43 — Renovate will rebase and include a tidy'd `go.sum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)