### PR TITLE
feat: add cli shorthand flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,12 @@ go run ./cmd/main.go --help
 
 ### Subcommands
 
-- `run` (default) — extract + optional upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`, `--kind`, `--group`, and `--version`; the output root must already exist.
-- `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version` filters and CLI flags (`--output-dir`, `--context`, `--base-path`, `--skip-render`) that override env vars.
-- `convert` — convert CRD YAML files to JSON Schema without a cluster connection. Requires `--output-dir`. Reads from `--file` (comma-separated, `-` for stdin) and/or `--dir`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
-- `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`; the output root must already exist.
-- `watch` — long-lived process: informer watches CRDs, debounces events, and runs extract plus optional upload cycles. Leader election for multi-replica safety. Accepts `--output-dir`, `--kind`, `--group`, and `--version`; the output root must already exist. Filters are applied to generated output, not to the informer watch scope.
-- `preview` — generate sample data by default, or with explicit `--output-dir` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
+- `run` (default) — extract + optional upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`/`-o`, `--kind`, `--group`, and `--version`; the output root must already exist.
+- `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir`/`-o` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version` filters and CLI flags (`--output-dir`/`-o`, `--context`, `--base-path`, `--skip-render`) that override env vars.
+- `convert` — convert CRD YAML files to JSON Schema without a cluster connection. Requires `--output-dir`/`-o`. Reads from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
+- `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`/`-o`; the output root must already exist.
+- `watch` — long-lived process: informer watches CRDs, debounces events, and runs extract plus optional upload cycles. Leader election for multi-replica safety. Accepts `--output-dir`/`-o`, `--kind`, `--group`, and `--version`; the output root must already exist. Filters are applied to generated output, not to the informer watch scope.
+- `preview` — generate sample data by default, or with explicit `--output-dir`/`-o` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
 
 ### Configuration (env vars)
 
@@ -92,16 +92,16 @@ go run ./cmd/main.go --help
 
 ### CLI Flags
 
-`extract`, `convert`, `run`, `watch`, `upload`, and `preview` all support command-specific flags. `extract` requires `--output-dir` or `OUTPUT_DIR` and does not default to `/output`. `convert` requires `--output-dir` and does not read `OUTPUT_DIR`. For runtime-oriented commands (`run`, `watch`, `upload`), `--output-dir` overrides `OUTPUT_DIR` but must point at a pre-created directory. `preview` ignores ambient `OUTPUT_DIR` and only uses real extracted output when `--output-dir` is passed explicitly.
+`extract`, `convert`, `run`, `watch`, `upload`, and `preview` all support command-specific flags. `extract` requires `--output-dir`/`-o` or `OUTPUT_DIR` and does not default to `/output`. `convert` requires `--output-dir`/`-o` and does not read `OUTPUT_DIR`. For runtime-oriented commands (`run`, `watch`, `upload`), `--output-dir`/`-o` overrides `OUTPUT_DIR` but must point at a pre-created directory. `preview` ignores ambient `OUTPUT_DIR` and only uses real extracted output when `--output-dir`/`-o` is passed explicitly.
 
 | Flag | Subcommands | Default | Purpose |
 | --- | --- | --- | --- |
-| `--output-dir` | run, extract, convert, upload, watch, preview | `convert`: required flag; `extract`: `$OUTPUT_DIR` (required if unset); `run`/`upload`/`watch`: `$OUTPUT_DIR` or `/output`; `preview`: none | Output directory |
+| `--output-dir`, `-o` | run, extract, convert, upload, watch, preview | `convert`: required flag; `extract`: `$OUTPUT_DIR` (required if unset); `run`/`upload`/`watch`: `$OUTPUT_DIR` or `/output`; `preview`: none | Output directory |
 | `--context` | extract | `$KUBECTL_CONTEXT` | Kubernetes context |
 | `--base-path` | extract, convert | `$BASE_PATH` | URL path prefix |
 | `--skip-render` | extract | `$SKIP_RENDER` | Skip HTML rendering |
-| `--file` | convert | — | CRD YAML file(s), comma-separated. `-` for stdin |
-| `--dir` | convert | — | Directory of CRD YAML files (non-recursive) |
+| `--file`, `-f` | convert | — | CRD YAML file(s), comma-separated. `-` for stdin |
+| `--dir`, `-d` | convert | — | Directory of CRD YAML files (non-recursive) |
 | `--render` | convert | `false` | Render HTML docs |
 | `--kind` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_KIND`; `convert`: — | Filter by kind (comma-separated, case-insensitive) |
 | `--group` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_GROUP`; `convert`: — | Filter by group (comma-separated, case-insensitive) |

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Use the standalone binary or `go run ./cmd/` to convert CRD YAML files without a
 
 ```bash
 # Convert one CRD YAML file
