### PR TITLE
fix: align cronjob credential handling

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -24,6 +24,9 @@ jobs:
         run: helm template test charts/crd-schema-publisher --set existingSecret.name=test
 
       - name: Template (cronjob mode)
+        run: helm template test charts/crd-schema-publisher --set mode=cronjob
+
+      - name: Template (cronjob mode with Cloudflare)
         run: helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test
 
       - name: Template (all features)
@@ -43,7 +46,7 @@ jobs:
       - name: Verify mode isolation
         run: |
           # Cronjob mode must not produce controller-only resources
-          ROLE_COUNT=$(helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test | grep -c "^kind: Role$" || true)
+          ROLE_COUNT=$(helm template test charts/crd-schema-publisher --set mode=cronjob | grep -c "^kind: Role$" || true)
           if [[ "${ROLE_COUNT}" -ne 0 ]]; then
             echo "ERROR: cronjob mode should not produce Role resources"
             exit 1
@@ -72,6 +75,58 @@ jobs:
             exit 1
           fi
           echo "Network policy mutual exclusivity enforced"
+
+      - name: Verify optional Cloudflare env vars
+        run: |
+          CRON_EXTRACT_ONLY=$(helm template test charts/crd-schema-publisher --set mode=cronjob)
+          if grep -q "CLOUDFLARE_" <<< "${CRON_EXTRACT_ONLY}" || grep -q "CF_PAGES_PROJECT" <<< "${CRON_EXTRACT_ONLY}"; then
+            echo "ERROR: cronjob extract-only mode should not render Cloudflare env vars"
+            exit 1
+          fi
+          echo "CronJob extract-only mode omits Cloudflare env vars"
+
+          CRON_WITH_SECRET=$(helm template test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test)
+          if ! grep -q "CLOUDFLARE_API_TOKEN" <<< "${CRON_WITH_SECRET}" || ! grep -q "CLOUDFLARE_ACCOUNT_ID" <<< "${CRON_WITH_SECRET}" || ! grep -q "CF_PAGES_PROJECT" <<< "${CRON_WITH_SECRET}"; then
+            echo "ERROR: cronjob Cloudflare mode should render Cloudflare env vars"
+            exit 1
+          fi
+          echo "CronJob Cloudflare mode renders Cloudflare env vars"
+
+      - name: Verify cronjob extract-only emptyDir warning
+        run: |
+          WARNING_TEXT="WARNING: CronJob extract-only mode is using emptyDir output"
+
+          CRON_EXTRACT_ONLY_NOTES=$(helm install --dry-run --debug test charts/crd-schema-publisher --set mode=cronjob 2>/dev/null)
+          if ! grep -q "${WARNING_TEXT}" <<< "${CRON_EXTRACT_ONLY_NOTES}"; then
+            echo "ERROR: cronjob extract-only emptyDir mode should warn that output is discarded"
+            exit 1
+          fi
+          echo "CronJob extract-only emptyDir mode warns about discarded output"
+
+          CRON_WITH_SECRET_NOTES=$(helm install --dry-run --debug test charts/crd-schema-publisher --set mode=cronjob --set existingSecret.name=test 2>/dev/null)
+          if grep -q "${WARNING_TEXT}" <<< "${CRON_WITH_SECRET_NOTES}"; then
+            echo "ERROR: cronjob Cloudflare mode should not show emptyDir extract-only warning"
+            exit 1
+          fi
+          echo "CronJob Cloudflare mode omits extract-only emptyDir warning"
+
+          CRON_WITH_PERSISTENCE_NOTES=$(helm install --dry-run --debug test charts/crd-schema-publisher --set mode=cronjob --set persistence.enabled=true 2>/dev/null)
+          if grep -q "${WARNING_TEXT}" <<< "${CRON_WITH_PERSISTENCE_NOTES}"; then
+            echo "ERROR: cronjob persistent extract-only mode should not show emptyDir warning"
+            exit 1
+          fi
+          echo "CronJob persistent extract-only mode omits emptyDir warning"
+
+          CRON_WITH_BACKEND_NOTES=$(helm install --dry-run --debug test charts/crd-schema-publisher \
+            --set mode=cronjob \
+            --set 'extraContainers[0].name=backend' \
+            --set 'extraContainers[0].image=busybox' \
+            2>/dev/null)
+          if grep -q "${WARNING_TEXT}" <<< "${CRON_WITH_BACKEND_NOTES}"; then
+            echo "ERROR: cronjob backend extract-only mode should not show emptyDir warning"
+            exit 1
+          fi
+          echo "CronJob backend extract-only mode omits emptyDir warning"
 
       - name: Verify dashboard embedding
         run: |
