### PR TITLE
feat: expand CLI with offline conversion and release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,62 @@ jobs:
     needs: [guard]
     uses: ./.github/workflows/helm-lint.yml
 
+  binaries:
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      attestation-url: ${{ steps.attest.outputs.attestation-url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        env:
+          VERSION: ${{ needs.build.outputs.date-tag }}
+        run: |
+          for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            goos="${pair%/*}"
+            goarch="${pair#*/}"
+            CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" \
+              go build -ldflags="-s -w -X main.version=${VERSION}" -o "dist/crd-schema-publisher-${goos}-${goarch}" ./cmd/
+          done
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum crd-schema-publisher-* > checksums-sha256.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign checksum manifest
+        run: |
+          cosign sign-blob --yes \
+            --bundle dist/checksums-sha256.txt.sigstore.json \
+            dist/checksums-sha256.txt
+
+      - name: Attest binaries
+        id: attest
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: dist/checksums-sha256.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries
+          path: dist/
+          retention-days: 1
+
   build:
     needs: [test]
     runs-on: ubuntu-latest
@@ -180,7 +236,7 @@ jobs:
         run: cosign sign --yes "${REGISTRY}/sholdee/charts/crd-schema-publisher:${SEMVER}"
 
   release:
-    needs: [build, sign, helm-package]
+    needs: [build, sign, helm-package, binaries]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -190,12 +246,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binaries
+          path: dist/
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DATE_TAG: ${{ needs.build.outputs.date-tag }}
           FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ needs.build.outputs.digest }}
+          ATTESTATION_URL: ${{ needs.binaries.outputs.attestation-url }}
         run: |
           git tag "${DATE_TAG}"
           git push origin "${DATE_TAG}"
@@ -206,8 +269,11 @@ jobs:
 
           IMAGE_LINE="**Image:** \`${FULL_IMAGE}:${DATE_TAG}@${DIGEST}\`"
           CHART_LINE="**Chart:** \`oci://${REGISTRY}/sholdee/charts/crd-schema-publisher:${DATE_TAG#v}\`"
-          printf '%s\n\n---\n\n%s\n%s\n' "${NOTES}" "${IMAGE_LINE}" "${CHART_LINE}" \
+          CHECKSUM_LINE="**Checksums:** \`checksums-sha256.txt\` (Sigstore bundle: \`checksums-sha256.txt.sigstore.json\`)"
+          PROVENANCE_LINE="**Binary provenance:** ${ATTESTATION_URL}"
+          printf '%s\n\n---\n\n%s\n%s\n%s\n%s\n' "${NOTES}" "${IMAGE_LINE}" "${CHART_LINE}" "${CHECKSUM_LINE}" "${PROVENANCE_LINE}" \
             | gh release create "${DATE_TAG}" \
               --verify-tag \
               --title "${DATE_TAG}" \
-              --notes-file -
+              --notes-file - \
+              dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes
 
 ```text
 charts/         Helm chart (OCI-distributed via GHCR, cosign-signed)
-cmd/            Entrypoint and subcommand dispatch (run/extract/upload/watch/preview)
+cmd/            Entrypoint and subcommand dispatch (run/extract/convert/upload/watch/preview)
 converter/      OpenAPI v3 -> JSON Schema transforms (ported from openapi2jsonschema.py)
-extractor/      client-go CRD listing, schema extraction, file writing, config builder
+extractor/      client-go CRD listing, schema extraction, file writing, config builder, file/YAML parsing
 index/          HTML index generation (deepspace theme, client-side search, starfield/flare effects)
 publisher/      Cloudflare Pages direct upload API client + BLAKE3 hashing
 renderer/       HTML schema page renderer (collapsible property trees, type badges, constraints)
@@ -37,26 +37,37 @@ golangci-lint run
 # Enable pre-commit hook
 git config core.hooksPath .githooks
 
-# Cross-compile (matches CI targets)
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o crd-schema-publisher ./cmd/
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o crd-schema-publisher ./cmd/
+# Cross-compile release binaries locally (matches release workflow targets)
+for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+  GOOS="${pair%/*}" GOARCH="${pair#*/}"
+  CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
+    go build -ldflags="-s -w" -o "crd-schema-publisher-${GOOS}-${GOARCH}" ./cmd/
+done
+
+# Generate release-style checksums
+sha256sum crd-schema-publisher-* > checksums-sha256.txt
 
 # Local extract (requires kubeconfig)
 KUBECTL_CONTEXT=my-context OUTPUT_DIR=./output go run ./cmd/ extract
 
 # Preview index UI locally (no cluster needed)
 go run ./cmd/ preview
+
+# Local subcommands must use the package path so Go compiles all cmd/*.go files.
+# Single-file invocation is supported only for top-level help/version smoke checks.
+go run ./cmd/main.go --help
 ```
 
 ## Architecture
 
 ### Subcommands
 
-- `run` (default) — extract + upload
-- `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`
-- `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages
-- `watch` — long-lived process: informer watches CRDs, debounces events, runs extract+publish cycles. Leader election for multi-replica safety.
-- `preview` — generate sample data or copy the active site into an isolated temp generation and serve it on localhost. No cluster or credentials needed. Handles signal cleanup of temp directories.
+- `run` (default) — extract + upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`; the output root must already exist.
+- `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version` filters and CLI flags (`--output-dir`, `--context`, `--base-path`, `--skip-render`) that override env vars.
+- `convert` — convert CRD YAML files to JSON Schema without a cluster connection. Requires `--output-dir`. Reads from `--file` (comma-separated, `-` for stdin) and/or `--dir`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
+- `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`; the output root must already exist.
+- `watch` — long-lived process: informer watches CRDs, debounces events, runs extract+publish cycles. Leader election for multi-replica safety. Accepts `--output-dir`; the output root must already exist.
+- `preview` — generate sample data by default, or with explicit `--output-dir` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
 
 ### Configuration (env vars)
 
