### PR TITLE
feat: add BASE_PATH env var for subpath deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ go run ./cmd/ preview
 | `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
+| `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages) |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address (preview mode) |
 
 ### Key Design Decisions

--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ All configuration is via environment variables. Variables marked *(watch)* apply
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address for preview server (preview mode) |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
+| `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`) |
+
+### Subpath Deployments (GitHub Pages)
+
+When hosting schemas at a URL subpath (e.g., `https://user.github.io/iac/`), set `BASE_PATH` to the subpath:
+
+```bash
+BASE_PATH=/iac go run ./cmd/ extract
+```
+
+Or in the Helm chart:
+
+```yaml
+config:
+  basePath: "/iac"
+```
+
+All generated HTML links will include the base path prefix. The preview server also respects `BASE_PATH`, mounting content at the subpath for local testing:
+
+```bash
+BASE_PATH=/iac go run ./cmd/ preview
+# → http://127.0.0.1:8989/iac/
+```
 
 ### Monitoring
 

--- a/charts/crd-schema-publisher/templates/_helpers.tpl
+++ b/charts/crd-schema-publisher/templates/_helpers.tpl
@@ -108,6 +108,10 @@ Secret refs + config vars that apply to all modes.
 - name: SKIP_RENDER
   value: {{ .Values.config.skipRender | quote }}
 {{- end }}
+{{- if .Values.config.basePath }}
+- name: BASE_PATH
+  value: {{ .Values.config.basePath | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -95,6 +95,10 @@
             "boolean"
           ],
           "description": "Set to true to skip HTML schema page rendering"
+        },
+        "basePath": {
+          "type": "string",
+          "description": "URL path prefix for subpath deployments (e.g., /iac)"
         }
       }
     },

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -38,6 +38,8 @@ config:
   leaseName: crd-schema-publisher
   # -- Set to "true" to skip HTML schema page rendering
   skipRender: ""
+  # -- URL path prefix for subpath deployments (e.g., /iac for GitHub Pages at user.github.io/iac/)
+  basePath: ""
 
 # ---------------------------------------------------------------------------
 # Secrets — configure exactly one of the two options below

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -84,6 +85,17 @@ func requireEnv(key string) (string, error) {
 		return "", fmt.Errorf("required environment variable %s is not set", key)
 	}
 	return v, nil
