### PR TITLE
docs: add BASE_PATH guidance to git-push sidecar example

### DIFF
--- a/examples/git-push/values.yaml
+++ b/examples/git-push/values.yaml
@@ -13,11 +13,22 @@
 # site. The sidecar handles both fresh repos (init + first push) and existing
 # repos (clone + incremental updates).
 #
+# If your GitHub Pages site serves from a subpath (e.g., user.github.io/repo/),
+# set config.basePath to match:
+#
+#   config:
+#     basePath: "/repo"
+#
+# This ensures all generated HTML links include the subpath prefix. Without it,
+# links resolve against the host root and break. Cloudflare Pages and other
+# hosts that serve from root do not need this.
+#
 # This pattern works with any git hosting (GitLab, Gitea, Bitbucket) by
 # adjusting the remote URL format in the sidecar command.
 #
 # Customize:
 #   - Secret credentials (github-token, github-repo)
+#   - config.basePath: set to your repo subpath for GitHub Pages (e.g., /repo)
 #   - GIT_BRANCH: change from gh-pages if needed
 #   - sync interval: adjust the sleep duration in the sidecar command
 #


### PR DESCRIPTION
## Summary

- Adds `config.basePath` documentation to the git-push sidecar example
- Explains when it's needed (GitHub Pages project sites) vs not (Cloudflare Pages, custom domains)
- Adds `config.basePath` to the Customize checklist

Follow-up to #49 — the git-push example is the primary use case for `BASE_PATH` and was missing guidance on when to set it.

## Test plan

- [x] E2E verified: deployed to cluster with `BASE_PATH=/crd-schemas-test`, pushed to `sholdee/crd-schemas-test` gh-pages, confirmed all links resolve correctly at `sholdee.github.io/crd-schemas-test/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)