-crd-schema-publisher convert --file crd.yaml --output-dir ./schemas
+crd-schema-publisher convert -f crd.yaml -o ./schemas
 
 # Convert every YAML CRD in a directory
-crd-schema-publisher convert --dir ./crds/ --output-dir ./schemas
+crd-schema-publisher convert -d ./crds/ -o ./schemas
 
 # Pipe CRDs from kubectl
-kubectl get crds -o yaml | crd-schema-publisher convert --file - --output-dir ./schemas
+kubectl get crds -o yaml | crd-schema-publisher convert -f - -o ./schemas
 ```
 
 See [Standalone Binary](#standalone-binary) for release downloads and [Configuration and CLI Reference](#configuration-and-cli-reference) for flags and command behavior.
@@ -258,7 +258,7 @@ cosign verify ghcr.io/sholdee/crd-schema-publisher:latest \
 
 ### Environment Variables
 
-Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`. Variables marked *(watch)* apply only to watch mode deployment.
+Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`/`-o`. Variables marked *(watch)* apply only to watch mode deployment.
 
 | Variable | Required | Default | Description |
 | -------- | -------- | ------- | ----------- |
@@ -297,17 +297,17 @@ Commands:
 
 | Command(s) | Output directory behavior |
 | --- | --- |
-| `extract` | Requires explicit `--output-dir` or `OUTPUT_DIR`; does not fall back to `/output`. |
-| `convert` | Requires `--output-dir`; does not read `OUTPUT_DIR`. |
-| `run`, `watch`, `upload` | Accept `--output-dir`; output root must already exist. |
-| `preview` | Uses sample data by default; reads real extracted output only when `--output-dir` is passed explicitly. |
+| `extract` | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; does not fall back to `/output`. |
+| `convert` | Requires `--output-dir`/`-o`; does not read `OUTPUT_DIR`. |
+| `run`, `watch`, `upload` | Accept `--output-dir`/`-o`; output root must already exist. |
+| `preview` | Uses sample data by default; reads real extracted output only when `--output-dir`/`-o` is passed explicitly. |
 
 | Command(s) | Filters and command-specific flags |
 | --- | --- |
 | `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`. |
 | `extract` | Supports `--context`, `--base-path`, and `--skip-render`. |
 | `convert` | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. |
-| `convert` | Supports `--file`, non-recursive `--dir` YAML loading, optional `--render`, and `--base-path` for rendered links. |
+| `convert` | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links. |
 
 ## 📋 Using Your Schemas
 
@@ -433,7 +433,7 @@ For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
 7. Atomically switches `OUTPUT_DIR/current` to the completed generation so sidecars read a stable snapshot
 8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
 
-The `convert` command skips Kubernetes access and reads CRD YAML from `--file`, stdin (`--file -`), and/or a non-recursive `--dir`. It applies the same schema transforms and writes flat output directly to `--output-dir`; with `--render`, it also renders HTML pages and an index.
+The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
 
 ## 🔧 Development
 
@@ -454,13 +454,13 @@ KUBECTL_CONTEXT=my-cluster \
   go run ./cmd/ --output-dir ./output
 
 # Convert CRD YAML files to JSON Schema (no cluster needed)
-go run ./cmd/ convert --file crd.yaml --output-dir ./schemas
+go run ./cmd/ convert -f crd.yaml -o ./schemas
 
 # Convert all CRDs in a directory
-go run ./cmd/ convert --dir ./crds/ --output-dir ./schemas
+go run ./cmd/ convert -d ./crds/ -o ./schemas
 
 # Pipe from kubectl
-kubectl get crds -o yaml | go run ./cmd/ convert --file - --output-dir ./schemas
+kubectl get crds -o yaml | go run ./cmd/ convert -f - -o ./schemas
 
 # Filter by kind and group
 go run ./cmd/ extract --output-dir ./schemas --kind certificate,issuer --group cert-manager.io

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -185,7 +184,7 @@ func loadCRDs(fileList, dir string) ([]apiextensionsv1.CustomResourceDefinition,
 }
 
 func runConvert(args []string) error {
-	fs := flag.NewFlagSet("convert", flag.ContinueOnError)
+	fs := newCommandFlagSet("convert")
 	var fileFlag string
 	stringFlagWithAlias(fs, &fileFlag, "file", "f", "", "CRD YAML file(s), comma-separated (use - for stdin)")
 	var dirFlag string

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -186,9 +186,12 @@ func loadCRDs(fileList, dir string) ([]apiextensionsv1.CustomResourceDefinition,
 
 func runConvert(args []string) error {
 	fs := flag.NewFlagSet("convert", flag.ContinueOnError)
-	fileFlag := fs.String("file", "", "CRD YAML file(s), comma-separated (use - for stdin)")
-	dirFlag := fs.String("dir", "", "directory containing CRD YAML files")
-	outputDir := fs.String("output-dir", "", "output directory for JSON schemas (required)")
+	var fileFlag string
+	stringFlagWithAlias(fs, &fileFlag, "file", "f", "", "CRD YAML file(s), comma-separated (use - for stdin)")
+	var dirFlag string
+	stringFlagWithAlias(fs, &dirFlag, "dir", "d", "", "directory containing CRD YAML files")
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", "", "output directory for JSON schemas (required)")
 	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
 	render := fs.Bool("render", false, "render HTML documentation pages")
 	kind := fs.String("kind", "", "filter by kind (comma-separated, case-insensitive)")
@@ -199,24 +202,24 @@ func runConvert(args []string) error {
 		return err
 	}
 
-	if *outputDir == "" {
+	if outputDir == "" {
 		return fmt.Errorf("--output-dir is required")
 	}
-	if err := extractor.ValidateOutputDir(*outputDir); err != nil {
+	if err := extractor.ValidateOutputDir(outputDir); err != nil {
 		return err
 	}
-	if *fileFlag == "" && *dirFlag == "" {
+	if fileFlag == "" && dirFlag == "" {
 		return fmt.Errorf("at least one of --file or --dir is required")
 	}
 
-	crds, err := loadCRDs(*fileFlag, *dirFlag)
+	crds, err := loadCRDs(fileFlag, dirFlag)
 	if err != nil {
 		return err
 	}
 
 	crds = extractor.FilterCRDs(crds, extractor.ParseFilter(*kind, *group, *version))
 
-	if err := cleanConvertArtifacts(*outputDir); err != nil {
+	if err := cleanConvertArtifacts(outputDir); err != nil {
 		return fmt.Errorf("preparing output directory: %w", err)
 	}
 
@@ -225,27 +228,27 @@ func runConvert(args []string) error {
 		return nil
 	}
 
-	preExisting := snapshotFiles(*outputDir)
+	preExisting := snapshotFiles(outputDir)
 
-	count, err := extractor.WriteSchemas(crds, *outputDir)
+	count, err := extractor.WriteSchemas(crds, outputDir)
 	if err != nil {
 		return fmt.Errorf("writing schemas: %w", err)
 	}
 
 	normalizedBasePath := normalizeBasePath(*basePath)
 	if *render {
-		if err := renderer.RenderAll(*outputDir, normalizedBasePath); err != nil {
+		if err := renderer.RenderAll(outputDir, normalizedBasePath); err != nil {
 			return fmt.Errorf("rendering schemas: %w", err)
 		}
-		if err := index.Generate(*outputDir, normalizedBasePath); err != nil {
+		if err := index.Generate(outputDir, normalizedBasePath); err != nil {
 			return fmt.Errorf("generating index: %w", err)
 		}
 	}
 
-	if err := writeConvertManifest(*outputDir, preExisting); err != nil {
+	if err := writeConvertManifest(outputDir, preExisting); err != nil {
 		return fmt.Errorf("writing convert manifest: %w", err)
 	}
 
-	slog.Info("convert complete", "count", count, "dir", *outputDir)
+	slog.Info("convert complete", "count", count, "dir", outputDir)
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,12 +95,20 @@ func parseSubcommand(osArgs []string) (string, []string) {
 }
 
 func isDefaultRunFlag(arg string) bool {
+	if arg == "-o" || strings.HasPrefix(arg, "-o=") {
+		return true
+	}
 	for _, name := range []string{"output-dir", "kind", "group", "version"} {
 		if arg == "--"+name || strings.HasPrefix(arg, "--"+name+"=") {
 			return true
 		}
 	}
 	return false
+}
+
+func stringFlagWithAlias(fs *flag.FlagSet, target *string, name, alias, value, usage string) {
+	fs.StringVar(target, name, value, usage)
+	fs.StringVar(target, alias, value, usage)
 }
 
 func handleCmdError(cmd string, err error) {
@@ -151,7 +159,8 @@ func requireEnv(key string) (string, error) {
 
 func parseOutputDirArg(cmd string, args []string, fallback string) (string, bool, error) {
 	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
-	outputDir := fs.String("output-dir", fallback, "output directory")
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", fallback, "output directory")
 	if err := fs.Parse(args); err != nil {
 		return "", false, err
 	}
@@ -160,11 +169,11 @@ func parseOutputDirArg(cmd string, args []string, fallback string) (string, bool
 	}
 	explicit := false
 	fs.Visit(func(f *flag.Flag) {
-		if f.Name == "output-dir" {
+		if f.Name == "output-dir" || f.Name == "o" {
 			explicit = true
 		}
 	})
-	return *outputDir, explicit, nil
+	return outputDir, explicit, nil
 }
 
 func requireExistingOutputDir(outputDir, guidance string) error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -106,9 +106,61 @@ func isDefaultRunFlag(arg string) bool {
 	return false
 }
 
+type flagAlias struct {
+	name  string
+	alias string
+}
+
+var flagAliases = map[*flag.FlagSet][]flagAlias{}
+
+func newCommandFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.Usage = func() {
+		printFlagDefaults(fs)
+	}
+	return fs
+}
+
 func stringFlagWithAlias(fs *flag.FlagSet, target *string, name, alias, value, usage string) {
 	fs.StringVar(target, name, value, usage)
 	fs.StringVar(target, alias, value, usage)
+	flagAliases[fs] = append(flagAliases[fs], flagAlias{name: name, alias: alias})
+}
+
+func printFlagDefaults(fs *flag.FlagSet) {
+	output := fs.Output()
+	fmt.Fprintf(output, "Usage of %s:\n", fs.Name())
+
+	aliases := map[string]string{}
+	aliasNames := map[string]bool{}
+	for _, a := range flagAliases[fs] {
+		aliases[a.name] = a.alias
+		aliasNames[a.alias] = true
+	}
+
+	fs.VisitAll(func(f *flag.Flag) {
+		if aliasNames[f.Name] {
+			return
+		}
+
+		name, usage := flag.UnquoteUsage(f)
+		displayName := "--" + f.Name
+		if alias, ok := aliases[f.Name]; ok {
+			displayName = "-" + alias + ", " + displayName
+		}
+		if name != "" {
+			displayName += " " + name
+		}
+
+		fmt.Fprintf(output, "  %s\n", displayName)
+		if usage != "" {
+			fmt.Fprintf(output, "\t%s", usage)
+			if f.DefValue != "" && f.DefValue != "false" {
+				fmt.Fprintf(output, " (default %q)", f.DefValue)
+			}
+			fmt.Fprintln(output)
+		}
+	})
 }
 
 func handleCmdError(cmd string, err error) {
@@ -158,7 +210,7 @@ func requireEnv(key string) (string, error) {
 }
 
 func parseOutputDirArg(cmd string, args []string, fallback string) (string, bool, error) {
-	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
+	fs := newCommandFlagSet(cmd)
 	var outputDir string
 	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", fallback, "output directory")
 	if err := fs.Parse(args); err != nil {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"errors"
+	"flag"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -75,6 +78,34 @@ func TestPrintUsage_ContainsAllCommands(t *testing.T) {
 			t.Errorf("usage output missing command %q", cmd.name)
 		}
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func TestRegisteredCommandsMatchAdvertisedCommands(t *testing.T) {
@@ -617,6 +648,34 @@ spec:
 	}
 	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "issuer_v1.json")); err != nil {
 		t.Fatal("expected Issuer schema from --dir")
+	}
+}
+
+func TestRunConvert_HelpCombinesAliasFlags(t *testing.T) {
+	output := captureStderr(t, func() {
+		err := runConvert([]string{"--help"})
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("expected flag.ErrHelp, got %v", err)
+		}
+	})
+
+	for _, expected := range []string{
+		"-f, --file",
+		"-d, --dir",
+		"-o, --output-dir",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected help output to contain %q:\n%s", expected, output)
+		}
+	}
+	if count := strings.Count(output, "CRD YAML file(s), comma-separated"); count != 1 {
+		t.Fatalf("expected file help text once, got %d:\n%s", count, output)
+	}
+	if count := strings.Count(output, "directory containing CRD YAML files"); count != 1 {
+		t.Fatalf("expected dir help text once, got %d:\n%s", count, output)
+	}
+	if count := strings.Count(output, "output directory for JSON schemas"); count != 1 {
+		t.Fatalf("expected output-dir help text once, got %d:\n%s", count, output)
 	}
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -136,6 +136,16 @@ func TestParseSubcommand_LeadingFlagDefaultsToRun(t *testing.T) {
 	}
 }
 
+func TestParseSubcommand_LeadingOutputDirShortDefaultsToRun(t *testing.T) {
+	cmd, args := parseSubcommand([]string{"crd-schema-publisher", "-o", "/tmp/out"})
+	if cmd != "run" {
+		t.Errorf("expected default 'run' for -o, got %q", cmd)
+	}
+	if len(args) != 2 || args[0] != "-o" || args[1] != "/tmp/out" {
+		t.Errorf("expected ['-o', '/tmp/out'], got %v", args)
+	}
+}
+
 func TestParseSubcommand_LeadingOutputDirEqualsDefaultsToRun(t *testing.T) {
 	cmd, args := parseSubcommand([]string{"crd-schema-publisher", "--output-dir=/tmp/out"})
 	if cmd != "run" {
@@ -216,6 +226,19 @@ func TestVersionDefault(t *testing.T) {
 	}
 }
 
+func TestParseOutputDirArg_ShortOutputDirMarksExplicit(t *testing.T) {
+	outputDir, explicit, err := parseOutputDirArg("preview", []string{"-o", "/tmp/out"}, "/fallback")
+	if err != nil {
+		t.Fatalf("parseOutputDirArg error: %v", err)
+	}
+	if outputDir != "/tmp/out" {
+		t.Fatalf("expected short output dir /tmp/out, got %q", outputDir)
+	}
+	if !explicit {
+		t.Fatal("expected -o to mark output dir explicit")
+	}
+}
+
 func TestRunExtract_FlagsOverrideEnvVars(t *testing.T) {
 	clientOrig := buildClientFunc
 	buildOrig := buildSiteFunc
@@ -248,6 +271,35 @@ func TestRunExtract_FlagsOverrideEnvVars(t *testing.T) {
 	}
 	if capturedOpts.OutputDir != tmpDir {
 		t.Errorf("expected flag output-dir %q, got %q", tmpDir, capturedOpts.OutputDir)
+	}
+}
+
+func TestRunExtract_OutputDirShortFlagOverridesEnvVar(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+	}()
+
+	var capturedOpts extractor.SiteBuildOptions
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		capturedOpts = opts
+		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
+	}
+
+	t.Setenv("OUTPUT_DIR", "/env-output")
+
+	tmpDir := t.TempDir()
+	err := runExtract([]string{"-o", tmpDir})
+	if err != nil {
+		t.Fatalf("runExtract error: %v", err)
+	}
+	if capturedOpts.OutputDir != tmpDir {
+		t.Errorf("expected short output-dir %q, got %q", tmpDir, capturedOpts.OutputDir)
 	}
 }
 
@@ -555,7 +607,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	err := runConvert([]string{"--file", singleFile, "--dir", inputDir, "--output-dir", outputDir})
+	err := runConvert([]string{"-f", singleFile, "-d", inputDir, "-o", outputDir})
 	if err != nil {
 		t.Fatalf("runConvert error: %v", err)
 	}

--- a/cmd/run_flow_test.go
+++ b/cmd/run_flow_test.go
@@ -112,6 +112,41 @@ func TestRunAll_OutputDirFlagOverridesEnvVar(t *testing.T) {
 	}
 }
 
+func TestRunAll_OutputDirShortFlagOverridesEnvVar(t *testing.T) {
+	clientOrig := buildClientFunc
+	buildOrig := buildSiteFunc
+	publishOrig := publishOutputFunc
+	defer func() {
+		buildClientFunc = clientOrig
+		buildSiteFunc = buildOrig
+		publishOutputFunc = publishOrig
+	}()
+
+	var captured extractor.SiteBuildOptions
+	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	}
+	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+		captured = opts
+		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
+	}
+	publishOutputFunc = func(string) error {
+		t.Fatal("publish should not be called for noop build")
+		return nil
+	}
+
+	envDir := t.TempDir()
+	flagDir := t.TempDir()
+	t.Setenv("OUTPUT_DIR", envDir)
+
+	if err := runAll([]string{"-o", flagDir}); err != nil {
+		t.Fatalf("runAll error: %v", err)
+	}
+	if captured.OutputDir != flagDir {
+		t.Fatalf("expected short output dir %q, got %q", flagDir, captured.OutputDir)
+	}
+}
+
 func TestRunAll_UsesSchemaFilterEnvVars(t *testing.T) {
 	clientOrig := buildClientFunc
 	buildOrig := buildSiteFunc

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -43,7 +43,8 @@ func init() {
 
 func runExtract(args []string) error {
 	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
-	outputDir := fs.String("output-dir", os.Getenv("OUTPUT_DIR"), "output directory")
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", os.Getenv("OUTPUT_DIR"), "output directory")
 	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
 	kubeContext := fs.String("context", os.Getenv("KUBECTL_CONTEXT"), "Kubernetes context")
 	skipRender := fs.Bool("skip-render", os.Getenv("SKIP_RENDER") == "true", "skip HTML rendering")
@@ -57,7 +58,7 @@ func runExtract(args []string) error {
 	if extras := fs.Args(); len(extras) > 0 {
 		return fmt.Errorf("unexpected arguments for extract: %s", strings.Join(extras, " "))
 	}
-	if err := requireConfiguredOutputDir(*outputDir, "Provide a writable directory for extracted schemas"); err != nil {
+	if err := requireConfiguredOutputDir(outputDir, "Provide a writable directory for extracted schemas"); err != nil {
 		return err
 	}
 
@@ -71,7 +72,7 @@ func runExtract(args []string) error {
 
 	result, err := buildSiteFunc(extractor.SiteBuildOptions{
 		Lister:    client.ApiextensionsV1().CustomResourceDefinitions(),
-		OutputDir: *outputDir,
+		OutputDir: outputDir,
 		BasePath:  normalizeBasePath(*basePath),
 		Render:    !*skipRender,
 		Filter:    filter,
@@ -84,13 +85,14 @@ func runExtract(args []string) error {
 		return nil
 	}
 
-	slog.Info("extract complete", "count", result.SchemaCount, "dir", *outputDir)
+	slog.Info("extract complete", "count", result.SchemaCount, "dir", outputDir)
 	return nil
 }
 
 func parseRuntimeCommandArgs(cmd string, args []string, fallbackOutputDir string) (runtimeCommandOptions, error) {
 	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
-	outputDir := fs.String("output-dir", fallbackOutputDir, "output directory")
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", fallbackOutputDir, "output directory")
 	kind := fs.String("kind", os.Getenv(schemaFilterKindEnv), "filter by kind (comma-separated, case-insensitive)")
 	group := fs.String("group", os.Getenv(schemaFilterGroupEnv), "filter by group (comma-separated, case-insensitive)")
 	version := fs.String("version", os.Getenv(schemaFilterVersionEnv), "filter by version (comma-separated, case-insensitive)")
@@ -102,7 +104,7 @@ func parseRuntimeCommandArgs(cmd string, args []string, fallbackOutputDir string
 	}
 
 	return runtimeCommandOptions{
-		OutputDir: *outputDir,
+		OutputDir: outputDir,
 		Filter:    extractor.ParseFilter(*kind, *group, *version),
 	}, nil
 }

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -42,7 +41,7 @@ func init() {
 }
 
 func runExtract(args []string) error {
-	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
+	fs := newCommandFlagSet("extract")
 	var outputDir string
 	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", os.Getenv("OUTPUT_DIR"), "output directory")
 	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
@@ -90,7 +89,7 @@ func runExtract(args []string) error {
 }
 
 func parseRuntimeCommandArgs(cmd string, args []string, fallbackOutputDir string) (runtimeCommandOptions, error) {
-	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
+	fs := newCommandFlagSet(cmd)
 	var outputDir string
 	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", fallbackOutputDir, "output directory")
 	kind := fs.String("kind", os.Getenv(schemaFilterKindEnv), "filter by kind (comma-separated, case-insensitive)")


### PR DESCRIPTION
## What

- Add `-o` as shorthand for `--output-dir` across runtime, upload, preview, extract, and convert commands.
- Add convert-only `-f` and `-d` aliases for CRD file and directory inputs.
- Preserve explicit command behavior: top-level `-o` defaults to `run`, while top-level `-f` and `-d` do not imply `convert`.
- Update README/CLAUDE docs and add regression coverage for shorthand parsing and command wiring.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified; no workflow changes)