@@ -126,5 +181,4 @@ jobs:
           echo "Validating cronjob mode..."
           helm template test charts/crd-schema-publisher \
             --set mode=cronjob \
-            --set existingSecret.name=test \
             | kubeconform "${SCHEMA_ARGS[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,19 +62,19 @@ go run ./cmd/main.go --help
 
 ### Subcommands
 
-- `run` (default) — extract + upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`; the output root must already exist.
+- `run` (default) — extract + optional upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`; the output root must already exist.
 - `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version` filters and CLI flags (`--output-dir`, `--context`, `--base-path`, `--skip-render`) that override env vars.
 - `convert` — convert CRD YAML files to JSON Schema without a cluster connection. Requires `--output-dir`. Reads from `--file` (comma-separated, `-` for stdin) and/or `--dir`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
 - `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`; the output root must already exist.
-- `watch` — long-lived process: informer watches CRDs, debounces events, runs extract+publish cycles. Leader election for multi-replica safety. Accepts `--output-dir`; the output root must already exist.
+- `watch` — long-lived process: informer watches CRDs, debounces events, and runs extract plus optional upload cycles. Leader election for multi-replica safety. Accepts `--output-dir`; the output root must already exist.
 - `preview` — generate sample data by default, or with explicit `--output-dir` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
 
 ### Configuration (env vars)
 
 | Var | Required | Default | Purpose |
 | --- | -------- | ------- | ------- |
-| `CLOUDFLARE_API_TOKEN` | Yes (run/upload) | — | CF API token |
-| `CLOUDFLARE_ACCOUNT_ID` | Yes (run/upload) | — | CF account ID |
+| `CLOUDFLARE_API_TOKEN` | Upload only | — | CF API token |
+| `CLOUDFLARE_ACCOUNT_ID` | Upload only | — | CF account ID |
 | `CF_PAGES_PROJECT` | No | `kubernetes-schemas` | CF Pages project name |
 | `OUTPUT_DIR` | No | `/output` | Site output root. Stable read path is `OUTPUT_DIR/current` |
 | `KUBECTL_CONTEXT` | No | — | K8s context (local dev only) |
@@ -123,7 +123,7 @@ go run ./cmd/main.go --help
 - **Image signing** uses cosign keyless mode via GitHub OIDC. Production images on main are signed; PR images are not. Base images (golang, distroless) are verified before every build.
 - **Supply chain hardening**: all GitHub Actions pinned by commit SHA (not version tag), Dockerfile base images pinned by digest, `go mod verify` runs in CI.
 - **Prometheus metrics** use stdlib-only text exposition format (no `prometheus/client_golang` dependency). Atomic counters and gauges in `metrics/` package, served at `/metrics` on the health server port. Metrics are always registered in watch mode — zero overhead when not scraped. Recording methods are nil-receiver safe so callers don't need nil checks. Float gauges use `math.Float64bits`/`math.Float64frombits` with `atomic.Int64` for lock-free storage.