@@ -76,6 +87,23 @@ go run ./cmd/ preview
 | `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages) |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address (preview mode) |
 
+### CLI Flags
+
+`extract`, `convert`, `run`, `watch`, `upload`, and `preview` all support command-specific flags. `extract` requires `--output-dir` or `OUTPUT_DIR` and does not default to `/output`. `convert` requires `--output-dir` and does not read `OUTPUT_DIR`. For runtime-oriented commands (`run`, `watch`, `upload`), `--output-dir` overrides `OUTPUT_DIR` but must point at a pre-created directory. `preview` ignores ambient `OUTPUT_DIR` and only uses real extracted output when `--output-dir` is passed explicitly.
+
+| Flag | Subcommands | Default | Purpose |
+| --- | --- | --- | --- |
+| `--output-dir` | run, extract, convert, upload, watch, preview | `convert`: required flag; `extract`: `$OUTPUT_DIR` (required if unset); `run`/`upload`/`watch`: `$OUTPUT_DIR` or `/output`; `preview`: none | Output directory |
+| `--context` | extract | `$KUBECTL_CONTEXT` | Kubernetes context |
+| `--base-path` | extract, convert | `$BASE_PATH` | URL path prefix |
+| `--skip-render` | extract | `$SKIP_RENDER` | Skip HTML rendering |
+| `--file` | convert | — | CRD YAML file(s), comma-separated. `-` for stdin |
+| `--dir` | convert | — | Directory of CRD YAML files (non-recursive) |
+| `--render` | convert | `false` | Render HTML docs |
+| `--kind` | extract, convert | — | Filter by kind (comma-separated, case-insensitive) |
+| `--group` | extract, convert | — | Filter by group (comma-separated, case-insensitive) |
+| `--version` | extract, convert | — | Filter by version (comma-separated, case-insensitive) |
+
 ### Key Design Decisions
 
 - **No CGO.** Binary is statically linked. BLAKE3 uses `github.com/zeebo/blake3` (pure Go).
@@ -85,6 +113,7 @@ go run ./cmd/ preview
 - **Schema renderer** generates interactive HTML documentation pages (collapsible `<details>`/`<summary>` property trees, type/required badges, YAML boilerplate). Uses `html/template` with recursive `{{define "properties"}}` for nested schemas. Schema-page path search behavior lives in the extracted `theme/schema_search.js` asset, which `RenderAll` emits into the output root as `schema-search.js` and the page bootstrap loads at runtime. Enabled by default; disable with `SKIP_RENDER=true`.
 - **Theme package** (`theme/`) holds shared CSS, HTML fragments, small JS helpers used by both index and renderer templates, and emitted static assets such as `schema-search.js`. CSS custom properties are the union of both pages' needs. The deepspace theme (starfield, flare, light/dark toggle) is defined once here.
 - **Output format** builds immutable site generations under `OUTPUT_DIR/.generations/<generation>/` and atomically switches `OUTPUT_DIR/current` to the active generation. Each generation contains both directory formats: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility), plus rendered `.html` documentation pages, `index.html`, static assets, and an internal `_meta/kinds.json` manifest used to preserve exact CRD Kind casing for re-render/preview paths. Direct-volume consumers should read from `OUTPUT_DIR/current`, not the flat root. First-party Cloudflare, git, S3, and Caddy examples exclude `_meta/` from public output.
+- **Convert output cleanup** uses `_meta/convert-manifest.json` to remove only files generated by prior `convert` runs, then prunes empty generated directories. Files that existed before `convert` ran are preserved, even under generated directories. If the manifest exists but is corrupt, `convert` aborts instead of risking mixed stale-and-fresh output.
 - **Concurrency**: extractor uses 10 goroutines (buffered channel semaphore), publisher uses 3 concurrent upload workers, renderer uses 10 goroutines. These match the original tools' behavior.
 - **Watch mode uses first-trigger-immediate debounce.** The informer's initial List fires AddFunc for all existing CRDs, which signals the debounce loop. The first trigger fires immediately (zero delay), subsequent triggers are debounced. This produces exactly one publish cycle on startup — no explicit initial publish in runLeader.
 - **Watch mode uses full re-extract.** Simpler than incremental. Upload is already incremental via check-missing. Extraction of <200 CRDs is sub-second.
@@ -100,11 +129,14 @@ go run ./cmd/ preview
 
 | Dependency | Purpose |
 | --------- | ------- |
-| `k8s.io/client-go` | Kubernetes API access |
-| `k8s.io/apiextensions-apiserver` | CRD typed client |
 | `github.com/zeebo/blake3` | BLAKE3 hashing (pure Go) |
+| `gopkg.in/yaml.v3` | Streaming YAML document decoding for file/stdin conversion |
+| `k8s.io/apiextensions-apiserver` | CRD typed client and API types |
+| `k8s.io/apimachinery` | Shared Kubernetes API machinery used by clients and watchers |
+| `k8s.io/client-go` | Kubernetes API access, informer/watch plumbing, leader election |
+| `sigs.k8s.io/yaml` | YAML-to-Kubernetes-struct decoding for CRD conversion |
 
-No other external dependencies. Standard library for HTTP, JSON, HTML templates, MIME types.
+Everything else in `go.mod` is transitive. The project still leans heavily on the standard library for HTTP, JSON, HTML templates, MIME types, and the preview server.
 
 ## CI/CD
 
@@ -138,10 +170,11 @@ Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR
 | --- | --------- | ------- |
 | `test` | Always | Calls `test.yml` — re-runs all linting and Go tests as a safety net before building |
 | `helm-lint` | Always | Calls `helm-lint.yml` — re-runs all Helm validation before packaging |
+| `binaries` | After `test` and `build` pass | Cross-compiles static binaries for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, generates `checksums-sha256.txt`, signs the checksum manifest with cosign keyless blob signing, uploads `dist/` as artifacts for the `release` job, and publishes GitHub/Sigstore build provenance for the binaries via the attestations service. |
 | `build` | After `test` passes | Multi-arch Docker build (amd64 + arm64), pushes `vYYYY.MDD.HMMSS` + `latest` to GHCR. Verifies distroless base image digest with cosign before building. |
 | `sign` | After `build` | Cosign keyless signing via GitHub OIDC |
 | `helm-package` | After `helm-lint`, `build`, and `sign` | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
-| `release` | After `build`, `sign`, `helm-package` | Creates git tag, GitHub Release with auto-generated notes, image digest, and chart OCI reference. Note: tag push will fail if the tagged commit includes workflow file changes — create the tag manually in that case. |
+| `release` | After `build`, `sign`, `helm-package`, `binaries` | Creates git tag, GitHub Release with auto-generated notes, image digest, chart OCI reference, signed checksum manifest, binary provenance link, and standalone binaries. Note: tag push will fail if the tagged commit includes workflow file changes — create the tag manually in that case. |
 
 App image and Helm chart are always released together with the same CalVer version. Releases are decoupled from CI — trigger the release workflow when changes warrant a new version. The release workflow re-runs all tests before building as a safety net. A concurrency group prevents simultaneous releases from racing.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 
 # crd-schema-publisher — CRD docs and IDE validation, straight from the cluster
 
-Reads CRD JSON schemas directly from your Kubernetes API server and publishes a browsable documentation site with search and interactive schema pages. Runs as a Kubernetes-native controller with real-time CRD watching, or as a CronJob for scheduled extraction. Exports schemas for IDE validation (yaml-language-server) and CI linting (kubeconform). Cloudflare Pages is the built-in backend; S3, git repos, and local serving supported via sidecar.
+Extracts CRD OpenAPI schemas from your Kubernetes API server or YAML files, converts them to JSON Schema, and publishes a searchable documentation site with interactive schema pages.
 
-> **Direct-volume consumers:** the active site now lives at `OUTPUT_DIR/current`. This is a breaking change for sidecars or scripts that read the shared output volume directly. Cloudflare Pages users do not need to change anything.
+Run it as:
+
+- a Kubernetes-native controller for real-time CRD watching
+- a CronJob for scheduled extraction
+- a local CLI for extracting from a live cluster or converting YAML files
+
+Exports schemas for IDE validation with yaml-language-server and CI linting with kubeconform. Cloudflare Pages is built in; S3, git repos, and local serving are supported via sidecar.
+
+> **Upgrading direct-volume deployments:** the active site now lives at `OUTPUT_DIR/current`. Existing sidecars or scripts that read the shared output volume directly must be updated. Cloudflare Pages users do not need to change anything.
 
 **[Live demo →](https://kube-schemas.shold.io)**
 
@@ -23,6 +31,85 @@ Most CRD schema solutions rely on static catalogs — community-maintained repos
 - **No glue pipelines** — replaces multi-tool chains (CI runners, shell scripts, kubectl, CLI wrappers) with a single in-cluster binary. No external CI dependency, no cluster-admin runner pods, no scheduled workflow orchestration
 
 The JSON Schema conversion improves upon the widely-used [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) — see [How It Works](#%EF%B8%8F-how-it-works) for details.
+
+## ⚡ Quickstart
+
+### Deploy to a Cluster
+
+Install the Helm chart in controller mode for real-time CRD watching. Provide Cloudflare credentials to publish directly to Cloudflare Pages, or omit credentials to run extract-only and serve `OUTPUT_DIR/current` yourself.
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --create-namespace \
+  --set existingSecret.name=crd-schema-publisher-cloudflare
+```
+
+See [Deploying](#-deploying) for credentials, raw manifests, CronJob mode, alternative backends, and chart verification.
+
+### Convert CRD YAML Locally
+
+Use the standalone binary or `go run ./cmd/` to convert CRD YAML files without a cluster connection.
+
+```bash
+# Convert one CRD YAML file
+crd-schema-publisher convert --file crd.yaml --output-dir ./schemas
+
+# Convert every YAML CRD in a directory
+crd-schema-publisher convert --dir ./crds/ --output-dir ./schemas
+
+# Pipe CRDs from kubectl
+kubectl get crds -o yaml | crd-schema-publisher convert --file - --output-dir ./schemas
+```
+
+See [Standalone Binary](#standalone-binary) for release downloads and [Configuration and CLI Reference](#configuration-and-cli-reference) for flags and command behavior.
+
+### Use Published Schemas
+
+Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`.
+
+```yaml
+# yaml-language-server: $schema=https://kube-schemas.example.com/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example
+```
+
+See [Using Your Schemas](#-using-your-schemas) for IDE and kubeconform examples.
+
+## 📦 Installation
+
+### Standalone Binary
+
+Static binaries for Linux and macOS (amd64 + arm64) are attached to each [GitHub Release](https://github.com/sholdee/crd-schema-publisher/releases).
+
+```bash
+# Download the latest release (example: Linux amd64)
+curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/crd-schema-publisher-linux-amd64
+chmod +x crd-schema-publisher-linux-amd64
+```
+
+### Verify Release Artifacts
+
+```bash
+# Verify the signed checksum manifest
+curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/checksums-sha256.txt
+curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/checksums-sha256.txt.sigstore.json
+cosign verify-blob checksums-sha256.txt \
+  --bundle checksums-sha256.txt.sigstore.json \
+  --certificate-identity 'https://github.com/sholdee/crd-schema-publisher/.github/workflows/release.yaml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# Verify the binary against the trusted checksum manifest
+sha256sum -c --ignore-missing checksums-sha256.txt
+
+# Optional: verify build provenance for the binary
+gh attestation verify ./crd-schema-publisher-linux-amd64 \
+  --repo sholdee/crd-schema-publisher \
+  --signer-workflow sholdee/crd-schema-publisher/.github/workflows/release.yaml \
+  --source-ref refs/heads/main
+```
 
 ## 🚀 Deploying
 
@@ -84,6 +171,21 @@ helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publis
 
 Each example is a self-contained values file — copy it, fill in your credentials, and install. See the comments in each file for what to customize.
 
+#### GitHub Pages subpath deployments
+
+When serving schemas from a GitHub Pages project path such as `https://user.github.io/iac/`, set the base path so generated HTML links include the subpath:
+
+```bash
+BASE_PATH=/iac
+```
+
+Or in the Helm chart:
+
+```yaml
+config:
+  basePath: "/iac"
+```
+
 If you already use the first-party `git-push` or `rclone-s3` examples, update them to read `/data/current`. Older example configs fail closed after upgrading to a new image: syncing stops, but existing remote content is not deleted or overwritten. Cloudflare Pages users do not need to change anything.
 
 #### Verification
@@ -128,7 +230,7 @@ Pre-built multi-arch images (amd64 + arm64) are published to GHCR:
 ghcr.io/sholdee/crd-schema-publisher:latest
 ```
 
-Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`, with auto-generated release notes including the image digest and OCI Helm chart reference. PR builds get `pr-N` tags for testing.
+Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. PR builds get `pr-N` tags for testing.
 
 Images use `gcr.io/distroless/static:nonroot` as the runtime base — no shell, no package manager, runs as UID 65534. Production images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing via GitHub Actions OIDC:
 
@@ -138,9 +240,11 @@ cosign verify ghcr.io/sholdee/crd-schema-publisher:latest \
   --certificate-identity-regexp github.com/sholdee/crd-schema-publisher
 ```
 
-### Configuration
+## Configuration and CLI Reference
 
-All configuration is via environment variables. Variables marked *(watch)* apply only to watch mode deployment.
+### Environment Variables
+
+Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`. Variables marked *(watch)* apply only to watch mode deployment.
 
 | Variable | Required | Default | Description |
 | -------- | -------- | ------- | ----------- |
@@ -158,62 +262,32 @@ All configuration is via environment variables. Variables marked *(watch)* apply
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
 | `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`) |
 
-### Subpath Deployments (GitHub Pages)
+### Command Behavior
 
-When hosting schemas at a URL subpath (e.g., `https://user.github.io/iac/`), set `BASE_PATH` to the subpath:
+```text
+crd-schema-publisher [command]
 
-```bash
-BASE_PATH=/iac go run ./cmd/ extract
+Commands:
+  run       Extract schemas and upload to Cloudflare Pages (default)
+  extract   Extract schemas from a Kubernetes cluster
+  convert   Convert CRD YAML files to JSON Schema
+  upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
+  watch     Watch for CRD changes and publish on each change (extract-only if no credentials)
+  preview   Serve a local preview of the documentation site
 ```
 
-Or in the Helm chart:
+| Command(s) | Output directory behavior |
+| --- | --- |
+| `extract` | Requires explicit `--output-dir` or `OUTPUT_DIR`; does not fall back to `/output`. |
+| `convert` | Requires `--output-dir`; does not read `OUTPUT_DIR`. |
+| `run`, `watch`, `upload` | Accept `--output-dir`; output root must already exist. |
+| `preview` | Uses sample data by default; reads real extracted output only when `--output-dir` is passed explicitly. |
 
-```yaml
-config:
-  basePath: "/iac"
-```
-
-All generated HTML links will include the base path prefix. The preview server also respects `BASE_PATH`, mounting content at the subpath for local testing:
-
-```bash
-BASE_PATH=/iac go run ./cmd/ preview
-# → http://127.0.0.1:8989/iac/
-```
-
-### Monitoring
-
-In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` (default 8080) in Prometheus text format.
-
-| Metric | Type | Description |
-| ------ | ---- | ----------- |
-| `crdpublisher_publish_cycle_duration_seconds` | gauge | Duration of the most recent publish cycle |
-| `crdpublisher_publish_cycle_total` | counter | Publish cycles by result (`success`, `error`) |
-| `crdpublisher_crds_discovered` | gauge | CRDs found in the most recent cycle |
-| `crdpublisher_schemas_written` | gauge | Schemas written in the most recent cycle |
-| `crdpublisher_last_successful_publish_timestamp` | gauge | Unix epoch of the last successful publish |
-| `crdpublisher_watchdog_timestamp` | gauge | Unix epoch of the last debounce loop tick |
-| `crdpublisher_publish_skipped_total` | counter | Debounce skips (publish already in progress) |
-| `crdpublisher_leader` | gauge | Whether this pod is the current leader |
-
-The watchdog timestamp enables dead man's switch alerting — it updates on every debounce loop tick (regardless of whether a publish occurs), so `time() - crdpublisher_watchdog_timestamp` staying fresh proves the watcher is alive. The publish timestamp separately tracks when content was last pushed.
-
-The Helm chart includes a PodMonitor — enable it with `--set metrics.podMonitor.enabled=true`. For raw manifests or vanilla Prometheus Operator, create a PodMonitor:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: crd-schema-publisher
-spec:
-  selector:
-    matchLabels:
-      app: crd-schema-publisher
-  podMetricsEndpoints:
-    - port: health
-      path: /metrics
-```
-
-For vanilla Prometheus, add `prometheus.io/*` annotations to the pod template or configure a static scrape target.
+| Command(s) | Filters and command-specific flags |
+| --- | --- |
+| `extract`, `convert` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. |
+| `extract` | Supports `--context`, `--base-path`, and `--skip-render`. |
+| `convert` | Supports `--file`, non-recursive `--dir` YAML loading, optional `--render`, and `--base-path` for rendered links. |
 
 ## 📋 Using Your Schemas
 
@@ -259,7 +333,46 @@ This validates built-in Kubernetes resources against the default schemas and CRD
 
 > **Note:** Schema files are written as lowercase (e.g., `certificate_v1.json`) while `{{.ResourceKind}}` expands to the original case (e.g., `Certificate`). This works on Cloudflare Pages because it serves paths case-insensitively — the same convention used by [datreeio/CRDs-catalog](https://github.com/datreeio/CRDs-catalog). If serving schemas from a case-sensitive host, use lowercase kind names in your template paths.
 
-## Output Structure
+## Operations
+
+### Monitoring
+
+In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` (default 8080) in Prometheus text format.
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `crdpublisher_publish_cycle_duration_seconds` | gauge | Duration of the most recent publish cycle |
+| `crdpublisher_publish_cycle_total` | counter | Publish cycles by result (`success`, `error`) |
+| `crdpublisher_crds_discovered` | gauge | CRDs found in the most recent cycle |
+| `crdpublisher_schemas_written` | gauge | Schemas written in the most recent cycle |
+| `crdpublisher_last_successful_publish_timestamp` | gauge | Unix epoch of the last successful publish |
+| `crdpublisher_watchdog_timestamp` | gauge | Unix epoch of the last debounce loop tick |
+| `crdpublisher_publish_skipped_total` | counter | Debounce skips (publish already in progress) |
+| `crdpublisher_leader` | gauge | Whether this pod is the current leader |
+
+The watchdog timestamp enables dead man's switch alerting — it updates on every debounce loop tick (regardless of whether a publish occurs), so `time() - crdpublisher_watchdog_timestamp` staying fresh proves the watcher is alive. The publish timestamp separately tracks when content was last pushed.
+
+The Helm chart includes a PodMonitor — enable it with `--set metrics.podMonitor.enabled=true`. For raw manifests or vanilla Prometheus Operator, create a PodMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: crd-schema-publisher
+spec:
+  selector:
+    matchLabels:
+      app: crd-schema-publisher
+  podMetricsEndpoints:
+    - port: health
+      path: /metrics
+```
+
+For vanilla Prometheus, add `prometheus.io/*` annotations to the pod template or configure a static scrape target.
+
+### Output Structure
+
+Cluster-backed site generation (`run`, `extract`, `watch`) and preview temp generations use this layout:
 
 ```text
 <output-dir>/
@@ -280,18 +393,11 @@ This validates built-in Kubernetes resources against the default schemas and CRD
 
 Direct-volume consumers should read or serve `OUTPUT_DIR/current`, not the flat root of `OUTPUT_DIR`. First-party Cloudflare, git, S3, and Caddy examples exclude `_meta/` from published or served output.
 
+`convert` writes schema files directly into `--output-dir` instead of creating `.generations/current`. It records generated files in `_meta/convert-manifest.json` so reruns can remove stale generated artifacts while preserving files that existed before `convert` ran.
+
 ## ⚙️ How It Works
 
-```text
-crd-schema-publisher [command]
-
-Commands:
-  run       Extract schemas and upload to Cloudflare Pages (default)
-  extract   Extract schemas and generate the active site under OUTPUT_DIR/current
-  upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
-  watch     Watch for CRD changes and publish on each change (extract-only if no credentials)
-  preview   Generate a sample or active site snapshot and serve it locally
-```
+For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
 
 1. Connects to the Kubernetes API (in-cluster or via kubeconfig)
 2. Lists all CRDs and extracts `.spec.versions[].schema.openAPIV3Schema`
@@ -307,9 +413,42 @@ Commands:
 7. Atomically switches `OUTPUT_DIR/current` to the completed generation so sidecars read a stable snapshot
 8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
 
+The `convert` command skips Kubernetes access and reads CRD YAML from `--file`, stdin (`--file -`), and/or a non-recursive `--dir`. It applies the same schema transforms and writes flat output directly to `--output-dir`; with `--render`, it also renders HTML pages and an index.
+
 ## 🔧 Development
 
 ### Run Locally
+
+Use the package path (`go run ./cmd/ <command>`) for local subcommands so Go compiles every file in `cmd/`. Single-file invocation (`go run ./cmd/main.go --help` or `--version`) is only kept for top-level smoke checks.
+
+```bash
+# Extract schemas from a local cluster (no upload)
+KUBECTL_CONTEXT=my-cluster OUTPUT_DIR=./output go run ./cmd/ extract
+# Writes the active snapshot under ./output/current
+
+# Full run with upload
+mkdir -p ./output
+KUBECTL_CONTEXT=my-cluster \
+  CLOUDFLARE_API_TOKEN=xxx \
+  CLOUDFLARE_ACCOUNT_ID=xxx \
+  go run ./cmd/ --output-dir ./output
+
+# Convert CRD YAML files to JSON Schema (no cluster needed)
+go run ./cmd/ convert --file crd.yaml --output-dir ./schemas
+
+# Convert all CRDs in a directory
+go run ./cmd/ convert --dir ./crds/ --output-dir ./schemas
+
+# Pipe from kubectl
+kubectl get crds -o yaml | go run ./cmd/ convert --file - --output-dir ./schemas
+
+# Filter by kind and group
+go run ./cmd/ extract --output-dir ./schemas --kind certificate,issuer --group cert-manager.io
+```
+
+### Preview the Site Locally
+
+Preview is useful for UI development and local inspection. It needs no cluster or credentials when using sample data.
 
 ```bash
 # Preview the index UI (no cluster or credentials needed)
@@ -317,18 +456,12 @@ go run ./cmd/ preview
 # open http://127.0.0.1:8989
 
 # Preview with real extracted schemas
-OUTPUT_DIR=./output go run ./cmd/ preview
+go run ./cmd/ preview --output-dir ./output
 # Serves the active snapshot from ./output/current
 
-# Extract schemas from a local cluster (no upload)
-KUBECTL_CONTEXT=my-cluster OUTPUT_DIR=./output go run ./cmd/ extract
-# Writes the active snapshot under ./output/current
-
-# Full run with upload
-KUBECTL_CONTEXT=my-cluster \
-  CLOUDFLARE_API_TOKEN=xxx \
-  CLOUDFLARE_ACCOUNT_ID=xxx \
-  go run ./cmd/
+# Preview a subpath deployment locally
+BASE_PATH=/iac go run ./cmd/ preview
+# open http://127.0.0.1:8989/iac/
 ```
 
 ### Build
@@ -337,8 +470,15 @@ KUBECTL_CONTEXT=my-cluster \
 # Native build
 go build -o crd-schema-publisher ./cmd/
 
-# Static cross-compile (matches CI)
+# Example static cross-compile
 CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o crd-schema-publisher ./cmd/
+
+# Build all release binaries locally
+for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+  GOOS="${pair%/*}" GOARCH="${pair#*/}"
+  CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
+    go build -ldflags="-s -w" -o "crd-schema-publisher-${GOOS}-${GOARCH}" ./cmd/
+done
 
 # Docker (multi-arch)
 docker buildx build --platform linux/amd64,linux/arm64 -t crd-schema-publisher .

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+	"github.com/sholdee/crd-schema-publisher/index"
+	"github.com/sholdee/crd-schema-publisher/renderer"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func init() {
+	registerCommand("convert", runConvert)
+}
+
+func parseCRDsFromFileList(fileFlag string) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	var crds []apiextensionsv1.CustomResourceDefinition
+	for _, f := range strings.Split(fileFlag, ",") {
+		f = strings.TrimSpace(f)
+		if f == "-" {
+			stdinCRDs, err := extractor.ParseCRDsFromReader(os.Stdin)
+			if err != nil {
+				return nil, fmt.Errorf("parsing stdin: %w", err)
+			}
+			crds = append(crds, stdinCRDs...)
+		} else {
+			fileCRDs, err := extractor.ParseCRDsFromFiles([]string{f})
+			if err != nil {
+				return nil, err
+			}
+			crds = append(crds, fileCRDs...)
+		}
+	}
+	return crds, nil
+}
+
+const convertManifestPath = "_meta/convert-manifest.json"
+
+// cleanConvertArtifacts reads the convert manifest from a prior run and removes
+// exactly those files. After file removal, empty parent directories are pruned
+// bottom-up so user files inside generated directories are preserved. Returns
+// an error if the manifest exists but is corrupt — the user must resolve this
+// manually (delete the output directory or fix the manifest) rather than risk
+// mixed stale-and-fresh output.
+func cleanConvertArtifacts(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return os.MkdirAll(dir, 0o755)
+	}
+
+	manifest, err := readConvertManifest(dir)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return nil // no manifest file = nothing to clean (first run)
+	}
+
+	// Remove only the individual files listed in the manifest
+	parentDirs := make(map[string]bool)
+	for _, rel := range manifest {
+		abs := filepath.Join(dir, filepath.FromSlash(rel))
+		_ = os.Remove(abs)
+		// Track all ancestor directories (relative to output dir) for pruning
+		for parent := filepath.Dir(rel); parent != "." && parent != ""; parent = filepath.Dir(parent) {
+			parentDirs[filepath.Join(dir, filepath.FromSlash(parent))] = true
+		}
+	}
+
+	// Remove the manifest and _meta directory
+	_ = os.Remove(filepath.Join(dir, convertManifestPath))
+	parentDirs[filepath.Join(dir, "_meta")] = true
+
+	// Prune empty directories bottom-up — longest paths first so children
+	// are removed before parents. os.Remove on a directory only succeeds
+	// if it is empty, so user files inside generated directories survive.
+	sorted := make([]string, 0, len(parentDirs))
+	for d := range parentDirs {
+		sorted = append(sorted, d)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(sorted)))
+	for _, d := range sorted {
+		_ = os.Remove(d) // only removes if empty
+	}
+
+	return nil
+}
+
+// readConvertManifest reads the convert manifest. Returns (nil, nil) if the
+// manifest file does not exist (first run). Returns a non-nil error if the
+// file exists but cannot be parsed — this is a corruption condition.
+func readConvertManifest(dir string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(dir, convertManifestPath))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading convert manifest: %w", err)
+	}
+	var paths []string
+	if err := json.Unmarshal(data, &paths); err != nil {
+		return nil, fmt.Errorf("corrupt convert manifest in %s — delete the output directory or fix the manifest manually: %w",
+			filepath.Join(dir, convertManifestPath), err)
+	}
+	return paths, nil
+}
+
+// snapshotFiles returns the set of file paths (relative, slash-separated)
+// present in dir before convert writes anything. Used to distinguish
+// pre-existing user files from convert output.
+func snapshotFiles(dir string) map[string]bool {
+	files := make(map[string]bool)
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info.IsDir() {
+			return nil //nolint:nilerr // intentionally skip unreadable entries
+		}
+		if rel, relErr := filepath.Rel(dir, path); relErr == nil {
+			files[filepath.ToSlash(rel)] = true
+		}
+		return nil
+	})
+	return files
+}
+
+// writeConvertManifest walks the output directory and records only files that
+// were NOT in the pre-existing snapshot. This ensures user files present before
+// convert ran are never recorded as convert output.
+func writeConvertManifest(dir string, preExisting map[string]bool) error {
+	var paths []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if !preExisting[rel] {
+			paths = append(paths, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking output directory: %w", err)
+	}
+
+	metaDir := filepath.Join(dir, "_meta")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(paths, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, convertManifestPath), append(data, '\n'), 0o644)
+}
+
+func loadCRDs(fileList, dir string) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	var crds []apiextensionsv1.CustomResourceDefinition
+	if fileList != "" {
+		fileCRDs, err := parseCRDsFromFileList(fileList)
+		if err != nil {
+			return nil, err
+		}
+		crds = append(crds, fileCRDs...)
+	}
+	if dir != "" {
+		dirCRDs, err := extractor.ParseCRDsFromDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		crds = append(crds, dirCRDs...)
+	}
+	return crds, nil
+}
+
+func runConvert(args []string) error {
+	fs := flag.NewFlagSet("convert", flag.ContinueOnError)
+	fileFlag := fs.String("file", "", "CRD YAML file(s), comma-separated (use - for stdin)")
+	dirFlag := fs.String("dir", "", "directory containing CRD YAML files")
+	outputDir := fs.String("output-dir", "", "output directory for JSON schemas (required)")
+	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
+	render := fs.Bool("render", false, "render HTML documentation pages")
+	kind := fs.String("kind", "", "filter by kind (comma-separated, case-insensitive)")
+	group := fs.String("group", "", "filter by group (comma-separated, case-insensitive)")
+	version := fs.String("version", "", "filter by version (comma-separated, case-insensitive)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *outputDir == "" {
+		return fmt.Errorf("--output-dir is required")
+	}
+	if err := extractor.ValidateOutputDir(*outputDir); err != nil {
+		return err
+	}
+	if *fileFlag == "" && *dirFlag == "" {
+		return fmt.Errorf("at least one of --file or --dir is required")
+	}
+
+	crds, err := loadCRDs(*fileFlag, *dirFlag)
+	if err != nil {
+		return err
+	}
+
+	crds = extractor.FilterCRDs(crds, extractor.ParseFilter(*kind, *group, *version))
+
+	if err := cleanConvertArtifacts(*outputDir); err != nil {
+		return fmt.Errorf("preparing output directory: %w", err)
+	}
+
+	if len(crds) == 0 {
+		slog.Info("no CRDs matched filters")
+		return nil
+	}
+
+	preExisting := snapshotFiles(*outputDir)
+
+	count, err := extractor.WriteSchemas(crds, *outputDir)
+	if err != nil {
+		return fmt.Errorf("writing schemas: %w", err)
+	}
+
+	normalizedBasePath := normalizeBasePath(*basePath)
+	if *render {
+		if err := renderer.RenderAll(*outputDir, normalizedBasePath); err != nil {
+			return fmt.Errorf("rendering schemas: %w", err)
+		}
+		if err := index.Generate(*outputDir, normalizedBasePath); err != nil {
+			return fmt.Errorf("generating index: %w", err)
+		}
+	}
+
+	if err := writeConvertManifest(*outputDir, preExisting); err != nil {
+		return fmt.Errorf("writing convert manifest: %w", err)
+	}
+
+	slog.Info("convert complete", "count", count, "dir", *outputDir)
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,38 +1,51 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"os"
-	"os/signal"
-	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
-	"time"
 
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/index"
-	"github.com/sholdee/crd-schema-publisher/publisher"
 	"github.com/sholdee/crd-schema-publisher/renderer"
-	"github.com/sholdee/crd-schema-publisher/watcher"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 )
 