+}
+
+func normalizeBasePath(s string) string {
+	s = strings.TrimRight(s, "/")
+	if s == "" {
+		return ""
+	}
+	if !strings.HasPrefix(s, "/") {
+		s = "/" + s
+	}
+	return s
 }
 
 func runExtract() error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,6 +100,7 @@ func normalizeBasePath(s string) string {
 
 func runExtract() error {
 	outputDir := getEnv("OUTPUT_DIR", "/output")
+	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
 	kubeContext := os.Getenv("KUBECTL_CONTEXT")
 
 	slog.Info("building kubernetes client")
@@ -128,13 +129,13 @@ func runExtract() error {
 
 	if os.Getenv("SKIP_RENDER") != "true" {
 		slog.Info("rendering schema pages")
-		if err := renderer.RenderAll(outputDir); err != nil {
+		if err := renderer.RenderAll(outputDir, basePath); err != nil {
 			return fmt.Errorf("rendering schemas: %w", err)
 		}
 	}
 
 	slog.Info("generating index")
-	if err := index.Generate(outputDir); err != nil {
+	if err := index.Generate(outputDir, basePath); err != nil {
 		return fmt.Errorf("generating index: %w", err)
 	}
 
@@ -166,6 +167,7 @@ func runUpload() error {
 
 func runWatch() error {
 	outputDir := getEnv("OUTPUT_DIR", "/output")
+	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
 	kubeContext := os.Getenv("KUBECTL_CONTEXT")
 
 	podName, err := requireEnv("POD_NAME")
@@ -217,6 +219,7 @@ func runWatch() error {
 		Client:     client,
 		KubeConfig: cfg,
 		OutputDir:  outputDir,
+		BasePath:   basePath,
 		Publisher:  pub,
 		Debounce:   time.Duration(debounceSeconds) * time.Second,
 		Namespace:  podNamespace,
@@ -228,6 +231,7 @@ func runWatch() error {
 
 func runPreview() error {
 	dir := getEnv("OUTPUT_DIR", "")
+	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
 	isTempDir := false
 	if dir == "" {
 		var err error
@@ -247,7 +251,7 @@ func runPreview() error {
 
 	if os.Getenv("SKIP_RENDER") != "true" {
 		slog.Info("rendering schema pages")
-		if err := renderer.RenderAll(dir); err != nil {
+		if err := renderer.RenderAll(dir, basePath); err != nil {
 			if isTempDir {
 				_ = os.RemoveAll(dir)
 			}
@@ -256,7 +260,7 @@ func runPreview() error {
 	}
 
 	slog.Info("generating index")
-	if err := index.Generate(dir); err != nil {
+	if err := index.Generate(dir, basePath); err != nil {
 		if isTempDir {
 			_ = os.RemoveAll(dir)
 		}
@@ -264,7 +268,18 @@ func runPreview() error {
 	}
 
 	addr := getEnv("PREVIEW_ADDR", "127.0.0.1:8989")
-	srv := &http.Server{Addr: addr, Handler: http.FileServer(http.Dir(dir)), ReadHeaderTimeout: 10 * time.Second}
+	var handler http.Handler
+	if basePath != "" {
+		mux := http.NewServeMux()
+		mux.Handle(basePath+"/", http.StripPrefix(basePath, http.FileServer(http.Dir(dir))))
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, basePath+"/", http.StatusFound)
+		})
+		handler = mux
+	} else {
+		handler = http.FileServer(http.Dir(dir))
+	}
+	srv := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
@@ -276,7 +291,11 @@ func runPreview() error {
 		_ = srv.Shutdown(shutdownCtx)
 	}()
 
-	slog.Info("serving preview", "addr", addr)
+	if basePath != "" {
+		slog.Info("serving preview", "addr", addr, "url", "http://"+addr+basePath+"/")
+	} else {
+		slog.Info("serving preview", "addr", addr)
+	}
 	err := srv.ListenAndServe()
 	if isTempDir {
 		_ = os.RemoveAll(dir)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -5,6 +5,29 @@ import (
 	"testing"
 )
 
+func TestNormalizeBasePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"normal", "/iac", "/iac"},
+		{"trailing slash", "/iac/", "/iac"},
+		{"no leading slash", "iac", "/iac"},
+		{"both issues", "iac/", "/iac"},
+		{"just slash", "/", ""},
+		{"multi-segment", "/docs/schemas", "/docs/schemas"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeBasePath(tt.input); got != tt.expected {
+				t.Errorf("normalizeBasePath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestInitLogger_JSONForRun(t *testing.T) {
 	orig := slog.Default()
 	defer slog.SetDefault(orig)

--- a/index/index.go
+++ b/index/index.go
@@ -28,6 +28,7 @@ type indexData struct {
 	GroupCount int
 	TotalCount int
 	UpdatedAt  string
+	BasePath   string
 }
 
 const faviconSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
@@ -64,7 +65,7 @@ var indexTemplate = `<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Kubernetes CRD Schemas</title>
-<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/svg+xml" href="{{.BasePath}}/favicon.svg">
 <style>` + theme.CSSVars + theme.CSSBase + `
   header { margin-bottom: 2rem; }
   .title-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.25rem; }
@@ -247,7 +248,7 @@ metadata:
 <details class="group" data-group="{{.Name}}">
 <summary><span class="group-name">{{.Name}}</span> <span class="badge">{{len .Schemas}}</span></summary>
 <div class="schemas">
-{{range .Schemas}}<a href="/{{.HTMLPath}}" data-schema="{{.Name}}" data-url="/{{.Path}}">{{.Name}}<span class="copy-hint">copy URL</span></a>
+{{range .Schemas}}<a href="{{$.BasePath}}/{{.HTMLPath}}" data-schema="{{.Name}}" data-url="{{$.BasePath}}/{{.Path}}">{{.Name}}<span class="copy-hint">copy URL</span></a>
 {{end}}</div>
 </details>
 {{end}}
@@ -434,7 +435,7 @@ metadata:
 </body>
 </html>`
 
-func Generate(outputDir string) error {
+func Generate(outputDir, basePath string) error {
 	groups := map[string][]schemaEntry{}
 
 	entries, err := os.ReadDir(outputDir)
@@ -499,6 +500,7 @@ func Generate(outputDir string) error {
 		GroupCount: len(sortedGroups),
 		TotalCount: totalCount,
 		UpdatedAt:  time.Now().UTC().Format("2006-01-02 15:04 UTC"),
+		BasePath:   basePath,
 	}); err != nil {
 		return err
 	}

--- a/index/index.go
+++ b/index/index.go
@@ -180,7 +180,7 @@ var indexTemplate = `<!DOCTYPE html>
 </style>
 ` + theme.HeadScript + `
 </head>
-<body>
+<body data-base-path="{{.BasePath}}">
 ` + theme.FlareDiv + `
 <header>
   <div class="title-row">
@@ -387,7 +387,8 @@ metadata:
   });
 
   document.querySelectorAll('.usage-content code').forEach(function(el){
-    el.textContent = el.textContent.replace(/https:\/\/YOUR_DOMAIN/g, location.origin);
+    var base = document.body.dataset.basePath || '';
+    el.textContent = el.textContent.replace(/https:\/\/YOUR_DOMAIN/g, location.origin + base);
   });
 
   // Save view state before navigating to a schema page

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -16,7 +16,7 @@ func TestGenerate_CreatesIndexHTML(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "monitoring.coreos.com"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "monitoring.coreos.com", "servicemonitor_v1.json"), []byte(`{}`), 0o644)
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestGenerate_SkipsMasterStandalone(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "master-standalone"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "master-standalone", "example.io-test-stable-v1.json"), []byte(`{}`), 0o644)
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestGenerate_ManySchemasFewGroups(t *testing.T) {
 		_ = os.WriteFile(filepath.Join(tmpDir, "flux.io", s), []byte(`{}`), 0o644)
 	}
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestGenerate_ManySchemasFewGroups(t *testing.T) {
 func TestGenerate_EmptyOutputDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestGenerate_CreatesFavicon(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "test_v1.json"), []byte(`{}`), 0o644)
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestGenerate_LinksToHTMLWhenPresent(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{}`), 0o644)
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.html"), []byte(`<html></html>`), 0o644)
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestGenerate_FallsBackToJSONWhenNoHTML(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{}`), 0o644)
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestGenerate_SkipsNonJsonFiles(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "README.md"), []byte(`# hello`), 0o644)
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", ".gitkeep"), []byte(``), 0o644)
 
-	err := Generate(tmpDir)
+	err := Generate(tmpDir, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,5 +222,55 @@ func TestGenerate_SkipsNonJsonFiles(t *testing.T) {
 	}
 	if !strings.Contains(html, ">1</strong> schemas") {
 		t.Error("should count only JSON files")
+	}
+}
+
+func TestGenerate_BasePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "cert-manager.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "cert-manager.io", "certificate_v1.json"), []byte(`{}`), 0o644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "cert-manager.io", "certificate_v1.html"), []byte(`<html></html>`), 0o644)
+
+	err := Generate(tmpDir, "/iac")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "index.html"))
+	html := string(data)
+
+	checks := []struct {
+		substr string
+		desc   string
+	}{
+		{`href="/iac/favicon.svg"`, "favicon with base path"},
+		{`href="/iac/cert-manager.io/certificate_v1.html"`, "schema link with base path"},
+		{`data-url="/iac/cert-manager.io/certificate_v1.json"`, "data-url with base path"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(html, c.substr) {
+			t.Errorf("index should contain %s (looked for %q)", c.desc, c.substr)
+		}
+	}
+}
+
+func TestGenerate_EmptyBasePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{}`), 0o644)
+
+	err := Generate(tmpDir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "index.html"))
+	html := string(data)
+
+	if !strings.Contains(html, `href="/favicon.svg"`) {
+		t.Error("empty base path should produce root-relative favicon")
+	}
+	if !strings.Contains(html, `href="/example.io/thing_v1.json"`) {
+		t.Error("empty base path should produce root-relative schema links")
 	}
 }

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -246,6 +246,8 @@ func TestGenerate_BasePath(t *testing.T) {
 		{`href="/iac/favicon.svg"`, "favicon with base path"},
 		{`href="/iac/cert-manager.io/certificate_v1.html"`, "schema link with base path"},
 		{`data-url="/iac/cert-manager.io/certificate_v1.json"`, "data-url with base path"},
+		{`data-base-path="/iac"`, "body data-base-path attribute"},
+		{`document.body.dataset.basePath`, "usage example URL includes base path via data attr"},
 	}
 	for _, c := range checks {
 		if !strings.Contains(html, c.substr) {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -151,11 +151,12 @@ type schemaPageData struct {
 	Group    string
 	Version  string
 	JSONPath string
+	BasePath string
 	Schema   *SchemaNode
 }
 
 // renderSchemaFile reads a JSON schema file and writes a sibling .html file.
-func renderSchemaFile(tmpl *template.Template, jsonPath, group, filename string) error {
+func renderSchemaFile(tmpl *template.Template, jsonPath, group, filename, basePath string) error {
 	data, err := os.ReadFile(jsonPath)
 	if err != nil {
 		return fmt.Errorf("reading schema %s: %w", jsonPath, err)
@@ -178,7 +179,8 @@ func renderSchemaFile(tmpl *template.Template, jsonPath, group, filename string)
 		Kind:     kind,
 		Group:    group,
 		Version:  version,
-		JSONPath: "/" + group + "/" + filename,
+		JSONPath: basePath + "/" + group + "/" + filename,
+		BasePath: basePath,
 		Schema:   &schema,
 	}
 
@@ -234,7 +236,7 @@ func collectRenderJobs(outputDir string) ([]renderJob, error) {
 
 // RenderAll walks the output directory and generates an HTML page for each JSON schema.
 // Skips the master-standalone directory and non-JSON files.
-func RenderAll(outputDir string) error {
+func RenderAll(outputDir, basePath string) error {
 	funcMap := template.FuncMap{
 		"childNode": func(n *SchemaNode) *SchemaNode {
 			if len(n.Properties) > 0 {
@@ -270,7 +272,7 @@ func RenderAll(outputDir string) error {
 		go func(j renderJob) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if err := renderSchemaFile(tmpl, j.jsonPath, j.groupName, j.fileName); err != nil {
+			if err := renderSchemaFile(tmpl, j.jsonPath, j.groupName, j.fileName, basePath); err != nil {
 				errs <- fmt.Errorf("rendering %s/%s: %w", j.groupName, j.fileName, err)
 			}
 		}(job)
@@ -290,7 +292,7 @@ var schemaTemplate = `<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{.Kind}} {{.Version}} — {{.Group}}</title>
-<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/svg+xml" href="{{.BasePath}}/favicon.svg">
 <style>` + theme.CSSVars + theme.CSSBase + `
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
@@ -381,10 +383,10 @@ var schemaTemplate = `<!DOCTYPE html>
 </style>
 ` + theme.HeadScript + `
 </head>
-<body>
+<body data-base-path="{{.BasePath}}">
 ` + theme.FlareDiv + `
 <div class="nav-row">
-  <a href="/" class="back-link">← Back to index <kbd>Esc</kbd></a>
+  <a href="{{.BasePath}}/" class="back-link">← Back to index <kbd>Esc</kbd></a>
   ` + theme.ThemeToggleButton + `
 </div>
 <div class="meta-cards">
@@ -458,7 +460,7 @@ metadata:
       if (document.activeElement && document.activeElement !== document.body) {
         document.activeElement.blur();
       }
-      location.href = '/';
+      location.href = document.body.dataset.basePath + '/';
     }
   });
   document.getElementById('copy-url').addEventListener('click', function(){

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -240,7 +240,7 @@ func TestRenderSchema_BasicOutput(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "myresource_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "example.io", "myresource_v1.json"), "example.io", "myresource_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "example.io", "myresource_v1.json"), "example.io", "myresource_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestRenderSchema_LeafVsExpandable(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestRenderSchema_ArrayTypes(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestRenderSchema_IntOrString(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -409,7 +409,7 @@ func TestRenderSchema_EnumValues(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestRenderSchema_MinimalSchema(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "empty_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "empty_v1.json"), "test.io", "empty_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "empty_v1.json"), "test.io", "empty_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestRenderAll_CreatesHTMLFiles(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(tmpDir, "master-standalone", "test.json"),
 		[]byte(`{"type":"object"}`), 0o644)
 
-	err := RenderAll(tmpDir)
+	err := RenderAll(tmpDir, "")
 	if err != nil {
 		t.Fatalf("RenderAll error: %v", err)
 	}
@@ -491,7 +491,7 @@ func TestRenderAll_SkipsNonJsonFiles(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(`{"type":"object"}`), 0o644)
 	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "README.md"), []byte(`# hello`), 0o644)
 
-	err := RenderAll(tmpDir)
+	err := RenderAll(tmpDir, "")
 	if err != nil {
 		t.Fatalf("RenderAll error: %v", err)
 	}
@@ -507,9 +507,80 @@ func TestRenderAll_SkipsNonJsonFiles(t *testing.T) {
 func TestRenderAll_EmptyDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	err := RenderAll(tmpDir)
+	err := RenderAll(tmpDir, "")
 	if err != nil {
 		t.Fatalf("RenderAll should handle empty dir: %v", err)
+	}
+}
+
+func TestRenderSchema_BasePath(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := RenderAll(tmpDir, "/iac")
+	if err != nil {
+		t.Fatalf("RenderAll error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "example.io", "thing_v1.html"))
+	if err != nil {
+		t.Fatalf("HTML file not created: %v", err)
+	}
+
+	html := string(data)
+	checks := []struct {
+		substr string
+		desc   string
+	}{
+		{`href="/iac/favicon.svg"`, "favicon with base path"},
+		{`href="/iac/"`, "back link with base path"},
+		{`href="/iac/example.io/thing_v1.json"`, "raw schema link with base path"},
+		{`data-url="/iac/example.io/thing_v1.json"`, "copy URL data attr with base path"},
+		{`data-base-path="/iac"`, "base path data attribute on body"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(html, c.substr) {
+			t.Errorf("HTML should contain %s (looked for %q)", c.desc, c.substr)
+		}
+	}
+}
+
+func TestRenderSchema_EmptyBasePath(t *testing.T) {
+	schema := `{"type": "object", "properties": {"name": {"type": "string"}}}`
+
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "example.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "example.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := RenderAll(tmpDir, "")
+	if err != nil {
+		t.Fatalf("RenderAll error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "example.io", "thing_v1.html"))
+	html := string(data)
+
+	checks := []struct {
+		substr string
+		desc   string
+	}{
+		{`href="/favicon.svg"`, "favicon at root"},
+		{`href="/"`, "back link at root"},
+		{`href="/example.io/thing_v1.json"`, "raw schema link at root"},
+		{`data-base-path=""`, "empty base path data attribute on body"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(html, c.substr) {
+			t.Errorf("HTML should contain %s (looked for %q)", c.desc, c.substr)
+		}
 	}
 }
 
@@ -541,7 +612,7 @@ func TestRenderSchema_DeepNesting(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
 	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "deep_v1.json"), []byte(schema), 0o644)
 
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "deep_v1.json"), "test.io", "deep_v1.json")
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "deep_v1.json"), "test.io", "deep_v1.json", "")
 	if err != nil {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -34,6 +34,7 @@ type Config struct {
 	Client     *apiextensionsclient.Clientset
 	KubeConfig *rest.Config
 	OutputDir  string
+	BasePath   string
 	Publisher  *publisher.Publisher // nil = extract-only
 	Debounce   time.Duration
 	Namespace  string
@@ -282,14 +283,14 @@ func publishCycle(cfg Config) (retErr error) {
 	slog.Info("wrote schemas", "count", count)
 
 	if os.Getenv("SKIP_RENDER") != "true" {
-		if err := renderer.RenderAll(cfg.OutputDir); err != nil {
+		if err := renderer.RenderAll(cfg.OutputDir, cfg.BasePath); err != nil {
 			return fmt.Errorf("rendering schemas: %w", err)
 		}
 		slog.Info("rendered schema pages")
 	}
 
 	// Generate index
-	if err := index.Generate(cfg.OutputDir); err != nil {
+	if err := index.Generate(cfg.OutputDir, cfg.BasePath); err != nil {
 		return fmt.Errorf("generating index: %w", err)
 	}
 	slog.Info("generated index")


### PR DESCRIPTION
## Summary

- Adds `BASE_PATH` env var for deploying generated HTML to a URL subpath (e.g., GitHub Pages at `user.github.io/iac/`)
- All generated HTML links are prefixed with the base path at generation time — no post-processing needed
- Preview server mounts content at the base path with root redirect for local testing
- Helm chart exposes `config.basePath` value wired to `BASE_PATH` env var
- Fully backward compatible — empty `BASE_PATH` preserves current root behavior

Closes user request from @chkpwd who needed subpath support for GitHub Pages.

## ⚠️ Migration note

If you are currently using a `sed`-based workaround to rewrite HTML paths (as described in the original request), **remove the sed block** when upgrading. The binary now handles path prefixing natively, and the sed would double-prefix URLs (e.g., `/iac/iac/favicon.svg`).

## Changes

- `cmd/main.go` — `normalizeBasePath` validation, `BASE_PATH` threaded through extract/watch/preview
- `renderer/renderer.go` — `RenderAll` and `renderSchemaFile` accept `basePath`, template paths updated
- `index/index.go` — `Generate` accepts `basePath`, template paths use `{{$.BasePath}}`, usage example URLs include base path
- `watcher/watcher.go` — `Config.BasePath` threaded to renderer/index
- Helm chart — `config.basePath` in values/schema, `BASE_PATH` in `commonEnvVars`
- Documentation — env var tables and GitHub Pages usage section in README

## Test plan

- [x] `go test ./... -count=1` — all 9 packages pass
- [x] `go vet ./...` + `golangci-lint run` — 0 issues
- [x] `helm lint charts/crd-schema-publisher/` — passes
- [x] `BASE_PATH=/iac go run ./cmd/ preview` — root redirects to `/iac/`, all links prefixed, usage examples show correct URLs
- [x] `go run ./cmd/ preview` — backward compatible, root-relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)