-- **Helm chart** in `charts/crd-schema-publisher/` distributed as OCI artifact via GHCR. Two modes (`controller`/`cronjob`) with mode-isolated templates. Two-tier secret management: `existingSecret`, `externalSecret` (ESO). Controller mode gracefully degrades to extract-only without Cloudflare creds because it runs `watch` and simply omits the publisher; CronJob mode still expects Cloudflare creds because it runs the default `run` command. `values.schema.json` enforces secret mutual exclusivity via `if/then` (not `oneOf`, which breaks yaml-language-server with `additionalProperties: false`); template precedence in `_helpers.tpl` handles runtime resolution (`existingSecret.name` wins, else chart fullname). NetworkPolicy and CiliumNetworkPolicy are mutually exclusive (enforced via `fail` guard in `_helpers.tpl`). PrometheusRule only renders in controller mode. Chart version is CalVer SemVer: `YYYY.MDD.HMMSS` (no leading zeros on month or hour — e.g. `2026.413.65435`). Image and chart are always released together with the same CalVer version — both `version` and `appVersion` match the image tag. `Chart.yaml` version/appVersion fields are placeholder `0.0.0` — both overridden by the release workflow at package time. Dashboard embedded via `.Files.Get`. Pod anti-affinity presets in `_helpers.tpl`.
+- **Helm chart** in `charts/crd-schema-publisher/` distributed as OCI artifact via GHCR. Two modes (`controller`/`cronjob`) with mode-isolated templates. Two-tier optional secret management: `existingSecret`, `externalSecret` (ESO). Both controller and CronJob modes gracefully degrade to extract-only without Cloudflare creds: controller runs `watch` and omits the publisher, while CronJob runs the default `run` command and skips upload after extraction. `values.schema.json` enforces secret mutual exclusivity via `if/then` (not `oneOf`, which breaks yaml-language-server with `additionalProperties: false`); template precedence in `_helpers.tpl` handles runtime resolution (`existingSecret.name` wins, else chart fullname). NetworkPolicy and CiliumNetworkPolicy are mutually exclusive (enforced via `fail` guard in `_helpers.tpl`). PrometheusRule only renders in controller mode. Chart version is CalVer SemVer: `YYYY.MDD.HMMSS` (no leading zeros on month or hour — e.g. `2026.413.65435`). Image and chart are always released together with the same CalVer version — both `version` and `appVersion` match the image tag. `Chart.yaml` version/appVersion fields are placeholder `0.0.0` — both overridden by the release workflow at package time. Dashboard embedded via `.Files.Get`. Pod anti-affinity presets in `_helpers.tpl`.
 
 ### Dependencies (direct only)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Most CRD schema solutions rely on static catalogs — community-maintained repos
 - **Always accurate** — schemas reflect exactly what's installed in your cluster, including custom and internal CRDs, updated automatically when CRDs change
 - **Self-hosted** — run in extract-only mode and serve schemas however you like, or publish directly to Cloudflare Pages
 - **Single static binary** — no runtime dependencies, no interpreters, no package managers. One binary in a distroless nonroot container with no shell