+// version is set at build time via -ldflags "-X main.version=..."
+var version = "dev"
+
 var (
-	buildClientFunc       = extractor.BuildClient
-	buildSiteFunc         = extractor.BuildSite
-	validateOutputDirFunc = extractor.ValidateOutputDir
-	renderPreviewFunc     = renderer.RenderAll
-	generatePreviewFunc   = index.Generate
-	scaffoldPreviewFunc   = scaffoldSampleData
-	publishOutputFunc     = runUpload
+	buildClientFunc        = extractor.BuildClient
+	buildSiteFunc          = extractor.BuildSite
+	validateOutputDirFunc  = extractor.ValidateOutputDir
+	renderPreviewFunc      = renderer.RenderAll
+	generatePreviewFunc    = index.Generate
+	scaffoldPreviewFunc    func(string) error
+	preparePreviewSiteFunc func(string, string, bool) (string, func(), error)
+	publishOutputFunc      func(string) error
+	commands               = map[string]func([]string) error{}
 )
+
+type commandSpec struct {
+	name        string
+	description string
+}
+
+var commandSpecs = []commandSpec{
+	{name: "run", description: "Extract schemas and upload to Cloudflare Pages (default)"},
+	{name: "extract", description: "Extract schemas from a Kubernetes cluster"},
+	{name: "convert", description: "Convert CRD YAML files to JSON Schema"},
+	{name: "upload", description: "Upload schemas to Cloudflare Pages"},
+	{name: "watch", description: "Watch for CRD changes and publish automatically"},
+	{name: "preview", description: "Serve a local preview of the documentation site"},
+}
+
+func registerCommand(name string, run func([]string) error) {
+	commands[name] = run
+}
 
 func initLogger(cmd string) {
 	var handler slog.Handler
@@ -45,42 +58,66 @@ func initLogger(cmd string) {
 	slog.SetDefault(slog.New(handler))
 }
 
-func main() {
-	cmd := "run"
-	if len(os.Args) > 1 {
-		cmd = os.Args[1]
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `crd-schema-publisher — CRD JSON Schema extraction and documentation
+
+Usage:
+  crd-schema-publisher <command> [flags]
+
+Commands:
+`)
+	for _, cmd := range commandSpecs {
+		fmt.Fprintf(w, "  %-8s  %s\n", cmd.name, cmd.description)
 	}
+	fmt.Fprint(w, `
+Use "crd-schema-publisher <command> --help" for more information.
+`)
+}
+
+func parseSubcommand(osArgs []string) (string, []string) {
+	if len(osArgs) < 2 {
+		return "run", nil
+	}
+	arg := osArgs[1]
+	if arg == "--help" || arg == "-h" {
+		return "help", nil
+	}
+	if arg == "--version" || arg == "-v" {
+		return "version", nil
+	}
+	if arg == "--output-dir" || strings.HasPrefix(arg, "--output-dir=") {
+		return "run", osArgs[1:]
+	}
+	return arg, osArgs[2:]
+}
+
+func handleCmdError(cmd string, err error) {
+	if err == nil || errors.Is(err, flag.ErrHelp) {
+		return
+	}
+	slog.Error("command failed", "command", cmd, "error", err)
+	os.Exit(1)
+}
+
+func main() {
+	cmd, args := parseSubcommand(os.Args)
 	initLogger(cmd)
 
 	switch cmd {
-	case "run":
-		if err := runAll(); err != nil {
-			slog.Error("command failed", "command", cmd, "error", err)
-			os.Exit(1)
-		}
-	case "extract":
-		if err := runExtract(); err != nil {
-			slog.Error("command failed", "command", cmd, "error", err)
-			os.Exit(1)
-		}
-	case "upload":
-		if err := runUpload(); err != nil {
-			slog.Error("command failed", "command", cmd, "error", err)
-			os.Exit(1)
-		}
-	case "watch":
-		if err := runWatch(); err != nil {
-			slog.Error("command failed", "command", cmd, "error", err)
-			os.Exit(1)
-		}
-	case "preview":
-		if err := runPreview(); err != nil {
-			slog.Error("command failed", "command", cmd, "error", err)
-			os.Exit(1)
-		}
+	case "help":
+		printUsage(os.Stdout)
+		return
+	case "version":
+		fmt.Println(version)
+		return
 	default:
+		run, ok := commands[cmd]
+		if ok {
+			handleCmdError(cmd, run(args))
+			return
+		}
 		slog.Error("unknown command", "command", cmd)
-		fmt.Fprintf(os.Stderr, "usage: crd-schema-publisher [run|extract|upload|watch|preview]\n")
+		printUsage(os.Stderr)
 		os.Exit(1)
 	}
 }
@@ -100,6 +137,54 @@ func requireEnv(key string) (string, error) {
 	return v, nil
 }
 
+func parseOutputDirArg(cmd string, args []string, fallback string) (string, bool, error) {
+	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
+	outputDir := fs.String("output-dir", fallback, "output directory")
+	if err := fs.Parse(args); err != nil {
+		return "", false, err
+	}
+	if extras := fs.Args(); len(extras) > 0 {
+		return "", false, fmt.Errorf("unexpected arguments for %s: %s", cmd, strings.Join(extras, " "))
+	}
+	explicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "output-dir" {
+			explicit = true
+		}
+	})
+	return *outputDir, explicit, nil
+}
+
+func requireExistingOutputDir(outputDir, guidance string) error {
+	if strings.TrimSpace(outputDir) == "" {
+		return fmt.Errorf("OUTPUT_DIR must not be empty; it must already exist as a directory before running this command. %s", guidance)
+	}
+	if err := extractor.ValidateOutputDir(outputDir); err != nil {
+		return fmt.Errorf("%w. Runtime commands require OUTPUT_DIR to already exist as a directory. %s", err, guidance)
+	}
+	info, err := os.Stat(outputDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("OUTPUT_DIR %q does not exist; it must already exist as a directory before running this command. %s", outputDir, guidance)
+		}
+		return fmt.Errorf("checking OUTPUT_DIR %q: %w", outputDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("OUTPUT_DIR %q is not a directory; it must already exist as a directory before running this command. %s", outputDir, guidance)
+	}
+	return nil
+}
+
+func requireConfiguredOutputDir(outputDir, guidance string) error {
+	if strings.TrimSpace(outputDir) == "" {
+		return fmt.Errorf("OUTPUT_DIR is required for this command; set OUTPUT_DIR or pass --output-dir. %s", guidance)
+	}
+	if err := extractor.ValidateOutputDir(outputDir); err != nil {
+		return fmt.Errorf("%w. %s", err, guidance)
+	}
+	return nil
+}
+
 func normalizeBasePath(s string) string {
 	s = strings.TrimRight(s, "/")
 	if s == "" {
@@ -109,424 +194,4 @@ func normalizeBasePath(s string) string {
 		s = "/" + s
 	}
 	return s
-}
-
-func runExtract() error {
-	_, err := runBuild()
-	return err
-}
-
-func runBuild() (extractor.SiteBuildResult, error) {
-	outputDir := getEnv("OUTPUT_DIR", "/output")
-	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
-	kubeContext := os.Getenv("KUBECTL_CONTEXT")
-
-	slog.Info("building kubernetes client")
-	client, err := buildClientFunc(kubeContext)
-	if err != nil {
-		return extractor.SiteBuildResult{}, fmt.Errorf("building client: %w", err)
-	}
-
-	result, err := buildSiteFunc(extractor.SiteBuildOptions{
-		Lister:    client.ApiextensionsV1().CustomResourceDefinitions(),
-		OutputDir: outputDir,
-		BasePath:  basePath,
-		Render:    os.Getenv("SKIP_RENDER") != "true",
-	})
-	if err != nil {
-		return extractor.SiteBuildResult{}, err
-	}
-	if result.Status == extractor.BuildResultNoop {
-		slog.Info("no CRDs found, leaving existing output untouched")
-		return result, nil
-	}
-
-	slog.Info("extract complete", "count", result.SchemaCount, "dir", outputDir)
-	return result, nil
-}
-
-func runUpload() error {
-	outputDir := getEnv("OUTPUT_DIR", "/output")
-
-	apiToken, err := requireEnv("CLOUDFLARE_API_TOKEN")
-	if err != nil {
-		return err
-	}
-	accountID, err := requireEnv("CLOUDFLARE_ACCOUNT_ID")
-	if err != nil {
-		return err
-	}
-	projectName := getEnv("CF_PAGES_PROJECT", "kubernetes-schemas")
-
-	p := &publisher.Publisher{
-		APIToken:    apiToken,
-		AccountID:   accountID,
-		ProjectName: projectName,
-	}
-
-	return p.Publish(outputDir)
-}
-
-func runWatch() error {
-	outputDir := getEnv("OUTPUT_DIR", "/output")
-	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
-	kubeContext := os.Getenv("KUBECTL_CONTEXT")
-
-	podName, err := requireEnv("POD_NAME")
-	if err != nil {
-		return err
-	}
-	podNamespace, err := requireEnv("POD_NAMESPACE")
-	if err != nil {
-		return err
-	}
-
-	debounceSeconds := 15
-	if v := os.Getenv("DEBOUNCE_SECONDS"); v != "" {
-		parsed, err := strconv.Atoi(v)
-		if err != nil {
-			return fmt.Errorf("invalid DEBOUNCE_SECONDS: %w", err)
-		}
-		debounceSeconds = parsed
-	}
-
-	leaseName := getEnv("LEASE_NAME", "crd-schema-publisher")
-	healthPort := getEnv("HEALTH_PORT", "8080")
-
-	cfg, err := extractor.BuildConfig(kubeContext)
-	if err != nil {
-		return fmt.Errorf("building kubeconfig: %w", err)
-	}
-
-	client, err := apiextensionsclient.NewForConfig(cfg)
-	if err != nil {
-		return fmt.Errorf("building apiextensions client: %w", err)
-	}
-
-	var pub *publisher.Publisher
-	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
-	if apiToken != "" && accountID != "" {
-		pub = &publisher.Publisher{
-			APIToken:    apiToken,
-			AccountID:   accountID,
-			ProjectName: getEnv("CF_PAGES_PROJECT", "kubernetes-schemas"),
-		}
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer cancel()
-
-	return watcher.Run(ctx, watcher.Config{
-		Client:     client,
-		KubeConfig: cfg,
-		OutputDir:  outputDir,
-		BasePath:   basePath,
-		Publisher:  pub,
-		Debounce:   time.Duration(debounceSeconds) * time.Second,
-		Namespace:  podNamespace,
-		LeaseName:  leaseName,
-		PodName:    podName,
-		HealthPort: healthPort,
-	})
-}
-
-func runPreview() error {
-	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
-	serveDir, cleanup, err := preparePreviewSite(getEnv("OUTPUT_DIR", ""), basePath, os.Getenv("SKIP_RENDER") != "true")
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	addr := getEnv("PREVIEW_ADDR", "127.0.0.1:8989")
-	var handler http.Handler
-	if basePath != "" {
-		mux := http.NewServeMux()
-		mux.Handle(basePath+"/", http.StripPrefix(basePath, http.FileServer(http.Dir(serveDir))))
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, basePath+"/", http.StatusFound)
-		})
-		handler = mux
-	} else {
-		handler = http.FileServer(http.Dir(serveDir))
-	}
-	srv := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer cancel()
-
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer shutdownCancel()
-		_ = srv.Shutdown(shutdownCtx)
-	}()
-
-	if basePath != "" {
-		slog.Info("serving preview", "addr", addr, "url", "http://"+addr+basePath+"/")
-	} else {
-		slog.Info("serving preview", "addr", addr)
-	}
-	err = srv.ListenAndServe()
-	if errors.Is(err, http.ErrServerClosed) {
-		return nil
-	}
-	return err
-}
-
-func preparePreviewSite(outputDir, basePath string, render bool) (string, func(), error) {
-	if outputDir == "" {
-		rootDir, cleanup, err := newPreviewRoot()
-		if err != nil {
-			return "", nil, err
-		}
-		if err := preparePreviewGeneration(rootDir, basePath, render, scaffoldPreviewFunc, "scaffolding sample data"); err != nil {
-			cleanup()
-			return "", nil, err
-		}
-		slog.Info("using sample data", "dir", rootDir, "active_dir", extractor.ActiveOutputDir(rootDir))
-		return extractor.ActiveOutputDir(rootDir), cleanup, nil
-	}
-
-	if err := validateOutputDirFunc(outputDir); err != nil {
-		return "", nil, err
-	}
-
-	activeDir, resolvedActiveDir, err := resolvePreviewActiveDir(outputDir)
-	if err != nil {
-		return "", nil, err
-	}
-
-	rootDir, cleanup, err := newPreviewRoot()
-	if err != nil {
-		return "", nil, err
-	}
-	if err := preparePreviewGeneration(rootDir, basePath, render, func(generationDir string) error {
-		return copyPreviewFiles(resolvedActiveDir, generationDir)
-	}, "copying active output"); err != nil {
-		cleanup()
-		return "", nil, err
-	}
-	slog.Info("using existing output", "dir", outputDir, "active_dir", activeDir, "preview_dir", extractor.ActiveOutputDir(rootDir))
-	return extractor.ActiveOutputDir(rootDir), cleanup, nil
-}
-
-func newPreviewRoot() (string, func(), error) {
-	rootDir, err := os.MkdirTemp("", "crd-preview-*")
-	if err != nil {
-		return "", nil, fmt.Errorf("creating temp dir: %w", err)
-	}
-	return rootDir, func() {
-		_ = os.RemoveAll(rootDir)
-	}, nil
-}
-
-func resolvePreviewActiveDir(outputDir string) (string, string, error) {
-	activeDir := extractor.ActiveOutputDir(outputDir)
-	resolvedActiveDir, err := filepath.EvalSymlinks(activeDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", "", fmt.Errorf("active output %q does not exist; run extract first", activeDir)
-		}
-		return "", "", fmt.Errorf("resolving active output: %w", err)
-	}
-	return activeDir, resolvedActiveDir, nil
-}
-
-func preparePreviewGeneration(rootDir, basePath string, render bool, seed func(string) error, seedAction string) error {
-	generationDir, err := makePreviewGenerationDir(rootDir)
-	if err != nil {
-		return fmt.Errorf("creating preview generation: %w", err)
-	}
-	if err := seed(generationDir); err != nil {
-		return fmt.Errorf("%s: %w", seedAction, err)
-	}
-	if render {
-		slog.Info("rendering schema pages")
-		if err := renderPreviewFunc(generationDir, basePath); err != nil {
-			return fmt.Errorf("rendering schemas: %w", err)
-		}
-	}
-	slog.Info("generating index")
-	if err := generatePreviewFunc(generationDir, basePath); err != nil {
-		return fmt.Errorf("generating index: %w", err)
-	}
-	if err := activatePreviewGeneration(rootDir, generationDir); err != nil {
-		return fmt.Errorf("activating preview generation: %w", err)
-	}
-	return nil
-}
-
-func makePreviewGenerationDir(outputDir string) (string, error) {
-	generationsDir := filepath.Join(outputDir, ".generations")
-	if err := os.MkdirAll(generationsDir, 0o755); err != nil {
-		return "", err
-	}
-	return os.MkdirTemp(generationsDir, "preview-")
-}
-
-func activatePreviewGeneration(outputDir, generationDir string) error {
-	currentPath := extractor.ActiveOutputDir(outputDir)
-	tmpPath := filepath.Join(outputDir, ".current.tmp")
-	target := filepath.Join(".generations", filepath.Base(generationDir))
-
-	_ = os.Remove(tmpPath)
-	if err := os.Symlink(target, tmpPath); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, currentPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	return nil
-}
-
-func copyPreviewFiles(srcDir, dstDir string) error {
-	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return nil
-		}
-
-		dstPath := filepath.Join(dstDir, rel)
-		if info.IsDir() {
-			return os.MkdirAll(dstPath, info.Mode())
-		}
-		return copyPreviewFile(path, dstPath, info.Mode())
-	})
-}
-
-func copyPreviewFile(srcPath, dstPath string, mode os.FileMode) error {
-	src, err := os.Open(srcPath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = src.Close()
-	}()
-
-	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
-		return err
-	}
-
-	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = dst.Close()
-	}()
-
-	if _, err := io.Copy(dst, src); err != nil {
-		return err
-	}
-	return nil
-}
-
-func scaffoldSampleData(dir string) error {
-	type sampleSchema struct {
-		file string
-		kind string
-	}
-
-	sampleGroups := map[string][]sampleSchema{
-		"cert-manager.io": {
-			{file: "certificate_v1.json", kind: "Certificate"},
-			{file: "clusterissuer_v1.json", kind: "ClusterIssuer"},
-			{file: "issuer_v1.json", kind: "Issuer"},
-		},
-		"monitoring.coreos.com": {
-			{file: "alertmanager_v1.json", kind: "Alertmanager"},
-			{file: "podmonitor_v1.json", kind: "PodMonitor"},
-			{file: "prometheus_v1.json", kind: "Prometheus"},
-			{file: "servicemonitor_v1.json", kind: "ServiceMonitor"},
-		},
-		"helm.toolkit.fluxcd.io": {
-			{file: "helmrelease_v2.json", kind: "HelmRelease"},
-			{file: "helmrelease_v2beta1.json", kind: "HelmRelease"},
-		},
-		"source.toolkit.fluxcd.io": {
-			{file: "gitrepository_v1.json", kind: "GitRepository"},
-			{file: "helmchart_v1.json", kind: "HelmChart"},
-			{file: "helmrepository_v1.json", kind: "HelmRepository"},
-			{file: "ocirepository_v1beta2.json", kind: "OCIRepository"},
-		},
-		"kustomize.toolkit.fluxcd.io": {
-			{file: "kustomization_v1.json", kind: "Kustomization"},
-		},
-		"cilium.io": {
-			{file: "ciliumnetworkpolicy_v2.json", kind: "CiliumNetworkPolicy"},
-			{file: "ciliumclusterwidenetworkpolicy_v2.json", kind: "CiliumClusterwideNetworkPolicy"},
-			{file: "ciliumendpoint_v2.json", kind: "CiliumEndpoint"},
-		},
-		"traefik.io": {
-			{file: "ingressroute_v1alpha1.json", kind: "IngressRoute"},
-			{file: "middleware_v1alpha1.json", kind: "Middleware"},
-			{file: "tlsoption_v1alpha1.json", kind: "TLSOption"},
-		},
-		"external-secrets.io": {
-			{file: "externalsecret_v1beta1.json", kind: "ExternalSecret"},
-			{file: "clustersecretstore_v1beta1.json", kind: "ClusterSecretStore"},
-			{file: "secretstore_v1beta1.json", kind: "SecretStore"},
-		},
-		"metallb.io": {
-			{file: "ipaddresspool_v1beta1.json", kind: "IPAddressPool"},
-			{file: "l2advertisement_v1beta1.json", kind: "L2Advertisement"},
-		},
-		"volsync.backube": {
-			{file: "replicationsource_v1alpha1.json", kind: "ReplicationSource"},
-			{file: "replicationdestination_v1alpha1.json", kind: "ReplicationDestination"},
-		},
-	}
-	kinds := make(map[string]string)
-	for group, files := range sampleGroups {
-		groupDir := filepath.Join(dir, group)
-		if err := os.MkdirAll(groupDir, 0o755); err != nil {
-			return fmt.Errorf("creating group dir %s: %w", group, err)
-		}
-		for _, schema := range files {
-			path := filepath.Join(groupDir, schema.file)
-			if err := os.WriteFile(path, []byte(`{"type":"object"}`), 0o644); err != nil {
-				return fmt.Errorf("writing %s/%s: %w", group, schema.file, err)
-			}
-			kinds[filepath.ToSlash(filepath.Join(group, schema.file))] = schema.kind
-		}
-	}
-	manifestDir := filepath.Join(dir, "_meta")
-	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
-		return fmt.Errorf("creating metadata dir: %w", err)
-	}
-	manifestBytes, err := json.MarshalIndent(kinds, "", "  ")
-	if err != nil {
-		return fmt.Errorf("encoding kind manifest: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(manifestDir, "kinds.json"), append(manifestBytes, '\n'), 0o644); err != nil {
-		return fmt.Errorf("writing kind manifest: %w", err)
-	}
-	return nil
-}
-
-func runAll() error {
-	result, err := runBuild()
-	if err != nil {
-		return fmt.Errorf("extract: %w", err)
-	}
-	if result.Status == extractor.BuildResultNoop {
-		return nil
-	}
-	if publishOutputFunc == nil {
-		return nil
-	}
-	if err := publishOutputFunc(); err != nil {
-		return fmt.Errorf("upload: %w", err)
-	}
-	return nil
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2,7 +2,15 @@ package main
 
 import (
 	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/rest"
 )
 
 func TestNormalizeBasePath(t *testing.T) {
@@ -55,5 +63,974 @@ func TestInitLogger_TextForPreview(t *testing.T) {
 	handler := slog.Default().Handler()
 	if _, ok := handler.(*slog.TextHandler); !ok {
 		t.Errorf("expected TextHandler for 'preview', got %T", handler)
+	}
+}
+
+func TestPrintUsage_ContainsAllCommands(t *testing.T) {
+	var buf strings.Builder
+	printUsage(&buf)
+	output := buf.String()
+	for _, cmd := range commandSpecs {
+		if !strings.Contains(output, cmd.name) {
+			t.Errorf("usage output missing command %q", cmd.name)
+		}
+	}
+}
+
+func TestRegisteredCommandsMatchAdvertisedCommands(t *testing.T) {
+	advertised := make(map[string]bool)
+	for _, cmd := range commandSpecs {
+		advertised[cmd.name] = true
+		if commands[cmd.name] == nil {
+			t.Errorf("advertised command %q is not registered", cmd.name)
+		}
+	}
+	for name := range commands {
+		if !advertised[name] {
+			t.Errorf("registered command %q is not advertised in usage", name)
+		}
+	}
+}
+
+func TestSingleFileMainSupportsTopLevelHelpAndVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "help", args: []string{"--help"}, want: "crd-schema-publisher"},
+		{name: "version", args: []string{"--version"}, want: "dev"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"run", "./main.go"}, tt.args...)
+			cmd := exec.Command("go", args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("go %s failed: %v\n%s", strings.Join(args, " "), err, output)
+			}
+			if !strings.Contains(string(output), tt.want) {
+				t.Fatalf("expected output to contain %q, got:\n%s", tt.want, output)
+			}
+		})
+	}
+}
+
+func TestParseSubcommand_DefaultsToRun(t *testing.T) {
+	cmd, args := parseSubcommand([]string{"crd-schema-publisher"})
+	if cmd != "run" {
+		t.Errorf("expected default 'run', got %q", cmd)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+func TestParseSubcommand_LeadingFlagDefaultsToRun(t *testing.T) {
+	cmd, args := parseSubcommand([]string{"crd-schema-publisher", "--output-dir", "/tmp/out"})
+	if cmd != "run" {
+		t.Errorf("expected default 'run' for leading flag, got %q", cmd)
+	}
+	if len(args) != 2 || args[0] != "--output-dir" || args[1] != "/tmp/out" {
+		t.Errorf("expected ['--output-dir', '/tmp/out'], got %v", args)
+	}
+}
+
+func TestParseSubcommand_LeadingOutputDirEqualsDefaultsToRun(t *testing.T) {
+	cmd, args := parseSubcommand([]string{"crd-schema-publisher", "--output-dir=/tmp/out"})
+	if cmd != "run" {
+		t.Errorf("expected default 'run' for --output-dir=<path>, got %q", cmd)
+	}
+	if len(args) != 1 || args[0] != "--output-dir=/tmp/out" {
+		t.Errorf("expected ['--output-dir=/tmp/out'], got %v", args)
+	}
+}
+
+func TestParseSubcommand_NonOutputFlagDoesNotDefaultToRun(t *testing.T) {
+	cmd, args := parseSubcommand([]string{"crd-schema-publisher", "--kind", "certificate"})
+	if cmd != "--kind" {
+		t.Errorf("expected raw leading flag command '--kind', got %q", cmd)
+	}
+	if len(args) != 1 || args[0] != "certificate" {
+		t.Errorf("expected ['certificate'], got %v", args)
+	}
+}
+
+func TestParseSubcommand_ExtractsCommand(t *testing.T) {
+	cmd, args := parseSubcommand([]string{"crd-schema-publisher", "extract", "--output-dir", "/tmp"})
+	if cmd != "extract" {
+		t.Errorf("expected 'extract', got %q", cmd)
+	}
+	if len(args) != 2 || args[0] != "--output-dir" {
+		t.Errorf("expected ['--output-dir', '/tmp'], got %v", args)
+	}
+}
+
+func TestParseSubcommand_HelpFlag(t *testing.T) {
+	cmd, _ := parseSubcommand([]string{"crd-schema-publisher", "--help"})
+	if cmd != "help" {
+		t.Errorf("expected 'help', got %q", cmd)
+	}
+
+	cmd, _ = parseSubcommand([]string{"crd-schema-publisher", "-h"})
+	if cmd != "help" {
+		t.Errorf("expected 'help' for -h, got %q", cmd)
+	}
+}
+
+func TestParseSubcommand_VersionFlag(t *testing.T) {
+	cmd, _ := parseSubcommand([]string{"crd-schema-publisher", "--version"})
+	if cmd != "version" {
+		t.Errorf("expected 'version', got %q", cmd)
+	}
+
+	cmd, _ = parseSubcommand([]string{"crd-schema-publisher", "-v"})
+	if cmd != "version" {
+		t.Errorf("expected 'version' for -v, got %q", cmd)
+	}
+}
+
+func TestVersionDefault(t *testing.T) {
+	if version != "dev" {
+		t.Errorf("expected default version 'dev', got %q", version)
+	}
+}
+
+func TestRunExtract_FlagsOverrideEnvVars(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+	}()
+
+	var capturedOpts extractor.SiteBuildOptions
+	var capturedContext string
+	buildClientFunc = func(kubeContext string) (*apiextensionsclient.Clientset, error) {
+		capturedContext = kubeContext
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		capturedOpts = opts
+		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
+	}
+
+	t.Setenv("OUTPUT_DIR", "/env-output")
+	t.Setenv("KUBECTL_CONTEXT", "env-context")
+
+	tmpDir := t.TempDir()
+	err := runExtract([]string{"--output-dir", tmpDir, "--context", "flag-context"})
+	if err != nil {
+		t.Fatalf("runExtract error: %v", err)
+	}
+	if capturedContext != "flag-context" {
+		t.Errorf("expected flag context 'flag-context', got %q", capturedContext)
+	}
+	if capturedOpts.OutputDir != tmpDir {
+		t.Errorf("expected flag output-dir %q, got %q", tmpDir, capturedOpts.OutputDir)
+	}
+}
+
+func TestRunExtract_FallsBackToEnvVars(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+	}()
+
+	var capturedOpts extractor.SiteBuildOptions
+	buildClientFunc = func(kubeContext string) (*apiextensionsclient.Clientset, error) {
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		capturedOpts = opts
+		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("OUTPUT_DIR", tmpDir)
+	t.Setenv("KUBECTL_CONTEXT", "env-context")
+
+	err := runExtract([]string{})
+	if err != nil {
+		t.Fatalf("runExtract error: %v", err)
+	}
+	if capturedOpts.OutputDir != tmpDir {
+		t.Errorf("expected env OUTPUT_DIR %q, got %q", tmpDir, capturedOpts.OutputDir)
+	}
+}
+
+func TestRunExtract_RequiresExplicitOutputDir(t *testing.T) {
+	clientOrig := buildClientFunc
+	defer func() {
+		buildClientFunc = clientOrig
+	}()
+
+	called := false
+	buildClientFunc = func(kubeContext string) (*apiextensionsclient.Clientset, error) {
+		called = true
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+
+	t.Setenv("OUTPUT_DIR", "")
+	t.Setenv("KUBECTL_CONTEXT", "")
+
+	err := runExtract(nil)
+	if err == nil {
+		t.Fatal("expected runExtract error")
+	}
+	if !strings.Contains(err.Error(), "OUTPUT_DIR is required") {
+		t.Fatalf("expected required output dir error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "pass --output-dir") {
+		t.Fatalf("expected actionable guidance, got %v", err)
+	}
+	if called {
+		t.Fatal("expected runExtract to fail before building kubernetes client")
+	}
+}
+
+func TestRunExtract_RejectsUnexpectedPositionalArgs(t *testing.T) {
+	clientOrig := buildClientFunc
+	defer func() {
+		buildClientFunc = clientOrig
+	}()
+
+	called := false
+	buildClientFunc = func(kubeContext string) (*apiextensionsclient.Clientset, error) {
+		called = true
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+
+	err := runExtract([]string{"--output-dir", t.TempDir(), "upload"})
+	if err == nil {
+		t.Fatal("expected runExtract error")
+	}
+	if !strings.Contains(err.Error(), "unexpected arguments") {
+		t.Fatalf("expected unexpected arguments error, got %v", err)
+	}
+	if called {
+		t.Fatal("expected runExtract to fail before building kubernetes client")
+	}
+}
+
+func TestRunConvert_WritesSchemas(t *testing.T) {
+	dir := t.TempDir()
+	inputDir := filepath.Join(dir, "input")
+	outputDir := filepath.Join(dir, "output")
+	if err := os.MkdirAll(inputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                secretName:
+                  type: string
+`
+	if err := os.WriteFile(filepath.Join(inputDir, "crd.yaml"), []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runConvert([]string{"--file", filepath.Join(inputDir, "crd.yaml"), "--output-dir", outputDir})
+	if err != nil {
+		t.Fatalf("runConvert error: %v", err)
+	}
+
+	schemaPath := filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")
+	if _, err := os.Stat(schemaPath); err != nil {
+		t.Fatalf("expected schema at %s: %v", schemaPath, err)
+	}
+
+	standalonePath := filepath.Join(outputDir, "master-standalone", "cert-manager.io-certificate-stable-v1.json")
+	if _, err := os.Stat(standalonePath); err != nil {
+		t.Fatalf("expected standalone schema at %s: %v", standalonePath, err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, ".generations")); !os.IsNotExist(err) {
+		t.Fatal("convert should not create .generations directory")
+	}
+}
+
+func TestRunConvert_WithDirFlag(t *testing.T) {
+	dir := t.TempDir()
+	inputDir := filepath.Join(dir, "input")
+	outputDir := filepath.Join(dir, "output")
+	if err := os.MkdirAll(inputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	if err := os.WriteFile(filepath.Join(inputDir, "crd.yaml"), []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runConvert([]string{"--dir", inputDir, "--output-dir", outputDir})
+	if err != nil {
+		t.Fatalf("runConvert error: %v", err)
+	}
+
+	schemaPath := filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")
+	if _, err := os.Stat(schemaPath); err != nil {
+		t.Fatalf("expected schema at %s: %v", schemaPath, err)
+	}
+}
+
+func TestRunConvert_FiltersByKind(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	multiCRDYAML := `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crds.yaml")
+	if err := os.WriteFile(inputFile, []byte(multiCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir, "--kind", "certificate"})
+	if err != nil {
+		t.Fatalf("runConvert error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected Certificate schema to exist")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "issuer_v1.json")); !os.IsNotExist(err) {
+		t.Fatal("expected Issuer schema to be filtered out")
+	}
+}
+
+func TestRunConvert_CombinesFileAndDir(t *testing.T) {
+	dir := t.TempDir()
+	inputDir := filepath.Join(dir, "input")
+	outputDir := filepath.Join(dir, "output")
+	if err := os.MkdirAll(inputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	certCRD := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	issuerCRD := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	singleFile := filepath.Join(dir, "cert.yaml")
+	if err := os.WriteFile(singleFile, []byte(certCRD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "issuer.yaml"), []byte(issuerCRD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runConvert([]string{"--file", singleFile, "--dir", inputDir, "--output-dir", outputDir})
+	if err != nil {
+		t.Fatalf("runConvert error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected Certificate schema from --file")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "issuer_v1.json")); err != nil {
+		t.Fatal("expected Issuer schema from --dir")
+	}
+}
+
+func TestRunConvert_RequiresOutputDir(t *testing.T) {
+	err := runConvert([]string{"--file", "crd.yaml"})
+	if err == nil {
+		t.Fatal("expected error when --output-dir is missing")
+	}
+	if !strings.Contains(err.Error(), "output-dir") {
+		t.Errorf("expected error about output-dir, got: %v", err)
+	}
+}
+
+func TestRunConvert_RequiresInput(t *testing.T) {
+	err := runConvert([]string{"--output-dir", "/tmp/out"})
+	if err == nil {
+		t.Fatal("expected error when no input is specified")
+	}
+	if !strings.Contains(err.Error(), "file") || !strings.Contains(err.Error(), "dir") {
+		t.Errorf("expected error mentioning --file or --dir, got: %v", err)
+	}
+}
+
+func TestRunConvert_WithRender(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir, "--render"})
+	if err != nil {
+		t.Fatalf("runConvert --render error: %v", err)
+	}
+
+	// JSON schema should exist
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected JSON schema file")
+	}
+
+	// HTML schema page should exist
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.html")); err != nil {
+		t.Fatal("expected rendered HTML schema page")
+	}
+
+	// Index page should exist
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); err != nil {
+		t.Fatal("expected generated index.html")
+	}
+}
+
+func TestRunConvert_CleansStaleSchemas(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	multiCRDYAML := `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crds.yaml")
+	if err := os.WriteFile(inputFile, []byte(multiCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run: both CRDs
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "issuer_v1.json")); err != nil {
+		t.Fatal("expected Issuer schema after first run")
+	}
+
+	// Second run: only Certificate — stale Issuer should be removed
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir, "--kind", "certificate"}); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected Certificate schema after second run")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "issuer_v1.json")); !os.IsNotExist(err) {
+		t.Fatal("expected Issuer schema to be cleaned up after filtered second run")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "master-standalone", "cert-manager.io-issuer-stable-v1.json")); !os.IsNotExist(err) {
+		t.Fatal("expected standalone Issuer schema to be cleaned up")
+	}
+}
+
+func TestRunConvert_CleansStaleOnEmptyFilter(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run: generates Certificate schemas
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected schema after first run")
+	}
+
+	// Second run: filter matches nothing — stale output should still be cleaned
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir, "--kind", "nonexistent"}); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io")); !os.IsNotExist(err) {
+		t.Fatal("expected stale group directory to be cleaned even when filter matches nothing")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "master-standalone")); !os.IsNotExist(err) {
+		t.Fatal("expected stale master-standalone to be cleaned")
+	}
+}
+
+func TestRunConvert_PreservesUserFiles(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create user files that should not be deleted — including a directory
+	// with a dot in the name to verify we don't use dot-heuristics
+	if err := os.WriteFile(filepath.Join(outputDir, "README.md"), []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(outputDir, "my.scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "my.scripts", "validate.sh"), []byte("#!/bin/sh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+
+	// Second run — user files must survive cleanup of the first run's manifest
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+
+	// Generated output should exist
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected generated schema")
+	}
+
+	// User files should be preserved across both runs
+	data, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
+	if err != nil {
+		t.Fatal("expected README.md to be preserved after two runs")
+	}
+	if string(data) != "keep me" {
+		t.Fatalf("README.md content changed: %q", data)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "my.scripts", "validate.sh")); err != nil {
+		t.Fatal("expected my.scripts/validate.sh to be preserved after two runs")
+	}
+}
+
+func TestRunConvert_PreservesUserNamedFiles(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create user files with names that match render artifacts
+	if err := os.WriteFile(filepath.Join(outputDir, "index.html"), []byte("my landing page"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "favicon.svg"), []byte("my icon"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run — no prior manifest, user files should survive
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+
+	// Second run — manifest exists from first run, user files must still survive
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "index.html"))
+	if err != nil {
+		t.Fatal("expected user index.html to be preserved after two runs")
+	}
+	if string(data) != "my landing page" {
+		t.Fatalf("index.html was overwritten: %q", data)
+	}
+	data, err = os.ReadFile(filepath.Join(outputDir, "favicon.svg"))
+	if err != nil {
+		t.Fatal("expected user favicon.svg to be preserved after two runs")
+	}
+	if string(data) != "my icon" {
+		t.Fatalf("favicon.svg was overwritten: %q", data)
+	}
+}
+
+func TestRunConvert_CorruptManifest_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run produces output
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+
+	// Corrupt the manifest
+	if err := os.WriteFile(filepath.Join(outputDir, "_meta", "convert-manifest.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run should fail with a clear error about the corrupt manifest
+	err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir})
+	if err == nil {
+		t.Fatal("expected error for corrupt manifest")
+	}
+	if !strings.Contains(err.Error(), "manifest") {
+		t.Errorf("expected error mentioning manifest, got: %v", err)
+	}
+}
+
+func TestRunConvert_PreservesUserFilesInsideGeneratedDirs(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run creates cert-manager.io/
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+
+	// User adds a file inside the generated directory
+	if err := os.WriteFile(filepath.Join(outputDir, "cert-manager.io", "README.md"), []byte("user notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run should clean generated files but preserve the user's README.md
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+
+	// Generated schema should be freshly written
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected schema to exist after second run")
+	}
+
+	// User file inside generated directory should survive
+	data, err := os.ReadFile(filepath.Join(outputDir, "cert-manager.io", "README.md"))
+	if err != nil {
+		t.Fatal("expected user README.md inside generated dir to be preserved")
+	}
+	if string(data) != "user notes" {
+		t.Fatalf("README.md content changed: %q", data)
+	}
+}
+
+func TestRunConvert_CleansRenderArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	crdYAML := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte(crdYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run with --render
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir, "--render"}); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); err != nil {
+		t.Fatal("expected index.html after render run")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "favicon.svg")); err != nil {
+		t.Fatal("expected favicon.svg after render run")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "schema-search.js")); err != nil {
+		t.Fatal("expected schema-search.js after render run")
+	}
+
+	// Second run without --render — all render artifacts should be cleaned
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); !os.IsNotExist(err) {
+		t.Fatal("expected index.html to be cleaned after non-render run")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "favicon.svg")); !os.IsNotExist(err) {
+		t.Fatal("expected favicon.svg to be cleaned after non-render run")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "schema-search.js")); !os.IsNotExist(err) {
+		t.Fatal("expected schema-search.js to be cleaned after non-render run")
+	}
+	// JSON schema should still be present
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected schema to exist after non-render run")
+	}
+}
+
+func TestRunConvert_ValidatesOutputDir(t *testing.T) {
+	dir := t.TempDir()
+	inputFile := filepath.Join(dir, "crd.yaml")
+	if err := os.WriteFile(inputFile, []byte("apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current working directory should be rejected
+	err := runConvert([]string{"--file", inputFile, "--output-dir", "."})
+	if err == nil {
+		t.Fatal("expected error for unsafe output-dir '.'")
 	}
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+)
+
+func init() {
+	registerCommand("preview", runPreview)
+	if scaffoldPreviewFunc == nil {
+		scaffoldPreviewFunc = scaffoldSampleData
+	}
+	if preparePreviewSiteFunc == nil {
+		preparePreviewSiteFunc = preparePreviewSite
+	}
+}
+
+func runPreview(args []string) error {
+	outputDir, explicit, err := parseOutputDirArg("preview", args, "")
+	if err != nil {
+		return err
+	}
+	if explicit {
+		if err := requireExistingOutputDir(outputDir, "Pass --output-dir to a pre-created directory"); err != nil {
+			return err
+		}
+	}
+	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
+	serveDir, cleanup, err := preparePreviewSiteFunc(outputDir, basePath, os.Getenv("SKIP_RENDER") != "true")
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	addr := getEnv("PREVIEW_ADDR", "127.0.0.1:8989")
+	var handler http.Handler
+	if basePath != "" {
+		mux := http.NewServeMux()
+		mux.Handle(basePath+"/", http.StripPrefix(basePath, http.FileServer(http.Dir(serveDir))))
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, basePath+"/", http.StatusFound)
+		})
+		handler = mux
+	} else {
+		handler = http.FileServer(http.Dir(serveDir))
+	}
+	srv := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	if basePath != "" {
+		slog.Info("serving preview", "addr", addr, "url", "http://"+addr+basePath+"/")
+	} else {
+		slog.Info("serving preview", "addr", addr)
+	}
+	err = srv.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func preparePreviewSite(outputDir, basePath string, render bool) (string, func(), error) {
+	if outputDir == "" {
+		rootDir, cleanup, err := newPreviewRoot()
+		if err != nil {
+			return "", nil, err
+		}
+		if err := preparePreviewGeneration(rootDir, basePath, render, scaffoldPreviewFunc, "scaffolding sample data"); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+		slog.Info("using sample data", "dir", rootDir, "active_dir", extractor.ActiveOutputDir(rootDir))
+		return extractor.ActiveOutputDir(rootDir), cleanup, nil
+	}
+
+	if err := validateOutputDirFunc(outputDir); err != nil {
+		return "", nil, err
+	}
+
+	activeDir, resolvedActiveDir, err := resolvePreviewActiveDir(outputDir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	rootDir, cleanup, err := newPreviewRoot()
+	if err != nil {
+		return "", nil, err
+	}
+	if err := preparePreviewGeneration(rootDir, basePath, render, func(generationDir string) error {
+		return copyPreviewFiles(resolvedActiveDir, generationDir)
+	}, "copying active output"); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	slog.Info("using existing output", "dir", outputDir, "active_dir", activeDir, "preview_dir", extractor.ActiveOutputDir(rootDir))
+	return extractor.ActiveOutputDir(rootDir), cleanup, nil
+}
+
+func newPreviewRoot() (string, func(), error) {
+	rootDir, err := os.MkdirTemp("", "crd-preview-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	return rootDir, func() {
+		_ = os.RemoveAll(rootDir)
+	}, nil
+}
+
+func resolvePreviewActiveDir(outputDir string) (string, string, error) {
+	activeDir := extractor.ActiveOutputDir(outputDir)
+	resolvedActiveDir, err := filepath.EvalSymlinks(activeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "", fmt.Errorf("active output %q does not exist; run extract first", activeDir)
+		}
+		return "", "", fmt.Errorf("resolving active output: %w", err)
+	}
+	return activeDir, resolvedActiveDir, nil
+}
+
+func preparePreviewGeneration(rootDir, basePath string, render bool, seed func(string) error, seedAction string) error {
+	generationDir, err := makePreviewGenerationDir(rootDir)
+	if err != nil {
+		return fmt.Errorf("creating preview generation: %w", err)
+	}
+	if err := seed(generationDir); err != nil {
+		return fmt.Errorf("%s: %w", seedAction, err)
+	}
+	if render {
+		slog.Info("rendering schema pages")
+		if err := renderPreviewFunc(generationDir, basePath); err != nil {
+			return fmt.Errorf("rendering schemas: %w", err)
+		}
+	}
+	slog.Info("generating index")
+	if err := generatePreviewFunc(generationDir, basePath); err != nil {
+		return fmt.Errorf("generating index: %w", err)
+	}
+	if err := activatePreviewGeneration(rootDir, generationDir); err != nil {
+		return fmt.Errorf("activating preview generation: %w", err)
+	}
+	return nil
+}
+
+func makePreviewGenerationDir(outputDir string) (string, error) {
+	generationsDir := filepath.Join(outputDir, ".generations")
+	if err := os.MkdirAll(generationsDir, 0o755); err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(generationsDir, "preview-")
+}
+
+func activatePreviewGeneration(outputDir, generationDir string) error {
+	currentPath := extractor.ActiveOutputDir(outputDir)
+	tmpPath := filepath.Join(outputDir, ".current.tmp")
+	target := filepath.Join(".generations", filepath.Base(generationDir))
+
+	_ = os.Remove(tmpPath)
+	if err := os.Symlink(target, tmpPath); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, currentPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func copyPreviewFiles(srcDir, dstDir string) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+
+		dstPath := filepath.Join(dstDir, rel)
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+		return copyPreviewFile(path, dstPath, info.Mode())
+	})
+}
+
+func copyPreviewFile(srcPath, dstPath string, mode os.FileMode) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = src.Close()
+	}()
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return err
+	}
+
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = dst.Close()
+	}()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+	return nil
+}
+
+func scaffoldSampleData(dir string) error {
+	type sampleSchema struct {
+		file string
+		kind string
+	}
+
+	sampleGroups := map[string][]sampleSchema{
+		"cert-manager.io": {
+			{file: "certificate_v1.json", kind: "Certificate"},
+			{file: "clusterissuer_v1.json", kind: "ClusterIssuer"},
+			{file: "issuer_v1.json", kind: "Issuer"},
+		},
+		"monitoring.coreos.com": {
+			{file: "alertmanager_v1.json", kind: "Alertmanager"},
+			{file: "podmonitor_v1.json", kind: "PodMonitor"},
+			{file: "prometheus_v1.json", kind: "Prometheus"},
+			{file: "servicemonitor_v1.json", kind: "ServiceMonitor"},
+		},
+		"helm.toolkit.fluxcd.io": {
+			{file: "helmrelease_v2.json", kind: "HelmRelease"},
+			{file: "helmrelease_v2beta1.json", kind: "HelmRelease"},
+		},
+		"source.toolkit.fluxcd.io": {
+			{file: "gitrepository_v1.json", kind: "GitRepository"},
+			{file: "helmchart_v1.json", kind: "HelmChart"},
+			{file: "helmrepository_v1.json", kind: "HelmRepository"},
+			{file: "ocirepository_v1beta2.json", kind: "OCIRepository"},
+		},
+		"kustomize.toolkit.fluxcd.io": {
+			{file: "kustomization_v1.json", kind: "Kustomization"},
+		},
+		"cilium.io": {
+			{file: "ciliumnetworkpolicy_v2.json", kind: "CiliumNetworkPolicy"},
+			{file: "ciliumclusterwidenetworkpolicy_v2.json", kind: "CiliumClusterwideNetworkPolicy"},
+			{file: "ciliumendpoint_v2.json", kind: "CiliumEndpoint"},
+		},
+		"traefik.io": {
+			{file: "ingressroute_v1alpha1.json", kind: "IngressRoute"},
+			{file: "middleware_v1alpha1.json", kind: "Middleware"},
+			{file: "tlsoption_v1alpha1.json", kind: "TLSOption"},
+		},
+		"external-secrets.io": {
+			{file: "externalsecret_v1beta1.json", kind: "ExternalSecret"},
+			{file: "clustersecretstore_v1beta1.json", kind: "ClusterSecretStore"},
+			{file: "secretstore_v1beta1.json", kind: "SecretStore"},
+		},
+		"metallb.io": {
+			{file: "ipaddresspool_v1beta1.json", kind: "IPAddressPool"},
+			{file: "l2advertisement_v1beta1.json", kind: "L2Advertisement"},
+		},
+		"volsync.backube": {
+			{file: "replicationsource_v1alpha1.json", kind: "ReplicationSource"},
+			{file: "replicationdestination_v1alpha1.json", kind: "ReplicationDestination"},
+		},
+	}
+	kinds := make(map[string]string)
+	for group, files := range sampleGroups {
+		groupDir := filepath.Join(dir, group)
+		if err := os.MkdirAll(groupDir, 0o755); err != nil {
+			return fmt.Errorf("creating group dir %s: %w", group, err)
+		}
+		for _, schema := range files {
+			path := filepath.Join(groupDir, schema.file)
+			if err := os.WriteFile(path, []byte(`{"type":"object"}`), 0o644); err != nil {
+				return fmt.Errorf("writing %s/%s: %w", group, schema.file, err)
+			}
+			kinds[filepath.ToSlash(filepath.Join(group, schema.file))] = schema.kind
+		}
+	}
+	manifestDir := filepath.Join(dir, "_meta")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		return fmt.Errorf("creating metadata dir: %w", err)
+	}
+	manifestBytes, err := json.MarshalIndent(kinds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding kind manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "kinds.json"), append(manifestBytes, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing kind manifest: %w", err)
+	}
+	return nil
+}

--- a/cmd/run_flow_test.go
+++ b/cmd/run_flow_test.go
@@ -31,16 +31,109 @@ func TestRunAll_SkipsUploadOnNoopBuild(t *testing.T) {
 	}
 
 	called := false
-	publishOutputFunc = func() error {
+	publishOutputFunc = func(string) error {
 		called = true
 		return nil
 	}
 
-	if err := runAll(); err != nil {
+	dir := t.TempDir()
+	t.Setenv("OUTPUT_DIR", dir)
+
+	if err := runAll(nil); err != nil {
 		t.Fatalf("runAll error: %v", err)
 	}
 	if called {
 		t.Fatal("expected publish to be skipped for no-op build")
+	}
+}
+
+func TestRunAll_RequiresPreexistingOutputDir(t *testing.T) {
+	clientOrig := buildClientFunc
+	defer func() {
+		buildClientFunc = clientOrig
+	}()
+
+	called := false
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		called = true
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+
+	missing := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("OUTPUT_DIR", missing)
+
+	err := runAll(nil)
+	if err == nil {
+		t.Fatal("expected runAll error")
+	}
+	if !strings.Contains(err.Error(), "must already exist") {
+		t.Fatalf("expected explicit missing output dir error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Set OUTPUT_DIR or pass --output-dir") {
+		t.Fatalf("expected actionable error, got %v", err)
+	}
+	if called {
+		t.Fatal("expected runAll to fail before building kubernetes client")
+	}
+}
+
+func TestRunAll_OutputDirFlagOverridesEnvVar(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	publishOrig := publishOutputFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+		publishOutputFunc = publishOrig
+	}()
+
+	var captured extractor.SiteBuildOptions
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		captured = opts
+		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
+	}
+	publishOutputFunc = func(string) error {
+		t.Fatal("publish should not be called for noop build")
+		return nil
+	}
+
+	envDir := t.TempDir()
+	flagDir := t.TempDir()
+	t.Setenv("OUTPUT_DIR", envDir)
+
+	if err := runAll([]string{"--output-dir", flagDir}); err != nil {
+		t.Fatalf("runAll error: %v", err)
+	}
+	if captured.OutputDir != flagDir {
+		t.Fatalf("expected flag output dir %q, got %q", flagDir, captured.OutputDir)
+	}
+}
+
+func TestRunAll_RejectsUnexpectedPositionalArgs(t *testing.T) {
+	clientOrig := buildClientFunc
+	defer func() {
+		buildClientFunc = clientOrig
+	}()
+
+	called := false
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		called = true
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+
+	dir := t.TempDir()
+	err := runAll([]string{"--output-dir", dir, "upload"})
+	if err == nil {
+		t.Fatal("expected runAll error")
+	}
+	if !strings.Contains(err.Error(), "unexpected arguments") {
+		t.Fatalf("expected unexpected arguments error, got %v", err)
+	}
+	if called {
+		t.Fatal("expected runAll to fail before building kubernetes client")
 	}
 }
 
@@ -51,7 +144,6 @@ func TestRunPreview_ValidatesExplicitOutputDir(t *testing.T) {
 	}()
 
 	dir := t.TempDir()
-	t.Setenv("OUTPUT_DIR", dir)
 	t.Setenv("SKIP_RENDER", "true")
 
 	validateOutputDirFunc = func(path string) error {
@@ -61,7 +153,7 @@ func TestRunPreview_ValidatesExplicitOutputDir(t *testing.T) {
 		return fmt.Errorf("unsafe output dir")
 	}
 
-	err := runPreview()
+	err := runPreview([]string{"--output-dir", dir})
 	if err == nil {
 		t.Fatal("expected runPreview error")
 	}
@@ -71,6 +163,142 @@ func TestRunPreview_ValidatesExplicitOutputDir(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dir, "index.html")); !os.IsNotExist(err) {
 		t.Fatalf("expected preview to stop before mutating output dir, got err=%v", err)
+	}
+}
+
+func TestRunPreview_IgnoresOutputDirEnvWithoutFlag(t *testing.T) {
+	prepareOrig := preparePreviewSiteFunc
+	validateOrig := validateOutputDirFunc
+	defer func() {
+		preparePreviewSiteFunc = prepareOrig
+		validateOutputDirFunc = validateOrig
+	}()
+
+	envDir := t.TempDir()
+	t.Setenv("OUTPUT_DIR", envDir)
+	t.Setenv("PREVIEW_ADDR", "127.0.0.1:0")
+	t.Setenv("SKIP_RENDER", "true")
+
+	validateOutputDirFunc = func(path string) error {
+		t.Fatalf("did not expect validator to run for ambient OUTPUT_DIR %q", path)
+		return nil
+	}
+
+	called := false
+	preparePreviewSiteFunc = func(outputDir, basePath string, render bool) (string, func(), error) {
+		called = true
+		if outputDir != "" {
+			t.Fatalf("expected ambient OUTPUT_DIR to be ignored, got %q", outputDir)
+		}
+		return "", func() {}, fmt.Errorf("preview stub stop")
+	}
+
+	err := runPreview(nil)
+	if err == nil {
+		t.Fatal("expected runPreview error")
+	}
+	if err.Error() != "preview stub stop" {
+		t.Fatalf("expected stub error, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected preparePreviewSite to be called")
+	}
+}
+
+func TestRunPreview_OutputDirFlagOverridesEnvVar(t *testing.T) {
+	validateOrig := validateOutputDirFunc
+	defer func() {
+		validateOutputDirFunc = validateOrig
+	}()
+
+	envDir := t.TempDir()
+	flagDir := t.TempDir()
+	t.Setenv("OUTPUT_DIR", envDir)
+	t.Setenv("SKIP_RENDER", "true")
+
+	validateOutputDirFunc = func(path string) error {
+		if path != flagDir {
+			t.Fatalf("expected validator to receive %q, got %q", flagDir, path)
+		}
+		return fmt.Errorf("preview stop")
+	}
+
+	err := runPreview([]string{"--output-dir", flagDir})
+	if err == nil {
+		t.Fatal("expected runPreview error")
+	}
+	if err.Error() != "preview stop" {
+		t.Fatalf("expected validator error, got %v", err)
+	}
+}
+
+func TestRunPreview_RejectsExplicitEmptyOutputDir(t *testing.T) {
+	err := runPreview([]string{"--output-dir", ""})
+	if err == nil {
+		t.Fatal("expected runPreview error")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Fatalf("expected empty output dir error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Pass --output-dir") {
+		t.Fatalf("expected actionable guidance, got %v", err)
+	}
+	if strings.Contains(err.Error(), "Set OUTPUT_DIR") {
+		t.Fatalf("did not expect preview error to mention ambient OUTPUT_DIR, got %v", err)
+	}
+}
+
+func TestRunUpload_OutputDirFlagOverridesEnvVar(t *testing.T) {
+	envDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("OUTPUT_DIR", envDir)
+	t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+
+	err := runUpload([]string{"--output-dir", missing})
+	if err == nil {
+		t.Fatal("expected runUpload error")
+	}
+	if !strings.Contains(err.Error(), "must already exist") {
+		t.Fatalf("expected missing output dir error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "CLOUDFLARE_API_TOKEN") {
+		t.Fatalf("expected output-dir validation before credential checks, got %v", err)
+	}
+}
+
+func TestRunUpload_RejectsNonDirectoryOutputDirWithGuidance(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "output-file")
+	if err := os.WriteFile(file, []byte("not-a-dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runUpload([]string{"--output-dir", file})
+	if err == nil {
+		t.Fatal("expected runUpload error")
+	}
+	if !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("expected non-directory error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Set OUTPUT_DIR or pass --output-dir") {
+		t.Fatalf("expected actionable guidance, got %v", err)
+	}
+}
+
+func TestRunWatch_OutputDirFlagOverridesEnvVar(t *testing.T) {
+	envDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("OUTPUT_DIR", envDir)
+
+	err := runWatch([]string{"--output-dir", missing})
+	if err == nil {
+		t.Fatal("expected runWatch error")
+	}
+	if !strings.Contains(err.Error(), "must already exist") {
+		t.Fatalf("expected missing output dir error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "POD_NAME") || strings.Contains(err.Error(), "building kubeconfig") {
+		t.Fatalf("expected output-dir validation before runtime setup, got %v", err)
 	}
 }
 
@@ -249,6 +477,98 @@ func TestPreparePreviewSite_FailureDoesNotMutateExplicitOutputDir(t *testing.T) 
 		t.Fatalf("expected render error, got %v", err)
 	}
 	assertPreviewSourceUnchanged(t, rootDir)
+}
+
+func TestRunAll_SkipsUploadWhenNoCredentials(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	publishOrig := publishOutputFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+		publishOutputFunc = publishOrig
+	}()
+
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		return extractor.SiteBuildResult{Status: extractor.BuildResultBuilt, SchemaCount: 5}, nil
+	}
+
+	called := false
+	publishOutputFunc = func(string) error {
+		called = true
+		return nil
+	}
+
+	t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+	t.Setenv("OUTPUT_DIR", t.TempDir())
+
+	if err := runAll(nil); err != nil {
+		t.Fatalf("runAll error: %v", err)
+	}
+	if called {
+		t.Fatal("expected publish to be skipped when credentials are missing")
+	}
+}
+
+func TestRunAll_UploadsWhenCredentialsPresent(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	publishOrig := publishOutputFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+		publishOutputFunc = publishOrig
+	}()
+
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		return extractor.SiteBuildResult{Status: extractor.BuildResultBuilt, SchemaCount: 5}, nil
+	}
+
+	called := false
+	publishOutputFunc = func(string) error {
+		called = true
+		return nil
+	}
+
+	t.Setenv("CLOUDFLARE_API_TOKEN", "test-token")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "test-account")
+	t.Setenv("OUTPUT_DIR", t.TempDir())
+
+	if err := runAll(nil); err != nil {
+		t.Fatalf("runAll error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected publish to be called when credentials are present")
+	}
+}
+
+func TestRunAll_BuildError_PrintsGuidance(t *testing.T) {
+	clientOrig := buildClientFunc
+	defer func() {
+		buildClientFunc = clientOrig
+	}()
+
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		return nil, fmt.Errorf("unable to load kubeconfig")
+	}
+
+	t.Setenv("OUTPUT_DIR", t.TempDir())
+
+	err := runAll(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "extract") || !strings.Contains(errMsg, "convert") {
+		t.Errorf("expected guidance mentioning extract and convert commands, got: %s", errMsg)
+	}
 }
 
 func TestPreparePreviewSite_RequiresCurrentForExplicitOutputDir(t *testing.T) {

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+	"github.com/sholdee/crd-schema-publisher/publisher"
+	"github.com/sholdee/crd-schema-publisher/watcher"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+)
+
+func init() {
+	registerCommand("run", runAll)
+	registerCommand("extract", runExtract)
+	registerCommand("upload", runUpload)
+	registerCommand("watch", runWatch)
+	if publishOutputFunc == nil {
+		publishOutputFunc = func(outputDir string) error {
+			return runUpload([]string{"--output-dir", outputDir})
+		}
+	}
+}
+
+func runExtract(args []string) error {
+	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
+	outputDir := fs.String("output-dir", os.Getenv("OUTPUT_DIR"), "output directory")
+	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
+	kubeContext := fs.String("context", os.Getenv("KUBECTL_CONTEXT"), "Kubernetes context")
+	skipRender := fs.Bool("skip-render", os.Getenv("SKIP_RENDER") == "true", "skip HTML rendering")
+	kind := fs.String("kind", "", "filter by kind (comma-separated, case-insensitive)")
+	group := fs.String("group", "", "filter by group (comma-separated, case-insensitive)")
+	version := fs.String("version", "", "filter by version (comma-separated, case-insensitive)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if extras := fs.Args(); len(extras) > 0 {
+		return fmt.Errorf("unexpected arguments for extract: %s", strings.Join(extras, " "))
+	}
+	if err := requireConfiguredOutputDir(*outputDir, "Provide a writable directory for extracted schemas"); err != nil {
+		return err
+	}
+
+	slog.Info("building kubernetes client")
+	client, err := buildClientFunc(*kubeContext)
+	if err != nil {
+		return fmt.Errorf("building client: %w", err)
+	}
+
+	filter := extractor.ParseFilter(*kind, *group, *version)
+
+	result, err := buildSiteFunc(extractor.SiteBuildOptions{
+		Lister:    client.ApiextensionsV1().CustomResourceDefinitions(),
+		OutputDir: *outputDir,
+		BasePath:  normalizeBasePath(*basePath),
+		Render:    !*skipRender,
+		Filter:    filter,
+	})
+	if err != nil {
+		return err
+	}
+	if result.Status == extractor.BuildResultNoop {
+		slog.Info("no CRDs found, leaving existing output untouched")
+		return nil
+	}
+
+	slog.Info("extract complete", "count", result.SchemaCount, "dir", *outputDir)
+	return nil
+}
+
+func runBuild(outputDir string) (extractor.SiteBuildResult, error) {
+	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
+	kubeContext := os.Getenv("KUBECTL_CONTEXT")
+
+	slog.Info("building kubernetes client")
+	client, err := buildClientFunc(kubeContext)
+	if err != nil {
+		return extractor.SiteBuildResult{}, fmt.Errorf("building client: %w", err)
+	}
+
+	result, err := buildSiteFunc(extractor.SiteBuildOptions{
+		Lister:    client.ApiextensionsV1().CustomResourceDefinitions(),
+		OutputDir: outputDir,
+		BasePath:  basePath,
+		Render:    os.Getenv("SKIP_RENDER") != "true",
+	})
+	if err != nil {
+		return extractor.SiteBuildResult{}, err
+	}
+	if result.Status == extractor.BuildResultNoop {
+		slog.Info("no CRDs found, leaving existing output untouched")
+		return result, nil
+	}
+
+	slog.Info("extract complete", "count", result.SchemaCount, "dir", outputDir)
+	return result, nil
+}
+
+func runUpload(args []string) error {
+	outputDir, _, err := parseOutputDirArg("upload", args, getEnv("OUTPUT_DIR", "/output"))
+	if err != nil {
+		return err
+	}
+	if err := requireExistingOutputDir(outputDir, "Set OUTPUT_DIR or pass --output-dir to a pre-created directory"); err != nil {
+		return err
+	}
+
+	apiToken, err := requireEnv("CLOUDFLARE_API_TOKEN")
+	if err != nil {
+		return err
+	}
+	accountID, err := requireEnv("CLOUDFLARE_ACCOUNT_ID")
+	if err != nil {
+		return err
+	}
+	projectName := getEnv("CF_PAGES_PROJECT", "kubernetes-schemas")
+
+	p := &publisher.Publisher{
+		APIToken:    apiToken,
+		AccountID:   accountID,
+		ProjectName: projectName,
+	}
+
+	return p.Publish(outputDir)
+}
+
+func runWatch(args []string) error {
+	outputDir, _, err := parseOutputDirArg("watch", args, getEnv("OUTPUT_DIR", "/output"))
+	if err != nil {
+		return err
+	}
+	if err := requireExistingOutputDir(outputDir, "Set OUTPUT_DIR or pass --output-dir to a pre-created directory"); err != nil {
+		return err
+	}
+	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
+	kubeContext := os.Getenv("KUBECTL_CONTEXT")
+
+	podName, err := requireEnv("POD_NAME")
+	if err != nil {
+		return err
+	}
+	podNamespace, err := requireEnv("POD_NAMESPACE")
+	if err != nil {
+		return err
+	}
+
+	debounceSeconds := 15
+	if v := os.Getenv("DEBOUNCE_SECONDS"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid DEBOUNCE_SECONDS: %w", err)
+		}
+		debounceSeconds = parsed
+	}
+
+	leaseName := getEnv("LEASE_NAME", "crd-schema-publisher")
+	healthPort := getEnv("HEALTH_PORT", "8080")
+
+	cfg, err := extractor.BuildConfig(kubeContext)
+	if err != nil {
+		return fmt.Errorf("building kubeconfig: %w", err)
+	}
+
+	client, err := apiextensionsclient.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("building apiextensions client: %w", err)
+	}
+
+	var pub *publisher.Publisher
+	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if apiToken != "" && accountID != "" {
+		pub = &publisher.Publisher{
+			APIToken:    apiToken,
+			AccountID:   accountID,
+			ProjectName: getEnv("CF_PAGES_PROJECT", "kubernetes-schemas"),
+		}
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	return watcher.Run(ctx, watcher.Config{
+		Client:     client,
+		KubeConfig: cfg,
+		OutputDir:  outputDir,
+		BasePath:   basePath,
+		Publisher:  pub,
+		Debounce:   time.Duration(debounceSeconds) * time.Second,
+		Namespace:  podNamespace,
+		LeaseName:  leaseName,
+		PodName:    podName,
+		HealthPort: healthPort,
+	})
+}
+
+func runAll(args []string) error {
+	outputDir, _, err := parseOutputDirArg("run", args, getEnv("OUTPUT_DIR", "/output"))
+	if err != nil {
+		return err
+	}
+	if err := requireExistingOutputDir(outputDir, "Set OUTPUT_DIR or pass --output-dir to a pre-created directory"); err != nil {
+		return err
+	}
+
+	result, err := runBuild(outputDir)
+	if err != nil {
+		return fmt.Errorf("%w\n\n"+
+			"The \"run\" command extracts schemas from a Kubernetes cluster and uploads to Cloudflare Pages.\n\n"+
+			"To extract schemas from a cluster:\n"+
+			"  crd-schema-publisher extract --output-dir ./schemas\n\n"+
+			"To convert CRD YAML files directly:\n"+
+			"  crd-schema-publisher convert --file crd.yaml --output-dir ./schemas\n\n"+
+			"Use \"crd-schema-publisher --help\" for all commands", err)
+	}
+	if result.Status == extractor.BuildResultNoop {
+		return nil
+	}
+
+	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
+	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+	if apiToken == "" || accountID == "" {
+		slog.Info("skipping upload: CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID not set")
+		return nil
+	}
+
+	if err := publishOutputFunc(outputDir); err != nil {
+		return fmt.Errorf("upload: %w", err)
+	}
+	return nil
+}

--- a/extractor/build.go
+++ b/extractor/build.go
@@ -37,6 +37,7 @@ type SiteBuildOptions struct {
 	OutputDir string
 	BasePath  string
 	Render    bool
+	Filter    SchemaFilter
 }
 
 type SiteBuildResult struct {
@@ -56,6 +57,7 @@ func BuildSite(opts SiteBuildOptions) (SiteBuildResult, error) {
 	if err != nil {
 		return SiteBuildResult{}, fmt.Errorf("listing CRDs: %w", err)
 	}
+	crds = FilterCRDs(crds, opts.Filter)
 	if len(crds) == 0 {
 		return SiteBuildResult{Status: BuildResultNoop}, nil
 	}

--- a/extractor/filter.go
+++ b/extractor/filter.go
@@ -1,0 +1,91 @@
+package extractor
+
+import (
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type SchemaFilter struct {
+	Kinds    []string
+	Groups   []string
+	Versions []string
+}
+
+func ParseFilter(kinds, groups, versions string) SchemaFilter {
+	return SchemaFilter{
+		Kinds:    parseCSV(kinds),
+		Groups:   parseCSV(groups),
+		Versions: parseCSV(versions),
+	}
+}
+
+func parseCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.ToLower(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (f SchemaFilter) Matches(kind, group, version string) bool {
+	return matchesAny(f.Kinds, kind) && matchesAny(f.Groups, group) && matchesAny(f.Versions, version)
+}
+
+func matchesAny(filter []string, value string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	lower := strings.ToLower(value)
+	for _, f := range filter {
+		if f == lower {
+			return true
+		}
+	}
+	return false
+}
+
+func FilterCRDs(crds []apiextensionsv1.CustomResourceDefinition, f SchemaFilter) []apiextensionsv1.CustomResourceDefinition {
+	if f.Kinds == nil && f.Groups == nil && f.Versions == nil {
+		return crds
+	}
+
+	var result []apiextensionsv1.CustomResourceDefinition
+	for _, crd := range crds {
+		if !matchesAny(f.Kinds, crd.Spec.Names.Kind) {
+			continue
+		}
+		if !matchesAny(f.Groups, crd.Spec.Group) {
+			continue
+		}
+
+		if f.Versions == nil {
+			result = append(result, crd)
+			continue
+		}
+
+		var matchedVersions []apiextensionsv1.CustomResourceDefinitionVersion
+		for _, v := range crd.Spec.Versions {
+			if matchesAny(f.Versions, v.Name) {
+				matchedVersions = append(matchedVersions, v)
+			}
+		}
+		if len(matchedVersions) > 0 {
+			filtered := crd
+			filtered.Spec.Versions = matchedVersions
+			result = append(result, filtered)
+		}
+	}
+	return result
+}

--- a/extractor/filter_test.go
+++ b/extractor/filter_test.go
@@ -1,0 +1,136 @@
+package extractor
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseFilter_LowercasesValues(t *testing.T) {
+	f := ParseFilter("Certificate,Issuer", "Cert-Manager.IO", "V1")
+	if f.Kinds[0] != "certificate" || f.Kinds[1] != "issuer" {
+		t.Errorf("expected lowercased kinds, got %v", f.Kinds)
+	}
+	if f.Groups[0] != "cert-manager.io" {
+		t.Errorf("expected lowercased group, got %v", f.Groups)
+	}
+	if f.Versions[0] != "v1" {
+		t.Errorf("expected lowercased version, got %v", f.Versions)
+	}
+}
+
+func TestParseFilter_EmptyStringsProduceNilSlices(t *testing.T) {
+	f := ParseFilter("", "", "")
+	if f.Kinds != nil || f.Groups != nil || f.Versions != nil {
+		t.Errorf("expected nil slices for empty input, got kinds=%v groups=%v versions=%v", f.Kinds, f.Groups, f.Versions)
+	}
+}
+
+func TestSchemaFilter_MatchesAll_WhenEmpty(t *testing.T) {
+	f := ParseFilter("", "", "")
+	if !f.Matches("Certificate", "cert-manager.io", "v1") {
+		t.Error("empty filter should match everything")
+	}
+}
+
+func TestSchemaFilter_MatchesKind_CaseInsensitive(t *testing.T) {
+	f := ParseFilter("certificate", "", "")
+	if !f.Matches("Certificate", "cert-manager.io", "v1") {
+		t.Error("should match Certificate with lowercase filter")
+	}
+	if f.Matches("Issuer", "cert-manager.io", "v1") {
+		t.Error("should not match Issuer")
+	}
+}
+
+func TestSchemaFilter_ORWithinType_ANDAcrossTypes(t *testing.T) {
+	f := ParseFilter("certificate,issuer", "cert-manager.io", "")
+	if !f.Matches("Certificate", "cert-manager.io", "v1") {
+		t.Error("should match Certificate in cert-manager.io")
+	}
+	if !f.Matches("Issuer", "cert-manager.io", "v1") {
+		t.Error("should match Issuer in cert-manager.io")
+	}
+	if f.Matches("Certificate", "monitoring.coreos.com", "v1") {
+		t.Error("should not match Certificate in wrong group")
+	}
+}
+
+func TestSchemaFilter_VersionFilter(t *testing.T) {
+	f := ParseFilter("", "", "v1,v2")
+	if !f.Matches("Certificate", "cert-manager.io", "v1") {
+		t.Error("should match v1")
+	}
+	if !f.Matches("Certificate", "cert-manager.io", "v2") {
+		t.Error("should match v2")
+	}
+	if f.Matches("Certificate", "cert-manager.io", "v1beta1") {
+		t.Error("should not match v1beta1")
+	}
+}
+
+func testCRD(kind, group string, versions ...string) apiextensionsv1.CustomResourceDefinition {
+	crd := apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: kind + "." + group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: kind},
+		},
+	}
+	for _, v := range versions {
+		crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+			Name: v,
+			Schema: &apiextensionsv1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"},
+			},
+		})
+	}
+	return crd
+}
+
+func TestFilterCRDs_FiltersVersions(t *testing.T) {
+	crds := []apiextensionsv1.CustomResourceDefinition{
+		testCRD("Certificate", "cert-manager.io", "v1", "v1alpha2"),
+		testCRD("Issuer", "cert-manager.io", "v1"),
+		testCRD("Prometheus", "monitoring.coreos.com", "v1"),
+	}
+	f := ParseFilter("certificate", "", "v1")
+	result := FilterCRDs(crds, f)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 CRD, got %d", len(result))
+	}
+	if result[0].Spec.Names.Kind != "Certificate" {
+		t.Errorf("expected Certificate, got %s", result[0].Spec.Names.Kind)
+	}
+	if len(result[0].Spec.Versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(result[0].Spec.Versions))
+	}
+	if result[0].Spec.Versions[0].Name != "v1" {
+		t.Errorf("expected v1, got %s", result[0].Spec.Versions[0].Name)
+	}
+}
+
+func TestFilterCRDs_EmptyFilter_ReturnsAll(t *testing.T) {
+	crds := []apiextensionsv1.CustomResourceDefinition{
+		testCRD("Certificate", "cert-manager.io", "v1"),
+		testCRD("Prometheus", "monitoring.coreos.com", "v1"),
+	}
+	f := ParseFilter("", "", "")
+	result := FilterCRDs(crds, f)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 CRDs, got %d", len(result))
+	}
+}
+
+func TestFilterCRDs_NoMatch_ReturnsEmpty(t *testing.T) {
+	crds := []apiextensionsv1.CustomResourceDefinition{
+		testCRD("Certificate", "cert-manager.io", "v1"),
+	}
+	f := ParseFilter("nonexistent", "", "")
+	result := FilterCRDs(crds, f)
+	if len(result) != 0 {
+		t.Fatalf("expected 0 CRDs, got %d", len(result))
+	}
+}

--- a/extractor/parse.go
+++ b/extractor/parse.go
@@ -1,0 +1,210 @@
+package extractor
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+const (
+	// maxInputSize is the maximum total YAML input size (256 MB).
+	maxInputSize = 256 << 20
+	// maxDocuments is the maximum number of YAML documents in a single stream.
+	maxDocuments = 10_000
+)
+
+// countingReader wraps an io.Reader and tracks the total bytes read.
+type countingReader struct {
+	r     io.Reader
+	count int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.count += int64(n)
+	if cr.count > maxInputSize {
+		return n, fmt.Errorf("input exceeds maximum size of %d bytes", maxInputSize)
+	}
+	return n, err
+}
+
+// ParseCRDsFromReader decodes a multi-document YAML stream and returns all
+// CustomResourceDefinition documents. It also expands CustomResourceDefinitionList
+// and generic Kubernetes List documents such as kubectl get crds -o yaml.
+// Non-CRD documents are silently skipped. Malformed YAML causes an immediate
+// error. Input is capped at 256 MB and 10,000 documents. Uses a streaming YAML
+// decoder — documents are parsed one at a time without loading the entire input
+// into memory.
+func ParseCRDsFromReader(r io.Reader) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	cr := &countingReader{r: r}
+	dec := yamlv3.NewDecoder(cr)
+
+	var crds []apiextensionsv1.CustomResourceDefinition
+	docNum := 0
+
+	for {
+		var node yamlv3.Node
+		if err := dec.Decode(&node); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("parsing document %d: %w", docNum+1, err)
+		}
+		docNum++
+
+		if docNum > maxDocuments {
+			return nil, fmt.Errorf("input contains more than %d documents", maxDocuments)
+		}
+
+		docCRDs, err := parseCRDsFromDocumentNode(&node, docNum)
+		if err != nil {
+			return nil, err
+		}
+		crds = append(crds, docCRDs...)
+	}
+
+	return crds, nil
+}
+
+func parseCRDsFromDocumentNode(node *yamlv3.Node, docNum int) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	switch nodeKind(node) {
+	case "CustomResourceDefinition":
+		crd, err := parseCRDNode(node, docNum)
+		if err != nil {
+			return nil, err
+		}
+		return []apiextensionsv1.CustomResourceDefinition{crd}, nil
+	case "CustomResourceDefinitionList":
+		return parseCRDListNode(node, docNum)
+	case "List":
+		return parseCRDsFromGenericListNode(node, docNum)
+	default:
+		return nil, nil
+	}
+}
+
+func parseCRDNode(node *yamlv3.Node, docNum int) (apiextensionsv1.CustomResourceDefinition, error) {
+	raw, err := yamlv3.Marshal(node)
+	if err != nil {
+		return apiextensionsv1.CustomResourceDefinition{}, fmt.Errorf("re-encoding document %d: %w", docNum, err)
+	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := sigsyaml.Unmarshal(raw, &crd); err != nil {
+		return apiextensionsv1.CustomResourceDefinition{}, fmt.Errorf("parsing CRD in document %d: %w", docNum, err)
+	}
+	return crd, nil
+}
+
+func parseCRDListNode(node *yamlv3.Node, docNum int) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	raw, err := yamlv3.Marshal(node)
+	if err != nil {
+		return nil, fmt.Errorf("re-encoding document %d: %w", docNum, err)
+	}
+	var list apiextensionsv1.CustomResourceDefinitionList
+	if err := sigsyaml.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parsing CRD list in document %d: %w", docNum, err)
+	}
+	return list.Items, nil
+}
+
+func parseCRDsFromGenericListNode(node *yamlv3.Node, docNum int) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	if node.Kind == yamlv3.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yamlv3.MappingNode {
+		return nil, nil
+	}
+
+	var items *yamlv3.Node
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == "items" {
+			items = node.Content[i+1]
+			break
+		}
+	}
+	if items == nil {
+		return nil, nil
+	}
+	if items.Kind != yamlv3.SequenceNode {
+		return nil, fmt.Errorf("parsing Kubernetes list in document %d: items must be a sequence", docNum)
+	}
+
+	var crds []apiextensionsv1.CustomResourceDefinition
+	for i, item := range items.Content {
+		if nodeKind(item) != "CustomResourceDefinition" {
+			continue
+		}
+		crd, err := parseCRDNode(item, docNum)
+		if err != nil {
+			return nil, withCRDItemContext(err, i+1, docNum)
+		}
+		crds = append(crds, crd)
+	}
+	return crds, nil
+}
+
+func withCRDItemContext(err error, itemNum, docNum int) error {
+	return fmt.Errorf("parsing CRD item %d in document %d: %w", itemNum, docNum, err)
+}
+
+// nodeKind returns the top-level Kubernetes kind without fully deserializing
+// the document.
+func nodeKind(node *yamlv3.Node) string {
+	// Document nodes wrap the actual content
+	if node.Kind == yamlv3.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yamlv3.MappingNode {
+		return ""
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == "kind" {
+			return node.Content[i+1].Value
+		}
+	}
+	return ""
+}
+
+func ParseCRDsFromFiles(paths []string) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	var all []apiextensionsv1.CustomResourceDefinition
+	for _, path := range paths {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("opening %s: %w", path, err)
+		}
+		crds, err := ParseCRDsFromReader(f)
+		_ = f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+		all = append(all, crds...)
+	}
+	return all, nil
+}
+
+func ParseCRDsFromDir(dir string) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory %s: %w", dir, err)
+	}
+
+	var paths []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext == ".yaml" || ext == ".yml" {
+			paths = append(paths, filepath.Join(dir, entry.Name()))
+		}
+	}
+
+	return ParseCRDsFromFiles(paths)
+}

--- a/extractor/parse_test.go
+++ b/extractor/parse_test.go
@@ -1,0 +1,407 @@
+package extractor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const singleCRDYAML = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+`
+
+const multiDocYAML = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+
+const crdListYAML = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinitionList
+items:
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: certificates.cert-manager.io
+    spec:
+      group: cert-manager.io
+      names:
+        kind: Certificate
+        plural: certificates
+      scope: Namespaced
+      versions:
+        - name: v1
+          served: true
+          storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: issuers.cert-manager.io
+    spec:
+      group: cert-manager.io
+      names:
+        kind: Issuer
+        plural: issuers
+      scope: Namespaced
+      versions:
+        - name: v1
+          served: true
+          storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+`
+
+const kubectlCRDListYAML = `apiVersion: v1
+items:
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: certificates.cert-manager.io
+    spec:
+      group: cert-manager.io
+      names:
+        kind: Certificate
+        plural: certificates
+      scope: Namespaced
+      versions:
+        - name: v1
+          served: true
+          storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ignored
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: issuers.cert-manager.io
+    spec:
+      group: cert-manager.io
+      names:
+        kind: Issuer
+        plural: issuers
+      scope: Namespaced
+      versions:
+        - name: v1
+          served: true
+          storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+kind: List
+metadata:
+  resourceVersion: ""
+`
+
+func TestParseCRDsFromReader_SingleCRD(t *testing.T) {
+	crds, err := ParseCRDsFromReader(strings.NewReader(singleCRDYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 1 {
+		t.Fatalf("expected 1 CRD, got %d", len(crds))
+	}
+	if crds[0].Spec.Names.Kind != "Certificate" {
+		t.Errorf("expected Certificate, got %s", crds[0].Spec.Names.Kind)
+	}
+}
+
+func TestParseCRDsFromReader_MultiDocSkipsNonCRDs(t *testing.T) {
+	crds, err := ParseCRDsFromReader(strings.NewReader(multiDocYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 2 {
+		t.Fatalf("expected 2 CRDs (Namespace skipped), got %d", len(crds))
+	}
+	kinds := map[string]bool{}
+	for _, crd := range crds {
+		kinds[crd.Spec.Names.Kind] = true
+	}
+	if !kinds["Certificate"] || !kinds["Issuer"] {
+		t.Errorf("expected Certificate and Issuer, got %v", kinds)
+	}
+}
+
+func TestParseCRDsFromReader_CustomResourceDefinitionList(t *testing.T) {
+	crds, err := ParseCRDsFromReader(strings.NewReader(crdListYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 2 {
+		t.Fatalf("expected 2 CRDs from list, got %d", len(crds))
+	}
+	kinds := map[string]bool{}
+	for _, crd := range crds {
+		kinds[crd.Spec.Names.Kind] = true
+	}
+	if !kinds["Certificate"] || !kinds["Issuer"] {
+		t.Errorf("expected Certificate and Issuer, got %v", kinds)
+	}
+}
+
+func TestParseCRDsFromReader_KubectlGenericList(t *testing.T) {
+	crds, err := ParseCRDsFromReader(strings.NewReader(kubectlCRDListYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 2 {
+		t.Fatalf("expected 2 CRDs from kubectl list, got %d", len(crds))
+	}
+	kinds := map[string]bool{}
+	for _, crd := range crds {
+		kinds[crd.Spec.Names.Kind] = true
+	}
+	if !kinds["Certificate"] || !kinds["Issuer"] {
+		t.Errorf("expected Certificate and Issuer, got %v", kinds)
+	}
+}
+
+func TestParseCRDsFromReader_MalformedYAML_FailsFast(t *testing.T) {
+	malformed := "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nspec: [invalid"
+	_, err := ParseCRDsFromReader(strings.NewReader(malformed))
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestParseCRDsFromReader_EmptyInput(t *testing.T) {
+	crds, err := ParseCRDsFromReader(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 0 {
+		t.Fatalf("expected 0 CRDs, got %d", len(crds))
+	}
+}
+
+func TestParseCRDsFromReader_EmptyDocuments(t *testing.T) {
+	crds, err := ParseCRDsFromReader(strings.NewReader("---\n---\n---\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 0 {
+		t.Fatalf("expected 0 CRDs from empty documents, got %d", len(crds))
+	}
+}
+
+func TestParseCRDsFromReader_LongLines(t *testing.T) {
+	// CRDs with long lines (e.g., base64 blobs, deeply nested schemas) should
+	// parse correctly. The old bufio.Scanner had a 64KB line limit.
+	longValue := strings.Repeat("a", 128*1024) // 128KB single line
+	crd := fmt.Sprintf(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.example.io
+  annotations:
+    big-blob: "%s"
+spec:
+  group: example.io
+  names:
+    kind: Test
+    plural: tests
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`, longValue)
+
+	crds, err := ParseCRDsFromReader(strings.NewReader(crd))
+	if err != nil {
+		t.Fatalf("expected long-line CRD to parse, got: %v", err)
+	}
+	if len(crds) != 1 {
+		t.Fatalf("expected 1 CRD, got %d", len(crds))
+	}
+}
+
+func TestParseCRDsFromReader_DocumentCountLimit(t *testing.T) {
+	var buf strings.Builder
+	for range maxDocuments + 1 {
+		buf.WriteString("---\nkind: ConfigMap\n")
+	}
+	_, err := ParseCRDsFromReader(strings.NewReader(buf.String()))
+	if err == nil {
+		t.Fatal("expected error for too many documents")
+	}
+	if !strings.Contains(err.Error(), "documents") {
+		t.Errorf("expected document count error, got: %v", err)
+	}
+}
+
+func TestParseCRDsFromReader_ExactlyMaxDocuments(t *testing.T) {
+	var buf strings.Builder
+	for range maxDocuments {
+		buf.WriteString("---\nkind: ConfigMap\n")
+	}
+	// Should succeed — exactly at the limit, not over
+	_, err := ParseCRDsFromReader(strings.NewReader(buf.String()))
+	if err != nil {
+		t.Fatalf("expected %d documents to be accepted, got: %v", maxDocuments, err)
+	}
+}
+
+func TestParseCRDsFromReader_InputSizeLimit(t *testing.T) {
+	// Build input that exceeds maxInputSize: a valid CRD followed by padding
+	padding := strings.Repeat("# padding\n", maxInputSize/10+1)
+	input := singleCRDYAML + padding
+
+	_, err := ParseCRDsFromReader(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("expected error for oversized input")
+	}
+	if !strings.Contains(err.Error(), "maximum size") {
+		t.Errorf("expected size limit error, got: %v", err)
+	}
+}
+
+func TestParseCRDsFromReader_SeparatorWithTrailingWhitespace(t *testing.T) {
+	// YAML spec allows "--- " with trailing spaces as a document separator
+	input := "---   \napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: tests.example.io\nspec:\n  group: example.io\n  names:\n    kind: Test\n    plural: tests\n  scope: Namespaced\n  versions:\n    - name: v1\n      served: true\n      storage: true\n      schema:\n        openAPIV3Schema:\n          type: object\n"
+	crds, err := ParseCRDsFromReader(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 1 {
+		t.Fatalf("expected 1 CRD, got %d", len(crds))
+	}
+}
+
+func TestParseCRDsFromFiles_ReadsMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cert.yaml"), []byte(singleCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "multi.yaml"), []byte(multiDocYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	crds, err := ParseCRDsFromFiles([]string{
+		filepath.Join(dir, "cert.yaml"),
+		filepath.Join(dir, "multi.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 3 {
+		t.Fatalf("expected 3 CRDs total, got %d", len(crds))
+	}
+}
+
+func TestParseCRDsFromFiles_NonexistentFile_Fails(t *testing.T) {
+	_, err := ParseCRDsFromFiles([]string{"/nonexistent/crd.yaml"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestParseCRDsFromDir_ReadsYAMLFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "crd.yaml"), []byte(singleCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "crd2.yml"), []byte(singleCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), []byte("not yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	crds, err := ParseCRDsFromDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 2 {
+		t.Fatalf("expected 2 CRDs (.yaml + .yml), got %d", len(crds))
+	}
+}
+
+func TestParseCRDsFromDir_IgnoresSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "crd.yaml"), []byte(singleCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "nested.yaml"), []byte(singleCRDYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	crds, err := ParseCRDsFromDir(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(crds) != 1 {
+		t.Fatalf("expected 1 CRD (subdirectory ignored), got %d", len(crds))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.26.2
 
 require (
 	github.com/zeebo/blake3 v0.2.4
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -40,7 +42,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
@@ -48,5 +49,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )


### PR DESCRIPTION
## Summary
- Adds a standalone CLI conversion workflow for CRD YAML files, directories, stdin, and filtered schema output.
- Keeps cluster-backed extraction available while making local/offline conversion a first-class path for IDE and CI schema generation.
- Adds release binary artifact support and refreshes README guidance for installation, verification, command behavior, schema usage, and sidecar output paths.
- Supports `kubectl get crds -o yaml | crd-schema-publisher convert --file -` by parsing Kubernetes list output as well as standalone CRD documents.

## Test plan
- `go test ./... -count=1`
- `go vet ./...`
- pre-commit `golangci-lint` hook reported `0 issues`
- manually verified stdin conversion with captured `kubectl get crds -o yaml` output: `convert complete`, `count=177`