### PR TITLE
fix(chart): disable CRDPublisherNoPublish alert by default

### DIFF
--- a/charts/crd-schema-publisher/templates/prometheusrule.yaml
+++ b/charts/crd-schema-publisher/templates/prometheusrule.yaml
@@ -23,6 +23,7 @@ spec:
               The crd-schema-publisher watcher loop has not sent a heartbeat
               in over {{ .Values.metrics.prometheusRule.rules.watchdogStaleSeconds }} seconds.
               This indicates the process may be stuck or crashed.
+        {{- if gt (int .Values.metrics.prometheusRule.rules.noPublishSeconds) 0 }}
         - alert: CRDPublisherNoSuccessfulPublish
           expr: >-
             (crdpublisher_leader == 1)
@@ -36,6 +37,7 @@ spec:
               The leader pod has not completed a successful publish cycle
               in over {{ .Values.metrics.prometheusRule.rules.noPublishSeconds }} seconds.
               Check logs for errors.
+        {{- end }}
         - alert: CRDPublisherErrorSpike
           expr: increase(crdpublisher_publish_cycles_total{result="error"}[1h]) > {{ .Values.metrics.prometheusRule.rules.errorSpikeThreshold }}
           for: {{ .Values.metrics.prometheusRule.rules.errorSpikeFor }}

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -223,8 +223,8 @@ metrics:
       watchdogStaleSeconds: 120
       # -- Duration before watchdog stale alert fires
       watchdogStaleFor: 5m
-      # -- No successful publish threshold in seconds
-      noPublishSeconds: 86400
+      # -- No successful publish threshold in seconds (0 = disabled)
+      noPublishSeconds: 0
       # -- Duration before no-publish alert fires
       noPublishFor: 1h
       # -- Error spike threshold (errors per hour)


### PR DESCRIPTION
## Summary
- Defaults `noPublishSeconds` to `0` (disabled) in `values.yaml`
- Wraps the `CRDPublisherNoSuccessfulPublish` alert in a `{{- if gt (int ...) 0 }}` guard in `prometheusrule.yaml`

CRD updates are event-driven, not scheduled — a fixed time threshold is arbitrary and produces noise in quiet clusters where CRDs simply haven't changed. The watchdog and error spike alerts already cover the real failure modes (process stuck/crashed, publish attempts failing).

Users who want this alert can opt in by setting `metrics.prometheusRule.rules.noPublishSeconds` to a nonzero value.

## Test plan
- [x] `helm template` renders PrometheusRule without `CRDPublisherNoSuccessfulPublish` at default values
- [x] Setting `noPublishSeconds: 86400` renders the alert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)