-- **Controller-grade runtime** — watch mode uses informers, leader election, debounced publish cycles, and health probes. It's a proper workload, not a script on a timer
+- **Controller-grade runtime** — watch mode uses informers, leader election, debounced refresh cycles, and health probes. It's a proper workload, not a script on a timer
 - **No glue pipelines** — replaces multi-tool chains (CI runners, shell scripts, kubectl, CLI wrappers) with a single in-cluster binary. No external CI dependency, no cluster-admin runner pods, no scheduled workflow orchestration
 
 The JSON Schema conversion improves upon the widely-used [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) — see [How It Works](#%EF%B8%8F-how-it-works) for details.
@@ -128,9 +128,7 @@ This installs in **controller mode** by default (real-time watch with leader ele
 
 #### Credentials
 
-Cloudflare credentials are **optional in controller mode**. Without them, the Deployment runs in extract-only mode — site generations are written under the output directory and the active snapshot is exposed at `OUTPUT_DIR/current`, but nothing is uploaded. This is useful when serving schemas locally (e.g., via a sidecar web server) instead of Cloudflare Pages.
-
-CronJob mode still expects Cloudflare credentials because it runs the default `run` command (`extract` + `upload`). Extract-only cronjobs are not chart-supported yet.
+Cloudflare credentials are **optional in both controller and CronJob modes**. Without them, the workload runs in extract-only mode — site generations are written under the output directory and the active snapshot is exposed at `OUTPUT_DIR/current`, but nothing is uploaded. This is useful when serving schemas locally (e.g., via a sidecar web server) instead of Cloudflare Pages.
 
 To publish to Cloudflare Pages, provide an API token with **Cloudflare Pages: Edit** permission and your account ID. Two secret management options are supported:
 
@@ -204,7 +202,7 @@ For users who prefer raw YAML without Helm, deploy manifests are available in [`
 
 ### Watch Mode (recommended)
 
-Reacts to CRD changes in real-time with debounced publish cycles. Supports leader election for safe rolling updates. The container runs with `args: ["watch"]` — see [`deploy/deployment.yaml`](deploy/deployment.yaml).
+Reacts to CRD changes in real-time with debounced schema refreshes, uploading only when Cloudflare credentials are configured. Supports leader election for safe rolling updates. The container runs with `args: ["watch"]` — see [`deploy/deployment.yaml`](deploy/deployment.yaml).
 
 ```bash
 kubectl apply -f deploy/common.yaml -f deploy/deployment.yaml
@@ -212,7 +210,9 @@ kubectl apply -f deploy/common.yaml -f deploy/deployment.yaml
 
 ### CronJob Mode
 
-Runs extract + upload on a schedule. Simpler, but schemas are only updated when the job runs. The example uses a daily schedule — adjust the `schedule` field as needed. Uses the default `run` command — see [`deploy/cronjob.yaml`](deploy/cronjob.yaml).
+Runs scheduled schema extraction, uploading to Cloudflare Pages only when credentials are configured. Simpler, but schemas are only updated when the job runs. The example uses a daily schedule — adjust the `schedule` field as needed. Uses the default `run` command — see [`deploy/cronjob.yaml`](deploy/cronjob.yaml).
+
+Without Cloudflare credentials, CronJob mode is extract-only. With the default `emptyDir` output volume, extracted schemas are discarded when the Job pod exits. Configure Cloudflare credentials, `persistence.enabled`/`persistence.existingClaim`, or an extra container backend if you want scheduled output to be retained.
 
 ```bash
 kubectl apply -f deploy/common.yaml -f deploy/cronjob.yaml
@@ -220,7 +220,7 @@ kubectl apply -f deploy/common.yaml -f deploy/cronjob.yaml
 
 Both modes share [`deploy/common.yaml`](deploy/common.yaml) which provides namespace, ServiceAccount, RBAC (ClusterRole for CRD read access), and a hardened security context (nonroot, read-only rootfs, dropped capabilities).
 
-The deploy manifests include a placeholder Secret named `crd-schema-publisher-cloudflare`. Edit the placeholder values in `common.yaml` directly, or replace the Secret with your own secrets management (e.g., ExternalSecret, Sealed Secret). If the Secret is omitted, the Deployment can still run in extract-only mode (site generations written under `OUTPUT_DIR/.generations` with the active snapshot exposed at `OUTPUT_DIR/current`, but not uploaded). The CronJob manifest still requires Cloudflare credentials because it uses the default `run` command.
+The deploy manifests include an empty placeholder Secret named `crd-schema-publisher-cloudflare`. Fill in the values in `common.yaml` directly, or replace the Secret with your own secrets management (e.g., ExternalSecret, Sealed Secret). If Cloudflare credentials are empty or omitted, workloads run in extract-only mode (site generations written under `OUTPUT_DIR/.generations` with the active snapshot exposed at `OUTPUT_DIR/current`, but not uploaded). In raw CronJob mode, the default `emptyDir` output is discarded when the Job pod exits unless you replace it with retained storage or a backend sync.
 
 ### Container Image
 
@@ -248,8 +248,8 @@ Deployment/runtime configuration is primarily via environment variables. For loc
 
 | Variable | Required | Default | Description |
 | -------- | -------- | ------- | ----------- |
-| `CLOUDFLARE_API_TOKEN` | Yes (run/upload) | — | Cloudflare API token with Pages permissions |
-| `CLOUDFLARE_ACCOUNT_ID` | Yes (run/upload) | — | Cloudflare account ID |
+| `CLOUDFLARE_API_TOKEN` | Upload only | — | Cloudflare API token with Pages permissions |
+| `CLOUDFLARE_ACCOUNT_ID` | Upload only | — | Cloudflare account ID |
 | `CF_PAGES_PROJECT` | No | `kubernetes-schemas` | Cloudflare Pages project name |
 | `OUTPUT_DIR` | No | `/output` | Site output root. The active snapshot is exposed at `OUTPUT_DIR/current` |
 | `KUBECTL_CONTEXT` | No | — | Kubernetes context name (local development only) |
@@ -268,11 +268,11 @@ Deployment/runtime configuration is primarily via environment variables. For loc
 crd-schema-publisher [command]
 
 Commands:
-  run       Extract schemas and upload to Cloudflare Pages (default)
+  run       Extract schemas and upload to Cloudflare Pages when credentials are configured (default)
   extract   Extract schemas from a Kubernetes cluster
   convert   Convert CRD YAML files to JSON Schema
   upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
-  watch     Watch for CRD changes and publish on each change (extract-only if no credentials)
+  watch     Watch for CRD changes and upload when credentials are configured
   preview   Serve a local preview of the documentation site
 ```
 

--- a/charts/crd-schema-publisher/templates/NOTES.txt
+++ b/charts/crd-schema-publisher/templates/NOTES.txt
@@ -1,8 +1,12 @@
+{{- $cloudflareConfigured := or .Values.existingSecret.name .Values.externalSecret.enabled -}}
+{{- $persistentOutput := or .Values.persistence.enabled .Values.persistence.existingClaim -}}
+{{- $extraContainerBackend := not (empty .Values.extraContainers) -}}
+{{- $cronjobExtractOnlyEmptyDir := and (eq .Values.mode "cronjob") (not $cloudflareConfigured) (not $persistentOutput) (not $extraContainerBackend) -}}
 {{- if eq .Values.mode "controller" }}
 crd-schema-publisher is running in controller mode.
 
-The watcher will detect CRD changes and publish schemas automatically.
-Leader election ensures only one replica publishes at a time.
+The watcher will detect CRD changes and refresh schemas automatically.
+Leader election ensures only one replica performs work at a time.
 
 Health endpoints:
   /healthz  - liveness
@@ -11,18 +15,35 @@ Health endpoints:
 {{- else }}
 crd-schema-publisher is running in cronjob mode.
 
-Schemas will be extracted and published on schedule: {{ .Values.cronjob.schedule }}
+Schemas will be extracted on schedule: {{ .Values.cronjob.schedule }}
 {{- end }}
 
+{{- if $cloudflareConfigured }}
+Cloudflare credentials: configured
 Secret: {{ include "crd-schema-publisher.secretName" . }}
 {{- if .Values.existingSecret.name }}
   (using existing secret)
 {{- else if .Values.externalSecret.enabled }}
   (managed by ExternalSecret — wait for ESO to sync before the pod will start)
 {{- end }}
+{{- else }}
+Cloudflare credentials: not configured
+  (extract-only mode; upload will be skipped)
+{{- end }}
+
+{{- if $cronjobExtractOnlyEmptyDir }}
+
+WARNING: CronJob extract-only mode is using emptyDir output.
+Extracted schemas will be discarded when the Job pod exits.
+Configure Cloudflare credentials, persistence.enabled/persistence.existingClaim,
+or an extra container backend if you want the output retained.
+{{- end }}
 
 NOTE: This chart does not create its namespace. Use --create-namespace on first install:
   helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
     --namespace crd-schema-publisher \
-    --create-namespace \
-    --set existingSecret.name=<secret-name>
+    --create-namespace
+{{ if not $cloudflareConfigured }}
+To publish to Cloudflare Pages, add:
+  --set existingSecret.name=<secret-name>
+{{- end }}

--- a/charts/crd-schema-publisher/templates/_helpers.tpl
+++ b/charts/crd-schema-publisher/templates/_helpers.tpl
@@ -85,7 +85,7 @@ Digest takes precedence over tag; tag defaults to appVersion.
 
 {{/*
 Common environment variables shared by both deployment and cronjob pods.
-Secret refs + config vars that apply to all modes.
+Optional Secret refs + config vars that apply to all modes.
 */}}
 {{- define "crd-schema-publisher.commonEnvVars" -}}
 {{- if or .Values.existingSecret.name .Values.externalSecret.enabled }}

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -42,7 +42,8 @@ config:
   basePath: ""
 
 # ---------------------------------------------------------------------------
-# Secrets — configure exactly one of the two options below
+# Secrets — optional; configure at most one of the two options below
+# Omit both options to run in extract-only mode without Cloudflare upload.
 # Precedence: existingSecret > externalSecret
 # ---------------------------------------------------------------------------
 
@@ -274,7 +275,8 @@ ciliumNetworkPolicy:
 # Persistence (output directory volume)
 # ---------------------------------------------------------------------------
 persistence:
-  # -- Use a PersistentVolumeClaim for the output directory instead of emptyDir
+  # -- Use a PersistentVolumeClaim for the output directory instead of emptyDir.
+  # Recommended for CronJob extract-only mode when no upload backend is configured.
   enabled: false
   # -- Use an existing PVC (skips PVC creation when set)
   existingClaim: ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,11 +35,11 @@ type commandSpec struct {
 }
 
 var commandSpecs = []commandSpec{
-	{name: "run", description: "Extract schemas and upload to Cloudflare Pages (default)"},
+	{name: "run", description: "Extract schemas and upload when credentials are configured (default)"},
 	{name: "extract", description: "Extract schemas from a Kubernetes cluster"},
 	{name: "convert", description: "Convert CRD YAML files to JSON Schema"},
 	{name: "upload", description: "Upload schemas to Cloudflare Pages"},
-	{name: "watch", description: "Watch for CRD changes and publish automatically"},
+	{name: "watch", description: "Watch for CRD changes and upload when credentials are configured"},
 	{name: "preview", description: "Serve a local preview of the documentation site"},
 }
 

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -215,7 +215,7 @@ func runAll(args []string) error {
 	result, err := runBuild(outputDir)
 	if err != nil {
 		return fmt.Errorf("%w\n\n"+
-			"The \"run\" command extracts schemas from a Kubernetes cluster and uploads to Cloudflare Pages.\n\n"+
+			"The \"run\" command extracts schemas from a Kubernetes cluster and uploads when Cloudflare credentials are configured.\n\n"+
 			"To extract schemas from a cluster:\n"+
 			"  crd-schema-publisher extract --output-dir ./schemas\n\n"+
 			"To convert CRD YAML files directly:\n"+

--- a/deploy/common.yaml
+++ b/deploy/common.yaml
@@ -43,5 +43,5 @@ metadata:
   name: crd-schema-publisher-cloudflare
   namespace: crd-schema-publisher
 stringData:
-  CLOUDFLARE_API_TOKEN: "<your-cloudflare-api-token>"
-  CLOUDFLARE_ACCOUNT_ID: "<your-cloudflare-account-id>"
+  CLOUDFLARE_API_TOKEN: ""
+  CLOUDFLARE_ACCOUNT_ID: ""

--- a/deploy/cronjob.yaml
+++ b/deploy/cronjob.yaml
@@ -31,11 +31,13 @@ spec:
                     secretKeyRef:
                       name: crd-schema-publisher-cloudflare
                       key: CLOUDFLARE_API_TOKEN
+                      optional: true
                 - name: CLOUDFLARE_ACCOUNT_ID
                   valueFrom:
                     secretKeyRef:
                       name: crd-schema-publisher-cloudflare
                       key: CLOUDFLARE_ACCOUNT_ID
+                      optional: true
                 - name: CF_PAGES_PROJECT
                   value: kubernetes-schemas
                 - name: OUTPUT_DIR
@@ -58,4 +60,6 @@ spec:
                   mountPath: /output
           volumes:
             - name: output
+              # Without Cloudflare credentials, extract-only output on emptyDir
+              # is discarded when the Job pod exits.
               emptyDir: {}

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -64,11 +64,13 @@ spec:
                 secretKeyRef:
                   name: crd-schema-publisher-cloudflare
                   key: CLOUDFLARE_API_TOKEN
+                  optional: true
             - name: CLOUDFLARE_ACCOUNT_ID
               valueFrom:
                 secretKeyRef:
                   name: crd-schema-publisher-cloudflare
                   key: CLOUDFLARE_ACCOUNT_ID
+                  optional: true
             - name: CF_PAGES_PROJECT
               value: kubernetes-schemas
             - name: OUTPUT_DIR


### PR DESCRIPTION
## What

- Align Helm CronJob mode with controller mode so Cloudflare credentials are optional and no-credential CronJobs render without Cloudflare env vars.
- Keep Cloudflare publishing available when `existingSecret` or `externalSecret` is configured, using the same ExternalSecret target Secret as controller mode.
- Warn in Helm NOTES when CronJob extract-only mode uses default `emptyDir` output, since that output is discarded when the Job exits.
- Update README, CLI help text, raw manifests, and Helm lint coverage for the final behavior.
- Verified CronJob mode on the default cluster with the existing `crd-schema-publisher` ExternalSecret target; the manual Job extracted 177 CRDs and completed a Cloudflare Pages deployment.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified)
