### PR TITLE
fix: handle CRD fields named "properties" in schema converter

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -11,7 +11,20 @@ func AdditionalProperties(data map[string]interface{}, skip bool) map[string]int
 			data["additionalProperties"] = false
 		}
 	}
-	for _, v := range data {
+	for k, v := range data {
+		if k == "properties" {
+			// The "properties" keyword maps property names to sub-schemas.
+			// Recurse into each sub-schema individually — not the map itself,
+			// which would corrupt schemas with a property named "properties".
+			if props, ok := v.(map[string]interface{}); ok {
+				for _, pv := range props {
+					if propSchema, ok := pv.(map[string]interface{}); ok {
+						AdditionalProperties(propSchema, false)
+					}
+				}
+			}
+			continue
+		}
 		if nested, ok := v.(map[string]interface{}); ok {
 			AdditionalProperties(nested, false)
 		}

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -92,6 +92,60 @@ func TestAdditionalProperties_SkipsRootWhenFlagged(t *testing.T) {
 	}
 }
 
+func TestAdditionalProperties_DoesNotCorruptPropertiesMap(t *testing.T) {
+	// Regression: when a CRD has a field literally named "properties",
+	// the converter would enter the properties map, see the "properties" key,
+	// and inject "additionalProperties": false into the map — corrupting it
+	// with a boolean entry that isn't a valid schema.
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"output": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"properties": map[string]interface{}{
+						"type":        "object",
+						"description": "Output properties map",
+						"additionalProperties": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"value": map[string]interface{}{"type": "string"},
+							},
+						},
+					},
+					"required": map[string]interface{}{
+						"type":  "array",
+						"items": map[string]interface{}{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+	result := AdditionalProperties(schema, true)
+
+	// Navigate to output's properties map
+	outputSchema := propField(t, result, "output")
+	outputProps, ok := outputSchema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected output.properties to be a map")
+	}
+
+	// The properties map should only have "properties" and "required" — NOT "additionalProperties"
+	if _, found := outputProps["additionalProperties"]; found {
+		t.Fatal("additionalProperties was incorrectly injected into the properties map; " +
+			"a property named 'properties' caused the converter to treat the map as a schema object")
+	}
+
+	// The "properties" field's own additionalProperties (the schema) should still be intact
+	propsField, ok := outputProps["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected 'properties' property to be a map")
+	}
+	if _, ok := propsField["additionalProperties"].(map[string]interface{}); !ok {
+		t.Fatal("the additionalProperties schema on the 'properties' field should be preserved")
+	}
+}
+
 func TestReplaceIntOrString_ReplacesFormat(t *testing.T) {
 	schema := map[string]interface{}{
 		"type": "object",

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -444,6 +444,148 @@ func TestWriteSchemas_GoldenE2E(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool { return &b }
+
+func edgeCaseCRD() apiextensionsv1.CustomResourceDefinition {
+	return apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "virtualservices.testing.example.io"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "testing.example.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "VirtualService"},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: "v1",
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:     "object",
+						Required: []string{"spec"},
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec": {
+								Type:     "object",
+								Required: []string{"output"},
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"output": {
+										Type:     "object",
+										Required: []string{"properties"},
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"properties": {
+												Type:        "object",
+												Description: "Output properties map",
+												AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+													Schema: &apiextensionsv1.JSONSchemaProps{
+														Type:     "object",
+														Required: []string{"type"},
+														Properties: map[string]apiextensionsv1.JSONSchemaProps{
+															"type":        {Type: "string"},
+															"value":       {Type: "string"},
+															"description": {Type: "string"},
+															"default": {
+																// Only XPreserveUnknownFields — minimal schema passes through untouched
+																XPreserveUnknownFields: boolPtr(true),
+															},
+															"properties": {
+																Type:                   "object",
+																Description:            "Nested properties for object types",
+																XPreserveUnknownFields: boolPtr(true),
+															},
+														},
+													},
+												},
+											},
+											"required": {
+												Type: "array",
+												Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+													Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+												},
+											},
+										},
+									},
+									"match": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"type":     {Type: "string", Description: "Match type"},
+											"items":    {Type: "array", Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}}},
+											"required": {Type: "boolean", Description: "Whether match is required"},
+										},
+									},
+									"options": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"timeout": {Type: "string"},
+										},
+										AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{Allows: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+}
+
+const goldenEdgeCaseFixturePath = "testdata/golden_edgecase_v1.json"
+
+func TestWriteSchemas_GoldenEdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	crds := []apiextensionsv1.CustomResourceDefinition{edgeCaseCRD()}
+
+	count, err := WriteSchemas(crds, tmpDir)
+	if err != nil {
+		t.Fatalf("WriteSchemas error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 schema, got %d", count)
+	}
+
+	// Read actual output
+	actualPath := filepath.Join(tmpDir, "testing.example.io", "virtualservice_v1.json")
+	actual, err := os.ReadFile(actualPath)
+	if err != nil {
+		t.Fatalf("reading output schema: %v", err)
+	}
+
+	// Normalize: re-marshal to consistent formatting
+	var actualObj interface{}
+	if err := json.Unmarshal(actual, &actualObj); err != nil {
+		t.Fatalf("unmarshaling actual: %v", err)
+	}
+	actualNorm, _ := json.MarshalIndent(actualObj, "", "  ")
+
+	// Read or generate golden fixture
+	golden, err := os.ReadFile(goldenEdgeCaseFixturePath)
+	if err != nil {
+		// First run: generate the fixture
+		t.Logf("Golden fixture not found, generating: %s", goldenEdgeCaseFixturePath)
+		if err := os.WriteFile(goldenEdgeCaseFixturePath, append(actualNorm, '\n'), 0o644); err != nil {
+			t.Fatalf("writing golden fixture: %v", err)
+		}
+		t.Fatalf("Golden fixture generated at %s — verify it manually, then re-run", goldenEdgeCaseFixturePath)
+	}
+
+	// Normalize golden too
+	var goldenObj interface{}
+	if err := json.Unmarshal(golden, &goldenObj); err != nil {
+		t.Fatalf("unmarshaling golden fixture: %v", err)
+	}
+	goldenNorm, _ := json.MarshalIndent(goldenObj, "", "  ")
+
+	if string(actualNorm) != string(goldenNorm) {
+		t.Errorf("schema output does not match golden fixture %s\n\nTo update after an intentional change, delete the fixture and re-run.\n\ngot:\n%s\n\nwant:\n%s",
+			goldenEdgeCaseFixturePath, string(actualNorm), string(goldenNorm))
+	}
+
+	// Also verify master-standalone output exists and matches
+	standalonePath := filepath.Join(tmpDir, "master-standalone", "testing.example.io-virtualservice-stable-v1.json")
+	standalone, err := os.ReadFile(standalonePath)
+	if err != nil {
+		t.Fatalf("master-standalone file not found: %v", err)
+	}
+	if string(actual) != string(standalone) {
+		t.Error("master-standalone output differs from primary output — both should be identical")
+	}
+}
+
 func TestWriteSchemas_NullableOptionalFields(t *testing.T) {
 	schema := &apiextensionsv1.JSONSchemaProps{
 		Type: "object",

--- a/extractor/testdata/golden_edgecase_v1.json
+++ b/extractor/testdata/golden_edgecase_v1.json
@@ -1,0 +1,121 @@
+{
+  "properties": {
+    "spec": {
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "additionalProperties": false,
+          "properties": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "required": {
+              "description": "Whether match is required",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "type": {
+              "description": "Match type",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "options": {
+          "additionalProperties": true,
+          "properties": {
+            "timeout": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "output": {
+          "additionalProperties": false,
+          "properties": {
+            "properties": {
+              "additionalProperties": {
+                "additionalProperties": false,
+                "properties": {
+                  "default": {
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "properties": {
+                    "description": "Nested properties for object types",
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object"
+              },
+              "description": "Output properties map",
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "properties"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "output"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -36,6 +36,26 @@ type SchemaNode struct {
 	AdditionalProperties interface{}            `json:"additionalProperties,omitempty"`
 }
 
+// UnmarshalJSON handles both regular JSON Schema objects and boolean schemas
+// (true = accept any value, false = reject all values) which are valid in
+// JSON Schema but cannot be decoded into a struct by the default unmarshaler.
+func (n *SchemaNode) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && (data[0] == 't' || data[0] == 'f') {
+		// Boolean schema — treat as empty node (no type, no properties).
+		*n = SchemaNode{}
+		return nil
+	}
+
+	// Decode as a regular object using an alias to avoid infinite recursion.
+	type schemaAlias SchemaNode
+	var alias schemaAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*n = SchemaNode(alias)
+	return nil
+}
+
 // DisplayType returns a human-readable type string for the schema node.
 func (n *SchemaNode) DisplayType() string {
 	if len(n.OneOf) == 2 && n.Type == nil {

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -584,6 +584,85 @@ func TestRenderSchema_EmptyBasePath(t *testing.T) {
 	}
 }
 
+func TestRenderSchema_BooleanSchemaInProperties(t *testing.T) {
+	// JSON Schema allows boolean schemas (true/false) as property values.
+	// The renderer should handle these gracefully instead of crashing.
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"anything": true,
+			"nothing": false
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
+	if err != nil {
+		t.Fatalf("renderSchemaFile should handle boolean schemas: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "name") {
+		t.Error("should still render normal properties alongside boolean schemas")
+	}
+	if !strings.Contains(html, "anything") {
+		t.Error("should render boolean true schema property")
+	}
+	if !strings.Contains(html, "nothing") {
+		t.Error("should render boolean false schema property")
+	}
+}
+
+func TestRenderSchema_CompositionWithBooleanSchemas(t *testing.T) {
+	// JSON Schema allows boolean schemas (true/false) inside composition keywords
+	// (oneOf, anyOf, allOf). The renderer should handle these gracefully.
+	schema := `{
+		"type": "object",
+		"properties": {
+			"flexible": {
+				"oneOf": [{"type": "string"}, true]
+			},
+			"strict": {
+				"anyOf": [{"type": "integer"}, false]
+			},
+			"composed": {
+				"allOf": [{"type": "object", "properties": {"name": {"type": "string"}}}, true]
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
+	if err != nil {
+		t.Fatalf("renderSchemaFile should handle boolean schemas in composition keywords: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
+	html := string(data)
+
+	if !strings.Contains(html, "flexible") {
+		t.Error("should render the oneOf property with boolean schema")
+	}
+	if !strings.Contains(html, "strict") {
+		t.Error("should render the anyOf property with boolean schema")
+	}
+	if !strings.Contains(html, "composed") {
+		t.Error("should render the allOf property with boolean schema")
+	}
+	if !strings.Contains(html, "name") {
+		t.Error("should render nested property inside allOf composition")
+	}
+}
+
 func TestRenderSchema_DeepNesting(t *testing.T) {
 	schema := `{
 		"type": "object",


### PR DESCRIPTION
## Summary

- Fix `AdditionalProperties` converter to recurse into each property sub-schema individually instead of treating the `properties` map as a schema object — prevents corruption when a CRD has a field literally named "properties"
- Add `UnmarshalJSON` to `SchemaNode` as defense-in-depth for boolean schemas (`true`/`false`), which are valid in JSON Schema
- Add golden edge-case CRD test exercising property-name collisions with JSON Schema keywords, `additionalProperties`-as-schema, and `x-kubernetes-preserve-unknown-fields`

Closes #51

## Test plan

- [x] TDD verified: converter regression test fails without fix, passes with fix
- [x] TDD verified: renderer boolean schema test fails without UnmarshalJSON, passes with it
- [x] Original golden fixture (`golden_certificate_v1.json`) unchanged — no regression on existing schemas
- [x] New golden fixture (`golden_edgecase_v1.json`) freezes correct converter behavior for edge cases
- [x] Full extract + render against live cluster (166 CRDs / 189 schemas) succeeds, including the problematic toolhive CRD
- [x] `go test ./...`, `go vet ./...`, `golangci-lint run` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)