### PR TITLE
fix: reduce upload memory usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,9 @@ go run ./cmd/main.go --help
 | `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
+| `PROFILE_DIR` | No | — | Directory for opt-in heap profiles and phase memory logs |
+| `UPLOAD_BUCKET_SIZE_BYTES` | No | `41943040` | CF upload bucket size in bytes |
+| `UPLOAD_CONCURRENCY` | No | `3` | Concurrent CF upload buckets |
 | `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages) |
 | `SCHEMA_FILTER_KIND` | No | — | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
 | `SCHEMA_FILTER_GROUP` | No | — | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`) |

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Deployment/runtime configuration is primarily via environment variables. For loc
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address for preview server (preview mode) |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
+| `UPLOAD_BUCKET_SIZE_BYTES` | No | `41943040` | Cloudflare upload bucket size in bytes. Lower values reduce peak upload memory at the cost of more requests |
+| `UPLOAD_CONCURRENCY` | No | `3` | Concurrent Cloudflare upload buckets. Lower values reduce peak upload memory at the cost of slower cache-miss uploads |
 | `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`) |
 | `SCHEMA_FILTER_KIND` | No | — | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
 | `SCHEMA_FILTER_GROUP` | No | — | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`) |

--- a/charts/crd-schema-publisher/templates/_helpers.tpl
+++ b/charts/crd-schema-publisher/templates/_helpers.tpl
@@ -108,6 +108,18 @@ Optional Secret refs + config vars that apply to all modes.
 - name: SKIP_RENDER
   value: {{ .Values.config.skipRender | quote }}
 {{- end }}
+{{- if .Values.config.profileDir }}
+- name: PROFILE_DIR
+  value: {{ .Values.config.profileDir | quote }}
+{{- end }}
+{{- if .Values.config.uploadBucketSizeBytes }}
+- name: UPLOAD_BUCKET_SIZE_BYTES
+  value: {{ .Values.config.uploadBucketSizeBytes | quote }}
+{{- end }}
+{{- if .Values.config.uploadConcurrency }}
+- name: UPLOAD_CONCURRENCY
+  value: {{ .Values.config.uploadConcurrency | quote }}
+{{- end }}
 {{- if .Values.config.basePath }}
 - name: BASE_PATH
   value: {{ .Values.config.basePath | quote }}

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -96,6 +96,24 @@
           ],
           "description": "Set to true to skip HTML schema page rendering"
         },
+        "profileDir": {
+          "type": "string",
+          "description": "Directory for opt-in heap profiles and phase memory logs"
+        },
+        "uploadBucketSizeBytes": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "description": "Override Cloudflare upload bucket size in bytes. Empty uses the app default (40 MiB)."
+        },
+        "uploadConcurrency": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "description": "Override concurrent Cloudflare upload buckets. Empty uses the app default (3)."
+        },
         "basePath": {
           "type": "string",
           "description": "URL path prefix for subpath deployments (e.g., /iac)"

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -38,6 +38,12 @@ config:
   leaseName: crd-schema-publisher
   # -- Set to "true" to skip HTML schema page rendering
   skipRender: ""
+  # -- Directory for opt-in heap profiles and phase memory logs
+  profileDir: ""
+  # -- Override Cloudflare upload bucket size in bytes. Empty uses the app default (40 MiB).
+  uploadBucketSizeBytes: ""
+  # -- Override concurrent Cloudflare upload buckets. Empty uses the app default (3).
+  uploadConcurrency: ""
   # -- URL path prefix for subpath deployments (e.g., /iac for GitHub Pages at user.github.io/iac/)
   basePath: ""
   # -- Optional schema filters. Values are comma-separated and case-insensitive.

--- a/cmd/run_flow_test.go
+++ b/cmd/run_flow_test.go
@@ -673,6 +673,20 @@ func TestRunAll_UploadsWhenCredentialsPresent(t *testing.T) {
 	}
 }
 
+func TestRunUpload_RejectsInvalidUploadConfig(t *testing.T) {
+	t.Setenv("CLOUDFLARE_API_TOKEN", "test-token")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "test-account")
+	t.Setenv("UPLOAD_BUCKET_SIZE_BYTES", "0")
+
+	err := runUpload([]string{"--output-dir", t.TempDir()})
+	if err == nil {
+		t.Fatal("expected runUpload error")
+	}
+	if !strings.Contains(err.Error(), "UPLOAD_BUCKET_SIZE_BYTES") {
+		t.Fatalf("expected upload config error, got %v", err)
+	}
+}
+
 func TestRunAll_BuildError_PrintsGuidance(t *testing.T) {
 	clientOrig := buildClientFunc
 	defer func() {

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sholdee/crd-schema-publisher/diagnostics"
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/publisher"
 	"github.com/sholdee/crd-schema-publisher/watcher"
@@ -75,6 +76,7 @@ func runExtract(args []string) error {
 		BasePath:  normalizeBasePath(*basePath),
 		Render:    !*skipRender,
 		Filter:    filter,
+		Profiler:  diagnostics.NewFromEnv(),
 	})
 	if err != nil {
 		return err
@@ -124,6 +126,7 @@ func runBuild(outputDir string, filter extractor.SchemaFilter) (extractor.SiteBu
 		BasePath:  basePath,
 		Render:    os.Getenv("SKIP_RENDER") != "true",
 		Filter:    filter,
+		Profiler:  diagnostics.NewFromEnv(),
 	})
 	if err != nil {
 		return extractor.SiteBuildResult{}, err
@@ -155,11 +158,18 @@ func runUpload(args []string) error {
 		return err
 	}
 	projectName := getEnv("CF_PAGES_PROJECT", "kubernetes-schemas")
+	uploadConfig, err := publisher.UploadConfigFromEnv()
+	if err != nil {
+		return err
+	}
 
 	p := &publisher.Publisher{
-		APIToken:    apiToken,
-		AccountID:   accountID,
-		ProjectName: projectName,
+		APIToken:              apiToken,
+		AccountID:             accountID,
+		ProjectName:           projectName,
+		Profiler:              diagnostics.NewFromEnv(),
+		UploadBucketSizeBytes: uploadConfig.BucketSizeBytes,
+		UploadConcurrency:     uploadConfig.Concurrency,
 	}
 
 	return p.Publish(outputDir)
@@ -207,14 +217,22 @@ func runWatch(args []string) error {
 		return fmt.Errorf("building apiextensions client: %w", err)
 	}
 
+	profiler := diagnostics.NewFromEnv()
 	var pub *publisher.Publisher
 	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
 	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 	if apiToken != "" && accountID != "" {
+		uploadConfig, err := publisher.UploadConfigFromEnv()
+		if err != nil {
+			return err
+		}
 		pub = &publisher.Publisher{
-			APIToken:    apiToken,
-			AccountID:   accountID,
-			ProjectName: getEnv("CF_PAGES_PROJECT", "kubernetes-schemas"),
+			APIToken:              apiToken,
+			AccountID:             accountID,
+			ProjectName:           getEnv("CF_PAGES_PROJECT", "kubernetes-schemas"),
+			Profiler:              profiler,
+			UploadBucketSizeBytes: uploadConfig.BucketSizeBytes,
+			UploadConcurrency:     uploadConfig.Concurrency,
 		}
 	}
 
@@ -233,6 +251,7 @@ func runWatch(args []string) error {
 		PodName:    podName,
 		HealthPort: healthPort,
 		Filter:     opts.Filter,
+		Profiler:   profiler,
 	})
 }
 

--- a/diagnostics/profiler.go
+++ b/diagnostics/profiler.go
@@ -1,0 +1,156 @@
+package diagnostics
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"sync"
+)
+
+const profileDirEnv = "PROFILE_DIR"
+
+// Snapshotter records a named diagnostic point.
+type Snapshotter interface {
+	Snapshot(phase string, attrs ...any)
+}
+
+type preservePathProvider interface {
+	PreservePaths() []string
+}
+
+func PreservePaths(snapshotter Snapshotter) []string {
+	provider, ok := snapshotter.(preservePathProvider)
+	if !ok {
+		return nil
+	}
+	return provider.PreservePaths()
+}
+
+// Profiler writes opt-in heap profiles and memory stats for short-lived jobs.
+type Profiler struct {
+	dir              string
+	mu               sync.Mutex
+	sequence         int
+	readMemStats     func(*runtime.MemStats)
+	writeHeapProfile func(io.Writer) error
+}
+
+func NewFromEnv() *Profiler {
+	return NewProfiler(os.Getenv(profileDirEnv))
+}
+
+func NewProfiler(dir string) *Profiler {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return &Profiler{}
+	}
+	return &Profiler{
+		dir:              dir,
+		readMemStats:     runtime.ReadMemStats,
+		writeHeapProfile: pprof.WriteHeapProfile,
+	}
+}
+
+func (p *Profiler) Enabled() bool {
+	return p != nil && p.dir != ""
+}
+
+func (p *Profiler) PreservePaths() []string {
+	if !p.Enabled() {
+		return nil
+	}
+	return []string{p.dir}
+}
+
+func (p *Profiler) Snapshot(phase string, attrs ...any) {
+	if !p.Enabled() {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.sequence++
+	stats := p.memStats()
+	logAttrs := []any{
+		"phase", phase,
+		"alloc_bytes", stats.Alloc,
+		"total_alloc_bytes", stats.TotalAlloc,
+		"heap_alloc_bytes", stats.HeapAlloc,
+		"heap_inuse_bytes", stats.HeapInuse,
+		"heap_sys_bytes", stats.HeapSys,
+		"sys_bytes", stats.Sys,
+		"next_gc_bytes", stats.NextGC,
+		"num_gc", stats.NumGC,
+		"goroutines", runtime.NumGoroutine(),
+		"profile_dir", p.dir,
+	}
+	logAttrs = append(logAttrs, attrs...)
+
+	if err := os.MkdirAll(p.dir, 0o755); err != nil {
+		slog.Warn("memory profile snapshot failed", append(logAttrs, "error", err)...)
+		return
+	}
+
+	profilePath := filepath.Join(p.dir, fmt.Sprintf("%03d-heap-%s.pprof", p.sequence, sanitizePhase(phase)))
+	if err := p.writeHeap(profilePath); err != nil {
+		slog.Warn("memory profile snapshot failed", append(logAttrs, "profile_path", profilePath, "error", err)...)
+		return
+	}
+
+	slog.Info("memory profile snapshot", append(logAttrs, "profile_path", profilePath)...)
+}
+
+func (p *Profiler) memStats() runtime.MemStats {
+	var stats runtime.MemStats
+	read := p.readMemStats
+	if read == nil {
+		read = runtime.ReadMemStats
+	}
+	read(&stats)
+	return stats
+}
+
+func (p *Profiler) writeHeap(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	write := p.writeHeapProfile
+	if write == nil {
+		write = pprof.WriteHeapProfile
+	}
+	writeErr := write(f)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
+}
+
+func sanitizePhase(phase string) string {
+	phase = strings.ToLower(strings.TrimSpace(phase))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range phase {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	safe := strings.Trim(b.String(), "-")
+	if safe == "" {
+		return "snapshot"
+	}
+	return safe
+}

--- a/diagnostics/profiler_test.go
+++ b/diagnostics/profiler_test.go
@@ -1,0 +1,48 @@
+package diagnostics
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestProfilerSnapshotWritesSanitizedHeapProfile(t *testing.T) {
+	dir := t.TempDir()
+	p := NewProfiler(dir)
+	p.writeHeapProfile = func(w io.Writer) error {
+		_, err := w.Write([]byte("heap profile"))
+		return err
+	}
+	p.readMemStats = func(stats *runtime.MemStats) {
+		stats.Alloc = 1024
+		stats.TotalAlloc = 2048
+		stats.HeapAlloc = 1024
+		stats.HeapInuse = 4096
+		stats.HeapSys = 8192
+		stats.Sys = 16384
+		stats.NextGC = 32768
+		stats.NumGC = 2
+	}
+
+	p.Snapshot("upload/bucket 1: after marshal", "files", 3)
+
+	profilePath := filepath.Join(dir, "001-heap-upload-bucket-1-after-marshal.pprof")
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		t.Fatalf("expected heap profile at %s: %v", profilePath, err)
+	}
+	if string(data) != "heap profile" {
+		t.Fatalf("unexpected heap profile contents %q", string(data))
+	}
+}
+
+func TestProfilerDisabledWhenDirectoryEmpty(t *testing.T) {
+	p := NewProfiler("")
+	if p.Enabled() {
+		t.Fatal("expected empty profile dir to disable profiler")
+	}
+
+	p.Snapshot("ignored")
+}

--- a/extractor/build.go
+++ b/extractor/build.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sholdee/crd-schema-publisher/diagnostics"
 	"github.com/sholdee/crd-schema-publisher/index"
 	"github.com/sholdee/crd-schema-publisher/renderer"
 )
@@ -38,6 +39,7 @@ type SiteBuildOptions struct {
 	BasePath  string
 	Render    bool
 	Filter    SchemaFilter
+	Profiler  diagnostics.Snapshotter
 }
 
 type SiteBuildResult struct {
@@ -47,6 +49,7 @@ type SiteBuildResult struct {
 }
 
 func BuildSite(opts SiteBuildOptions) (SiteBuildResult, error) {
+	snapshot(opts.Profiler, "build.start", "output_dir", opts.OutputDir, "render", opts.Render)
 	if err := ValidateOutputDir(opts.OutputDir); err != nil {
 		return SiteBuildResult{}, err
 	}
@@ -57,7 +60,9 @@ func BuildSite(opts SiteBuildOptions) (SiteBuildResult, error) {
 	if err != nil {
 		return SiteBuildResult{}, fmt.Errorf("listing CRDs: %w", err)
 	}
+	snapshot(opts.Profiler, "build.after-list-crds", "crd_count", len(crds))
 	crds = FilterCRDs(crds, opts.Filter)
+	snapshot(opts.Profiler, "build.after-filter-crds", "crd_count", len(crds), "filter_active", opts.Filter.Active())
 	if len(crds) == 0 && !opts.Filter.Active() {
 		return SiteBuildResult{Status: BuildResultNoop}, nil
 	}
@@ -77,33 +82,45 @@ func BuildSite(opts SiteBuildOptions) (SiteBuildResult, error) {
 	if err != nil {
 		return SiteBuildResult{}, fmt.Errorf("writing schemas: %w", err)
 	}
+	snapshot(opts.Profiler, "build.after-write-schemas", "schema_count", count, "generation", generationName)
 
 	if opts.Render {
 		if err := renderAllFunc(generationDir, opts.BasePath); err != nil {
 			return SiteBuildResult{}, fmt.Errorf("rendering schemas: %w", err)
 		}
+		snapshot(opts.Profiler, "build.after-render", "schema_count", count, "generation", generationName)
 	}
 
 	if err := generateIndexFunc(generationDir, opts.BasePath); err != nil {
 		return SiteBuildResult{}, fmt.Errorf("generating index: %w", err)
 	}
+	snapshot(opts.Profiler, "build.after-index", "schema_count", count, "generation", generationName)
 
 	if err := activateGenerationFunc(opts.OutputDir, generationName); err != nil {
 		return SiteBuildResult{}, fmt.Errorf("activating generation: %w", err)
 	}
+	snapshot(opts.Profiler, "build.after-activate", "generation", generationName)
 	keepGeneration = true
-	if err := cleanLegacyRootFunc(opts.OutputDir); err != nil {
+	if err := cleanLegacyRootFunc(opts.OutputDir, diagnostics.PreservePaths(opts.Profiler)...); err != nil {
 		return SiteBuildResult{}, fmt.Errorf("cleaning legacy root: %w", err)
 	}
+	snapshot(opts.Profiler, "build.after-clean-legacy-root", "generation", generationName)
 	if err := pruneGenerationsFunc(opts.OutputDir, generationName, previousGeneration); err != nil {
 		return SiteBuildResult{}, fmt.Errorf("pruning generations: %w", err)
 	}
+	snapshot(opts.Profiler, "build.after-prune-generations", "generation", generationName)
 
 	return SiteBuildResult{
 		Status:      BuildResultBuilt,
 		CRDCount:    len(crds),
 		SchemaCount: count,
 	}, nil
+}
+
+func snapshot(profiler diagnostics.Snapshotter, phase string, attrs ...any) {
+	if profiler != nil {
+		profiler.Snapshot(phase, attrs...)
+	}
 }
 
 func ValidateOutputDir(outputDir string) error {
@@ -179,7 +196,7 @@ func activateGeneration(outputDir, generationName string) error {
 	return nil
 }
 
-func cleanLegacyRoot(outputDir string) error {
+func cleanLegacyRoot(outputDir string, preservePaths ...string) error {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
 		return err
@@ -189,11 +206,42 @@ func cleanLegacyRoot(outputDir string) error {
 		if name == generationsDirName || name == currentLinkName {
 			continue
 		}
+		if shouldPreserveRootEntry(outputDir, name, preservePaths) {
+			continue
+		}
 		if err := os.RemoveAll(filepath.Join(outputDir, name)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func shouldPreserveRootEntry(outputDir, name string, preservePaths []string) bool {
+	if len(preservePaths) == 0 {
+		return false
+	}
+	entryPath, err := filepath.Abs(filepath.Join(outputDir, name))
+	if err != nil {
+		return false
+	}
+	for _, preservePath := range preservePaths {
+		preservePath = strings.TrimSpace(preservePath)
+		if preservePath == "" {
+			continue
+		}
+		preserveAbs, err := filepath.Abs(preservePath)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(entryPath, preserveAbs)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
 }
 
 func currentGenerationName(outputDir string) string {

--- a/extractor/build_test.go
+++ b/extractor/build_test.go
@@ -4,11 +4,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/sholdee/crd-schema-publisher/diagnostics"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
+
+type recordingSnapshotter struct {
+	phases []string
+}
+
+func (r *recordingSnapshotter) Snapshot(phase string, attrs ...any) {
+	r.phases = append(r.phases, phase)
+}
 
 func seedActiveGeneration(t *testing.T, outputDir string, files map[string]string) string {
 	t.Helper()
@@ -38,6 +49,63 @@ func seedActiveGeneration(t *testing.T, outputDir string, files map[string]strin
 	}
 
 	return generationDir
+}
+
+func TestBuildSite_ProfilesBuildPhases(t *testing.T) {
+	outputDir := t.TempDir()
+	profiler := &recordingSnapshotter{}
+
+	result, err := BuildSite(SiteBuildOptions{
+		Lister:    &fakeLister{crds: []apiextensionsv1.CustomResourceDefinition{fakeCRD()}},
+		OutputDir: outputDir,
+		Render:    true,
+		Profiler:  profiler,
+	})
+	if err != nil {
+		t.Fatalf("BuildSite error: %v", err)
+	}
+	if result.Status != BuildResultBuilt {
+		t.Fatalf("expected BuildResultBuilt, got %q", result.Status)
+	}
+
+	for _, phase := range []string{
+		"build.start",
+		"build.after-list-crds",
+		"build.after-filter-crds",
+		"build.after-write-schemas",
+		"build.after-render",
+		"build.after-index",
+		"build.after-activate",
+		"build.after-clean-legacy-root",
+		"build.after-prune-generations",
+	} {
+		if !slices.Contains(profiler.phases, phase) {
+			t.Fatalf("expected profile phase %q in %v", phase, profiler.phases)
+		}
+	}
+}
+
+func TestBuildSite_PreservesProfilesUnderOutputDir(t *testing.T) {
+	outputDir := t.TempDir()
+	profileDir := filepath.Join(outputDir, "profile")
+
+	_, err := BuildSite(SiteBuildOptions{
+		Lister:    &fakeLister{crds: []apiextensionsv1.CustomResourceDefinition{fakeCRD()}},
+		OutputDir: outputDir,
+		Render:    true,
+		Profiler:  diagnostics.NewProfiler(profileDir),
+	})
+	if err != nil {
+		t.Fatalf("BuildSite error: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(profileDir, "*-heap-build-after-render.pprof"))
+	if err != nil {
+		t.Fatalf("glob profile dir: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected build.after-render profile to survive cleanup under %s", profileDir)
+	}
 }
 
 func currentTarget(t *testing.T, outputDir string) string {

--- a/publisher/config.go
+++ b/publisher/config.go
@@ -1,0 +1,46 @@
+package publisher
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const (
+	uploadBucketSizeBytesEnv = "UPLOAD_BUCKET_SIZE_BYTES"
+	uploadConcurrencyEnv     = "UPLOAD_CONCURRENCY"
+)
+
+type UploadConfig struct {
+	BucketSizeBytes int64
+	Concurrency     int
+}
+
+func DefaultUploadConfig() UploadConfig {
+	return UploadConfig{
+		BucketSizeBytes: maxBucketSize,
+		Concurrency:     uploadConcurrency,
+	}
+}
+
+func UploadConfigFromEnv() (UploadConfig, error) {
+	cfg := DefaultUploadConfig()
+
+	if raw := os.Getenv(uploadBucketSizeBytesEnv); raw != "" {
+		value, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || value <= 0 {
+			return UploadConfig{}, fmt.Errorf("invalid %s %q: must be a positive integer byte count", uploadBucketSizeBytesEnv, raw)
+		}
+		cfg.BucketSizeBytes = value
+	}
+
+	if raw := os.Getenv(uploadConcurrencyEnv); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value <= 0 {
+			return UploadConfig{}, fmt.Errorf("invalid %s %q: must be a positive integer", uploadConcurrencyEnv, raw)
+		}
+		cfg.Concurrency = value
+	}
+
+	return cfg, nil
+}

--- a/publisher/hash.go
+++ b/publisher/hash.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,14 +15,31 @@ import (
 // HashFile computes a file hash matching wrangler's hashFile function:
 // hex(blake3(base64(content) + extension))[0:32]
 func HashFile(path string) (string, error) {
-	content, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
-		return "", fmt.Errorf("reading file %s: %w", path, err)
+		return "", fmt.Errorf("opening file %s: %w", path, err)
 	}
-	b64 := base64.StdEncoding.EncodeToString(content)
+	defer func() { _ = file.Close() }()
+
 	ext := strings.TrimPrefix(filepath.Ext(path), ".")
+	hash, err := HashReaderWithExtension(file, ext)
+	if err != nil {
+		return "", fmt.Errorf("hashing file %s: %w", path, err)
+	}
+	return hash, nil
+}
+
+func HashReaderWithExtension(r io.Reader, ext string) (string, error) {
 	hasher := blake3.New()
-	_, _ = hasher.WriteString(b64 + ext)
+	encoder := base64.NewEncoder(base64.StdEncoding, hasher)
+	if _, err := io.Copy(encoder, r); err != nil {
+		_ = encoder.Close()
+		return "", err
+	}
+	if err := encoder.Close(); err != nil {
+		return "", err
+	}
+	_, _ = hasher.WriteString(ext)
 	sum := hasher.Sum(nil)
 	return hex.EncodeToString(sum)[:32], nil
 }

--- a/publisher/hash_test.go
+++ b/publisher/hash_test.go
@@ -1,9 +1,14 @@
 package publisher
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/zeebo/blake3"
 )
 
 func TestHashFile_MatchesWrangler(t *testing.T) {
@@ -81,5 +86,21 @@ func TestHashFile_DifferentContentDifferentHash(t *testing.T) {
 	hash2, _ := HashFile(path2)
 	if hash1 == hash2 {
 		t.Fatal("different content should produce different hashes")
+	}
+}
+
+func TestHashReaderWithExtension_MatchesWranglerAlgorithm(t *testing.T) {
+	content := []byte("streamed content with enough bytes to cross an encoder boundary")
+	got, err := HashReaderWithExtension(bytes.NewReader(content), "json")
+	if err != nil {
+		t.Fatalf("HashReaderWithExtension returned error: %v", err)
+	}
+
+	hasher := blake3.New()
+	_, _ = hasher.WriteString(base64.StdEncoding.EncodeToString(content) + "json")
+	want := hex.EncodeToString(hasher.Sum(nil))[:32]
+
+	if got != want {
+		t.Fatalf("HashReaderWithExtension() = %q, want %q", got, want)
 	}
 }

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sholdee/crd-schema-publisher/diagnostics"
 )
 
 const (
@@ -29,13 +31,21 @@ const (
 )
 
 type Publisher struct {
-	APIToken    string
-	AccountID   string
-	ProjectName string
-	BaseURL     string
-	AssetsURL   string
-	HTTPClient  *http.Client
-	SleepFunc   func(time.Duration)
+	APIToken              string
+	AccountID             string
+	ProjectName           string
+	BaseURL               string
+	AssetsURL             string
+	HTTPClient            *http.Client
+	SleepFunc             func(time.Duration)
+	Profiler              diagnostics.Snapshotter
+	UploadBucketSizeBytes int64
+	UploadConcurrency     int
+}
+
+type uploadBucket struct {
+	files []*fileEntry
+	size  int64
 }
 
 func (p *Publisher) sleepFunc() func(time.Duration) {
@@ -81,13 +91,16 @@ func (p *Publisher) httpClient() *http.Client {
 }
 
 func (p *Publisher) Publish(dir string) error {
+	p.snapshot("upload.start", "dir", dir)
 	if err := p.ensureProject(); err != nil {
 		return fmt.Errorf("ensuring project: %w", err)
 	}
+	p.snapshot("upload.after-ensure-project", "dir", dir)
 	files, err := p.collectActiveFiles(dir)
 	if err != nil {
 		return err
 	}
+	p.snapshot("upload.after-collect-files", "file_count", len(files))
 	if len(files) == 0 {
 		return fmt.Errorf("no files found in %s", dir)
 	}
@@ -99,30 +112,54 @@ func (p *Publisher) Publish(dir string) error {
 	}
 
 	hashToFile, uniqueHashes := buildUploadPlan(files)
+	p.snapshot("upload.after-upload-plan", "file_count", len(files), "unique_hashes", len(uniqueHashes))
 
 	missing, err := p.checkMissing(jwt, uniqueHashes)
 	if err != nil {
 		return fmt.Errorf("checking missing: %w", err)
 	}
+	p.snapshot("upload.after-check-missing", "missing", len(missing), "cached", len(uniqueHashes)-len(missing))
 	slog.Info("uploading files", "new", len(missing), "cached", len(uniqueHashes)-len(missing))
 
+	uploaded := 0
 	if len(missing) > 0 {
 		toUpload := selectUploadFiles(hashToFile, missing)
 		if err := p.uploadFiles(jwt, toUpload); err != nil {
 			return fmt.Errorf("uploading files: %w", err)
 		}
+		uploaded = len(toUpload)
 	}
+	p.snapshot("upload.after-upload-files", "uploaded", uploaded)
 
 	if err := p.upsertHashes(jwt, uniqueHashes); err != nil {
 		return fmt.Errorf("upserting hashes: %w", err)
 	}
+	p.snapshot("upload.after-upsert-hashes", "unique_hashes", len(uniqueHashes))
 
 	url, err := p.createDeployment(buildManifest(files))
 	if err != nil {
 		return fmt.Errorf("creating deployment: %w", err)
 	}
+	p.snapshot("upload.after-create-deployment", "file_count", len(files))
 	slog.Info("deployment successful", "url", url)
 	return nil
+}
+
+func (p *Publisher) snapshot(phase string, attrs ...any) {
+	if p.Profiler != nil {
+		p.Profiler.Snapshot(phase, attrs...)
+	}
+}
+
+func (p *Publisher) uploadConfig() UploadConfig {
+	cfg := DefaultUploadConfig()
+	if p.UploadBucketSizeBytes > 0 {
+		cfg.BucketSizeBytes = p.UploadBucketSizeBytes
+	}
+	if p.UploadConcurrency > 0 {
+		cfg.Concurrency = p.UploadConcurrency
+	}
+	return cfg
 }
 
 func (p *Publisher) collectActiveFiles(dir string) ([]*fileEntry, error) {
@@ -308,37 +345,20 @@ func (p *Publisher) checkMissing(jwt string, hashes []string) ([]string, error) 
 }
 
 func (p *Publisher) uploadFiles(jwt string, files []*fileEntry) error {
-	type bucket struct {
-		files []*fileEntry
-		size  int64
-	}
-	var buckets []bucket
-	current := bucket{}
-	for _, f := range files {
-		if len(current.files) >= maxBucketFiles || current.size+f.size > maxBucketSize {
-			if len(current.files) > 0 {
-				buckets = append(buckets, current)
-			}
-			current = bucket{}
-		}
-		current.files = append(current.files, f)
-		current.size += f.size
-	}
-	if len(current.files) > 0 {
-		buckets = append(buckets, current)
-	}
+	buckets := p.planUploadBuckets(files)
+	concurrency := p.uploadConfig().Concurrency
 
-	sem := make(chan struct{}, uploadConcurrency)
+	sem := make(chan struct{}, concurrency)
 	var mu sync.Mutex
 	var firstErr error
 	var wg sync.WaitGroup
 	for i, b := range buckets {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, b bucket) {
+		go func(idx int, b uploadBucket) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if err := p.uploadBucket(jwt, b.files); err != nil {
+			if err := p.uploadBucketWithIndex(jwt, b.files, idx); err != nil {
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = fmt.Errorf("bucket %d: %w", idx, err)
@@ -351,29 +371,39 @@ func (p *Publisher) uploadFiles(jwt string, files []*fileEntry) error {
 	return firstErr
 }
 
-func (p *Publisher) uploadBucket(jwt string, files []*fileEntry) error {
-	type uploadItem struct {
-		Key      string            `json:"key"`
-		Value    string            `json:"value"`
-		Metadata map[string]string `json:"metadata"`
-		Base64   bool              `json:"base64"`
-	}
-	var payload []uploadItem
+func (p *Publisher) planUploadBuckets(files []*fileEntry) []uploadBucket {
+	maxSize := p.uploadConfig().BucketSizeBytes
+	var buckets []uploadBucket
+	current := uploadBucket{}
 	for _, f := range files {
-		content, err := os.ReadFile(f.absPath)
-		if err != nil {
-			return err
+		if len(current.files) >= maxBucketFiles || current.size+f.size > maxSize {
+			if len(current.files) > 0 {
+				buckets = append(buckets, current)
+			}
+			current = uploadBucket{}
 		}
-		payload = append(payload, uploadItem{
-			Key:      f.hash,
-			Value:    base64.StdEncoding.EncodeToString(content),
-			Metadata: map[string]string{"contentType": f.contentType},
-			Base64:   true,
-		})
+		current.files = append(current.files, f)
+		current.size += f.size
 	}
-	body, err := json.Marshal(payload)
+	if len(current.files) > 0 {
+		buckets = append(buckets, current)
+	}
+	return buckets
+}
+
+func (p *Publisher) uploadBucket(jwt string, files []*fileEntry) error {
+	return p.uploadBucketWithIndex(jwt, files, -1)
+}
+
+func (p *Publisher) uploadBucketWithIndex(jwt string, files []*fileEntry, bucketIndex int) error {
+	body, err := buildUploadBucketBody(files)
 	if err != nil {
 		return fmt.Errorf("marshaling upload payload: %w", err)
+	}
+	if bucketIndex >= 0 {
+		p.snapshot(fmt.Sprintf("upload.bucket.%d.after-marshal", bucketIndex), "files", len(files), "body_bytes", len(body))
+	} else {
+		p.snapshot("upload.bucket.after-marshal", "files", len(files), "body_bytes", len(body))
 	}
 	url := fmt.Sprintf("%s/pages/assets/upload", p.assetsURL())
 	var lastErr error
@@ -413,6 +443,89 @@ func (p *Publisher) uploadBucket(jwt string, files []*fileEntry) error {
 	}
 	return fmt.Errorf("upload failed after %d retries: %w", maxUploadRetries, lastErr)
 }
+
+func buildUploadBucketBody(files []*fileEntry) ([]byte, error) {
+	var body bytes.Buffer
+	if size := estimateUploadBucketBodySize(files); size > 0 {
+		body.Grow(size)
+	}
+
+	body.WriteByte('[')
+	for i, f := range files {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		if err := writeUploadItem(&body, f); err != nil {
+			return nil, err
+		}
+	}
+	body.WriteByte(']')
+
+	return body.Bytes(), nil
+}
+
+func writeUploadItem(body *bytes.Buffer, f *fileEntry) error {
+	body.WriteString(`{"key":`)
+	if err := writeJSONString(body, f.hash); err != nil {
+		return err
+	}
+	body.WriteString(`,"value":"`)
+	if err := writeBase64File(body, f.absPath); err != nil {
+		return err
+	}
+	body.WriteString(`","metadata":{"contentType":`)
+	if err := writeJSONString(body, f.contentType); err != nil {
+		return err
+	}
+	body.WriteString(`},"base64":true}`)
+	return nil
+}
+
+func writeJSONString(body *bytes.Buffer, value string) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, _ = body.Write(encoded)
+	return nil
+}
+
+func writeBase64File(body *bytes.Buffer, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	encoder := base64.NewEncoder(base64.StdEncoding, body)
+	if _, err := io.Copy(encoder, file); err != nil {
+		_ = encoder.Close()
+		return err
+	}
+	return encoder.Close()
+}
+
+func estimateUploadBucketBodySize(files []*fileEntry) int {
+	total := 2
+	if len(files) > 1 {
+		total += len(files) - 1
+	}
+	const uploadItemStaticSize = len(`{"key":"","value":"","metadata":{"contentType":""},"base64":true}`)
+	for _, f := range files {
+		if f.size > int64(maxInt) {
+			return 0
+		}
+		encodedLen := base64.StdEncoding.EncodedLen(int(f.size))
+		next := total + uploadItemStaticSize + len(f.hash) + encodedLen + len(f.contentType)
+		if next < total {
+			return 0
+		}
+		total = next
+	}
+	return total
+}
+
+const maxInt = int(^uint(0) >> 1)
 
 func (p *Publisher) upsertHashes(jwt string, hashes []string) error {
 	body, err := json.Marshal(map[string][]string{"hashes": hashes})

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -1,12 +1,15 @@
 package publisher
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -121,6 +124,84 @@ func tempFileEntry(t *testing.T) *fileEntry {
 	return &fileEntry{
 		relPath: "test.json", absPath: path,
 		hash: "abc123", size: 13, contentType: "application/json",
+	}
+}
+
+type recordingSnapshotter struct {
+	phases []string
+}
+
+func (r *recordingSnapshotter) Snapshot(phase string, attrs ...any) {
+	r.phases = append(r.phases, phase)
+}
+
+func TestPublish_ProfilesUploadPhases(t *testing.T) {
+	var calls []string
+	server := httptest.NewServer(fullFlowHandler(t, &calls))
+	defer server.Close()
+
+	tmpDir := seedCurrentGeneration(t)
+	profiler := &recordingSnapshotter{}
+
+	p := &Publisher{
+		APIToken: "fake-token", AccountID: "fake-account", ProjectName: "test-project",
+		BaseURL: server.URL + "/client/v4", AssetsURL: server.URL + "/client/v4",
+		Profiler: profiler,
+	}
+	if err := p.Publish(tmpDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, phase := range []string{
+		"upload.start",
+		"upload.after-ensure-project",
+		"upload.after-collect-files",
+		"upload.after-upload-plan",
+		"upload.after-check-missing",
+		"upload.bucket.0.after-marshal",
+		"upload.after-upload-files",
+		"upload.after-upsert-hashes",
+		"upload.after-create-deployment",
+	} {
+		if !slices.Contains(profiler.phases, phase) {
+			t.Fatalf("expected profile phase %q in %v", phase, profiler.phases)
+		}
+	}
+}
+
+func TestPublish_ProfilesCachedUploadBoundary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/projects/test-project"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": map[string]interface{}{"name": "test-project"}})
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/upload-token"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": map[string]interface{}{"jwt": "fake-jwt-token"}})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/check-missing"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": []string{}})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/upsert-hashes"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": nil})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/deployments"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": map[string]interface{}{"url": "https://test.pages.dev"}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	tmpDir := seedCurrentGeneration(t)
+	profiler := &recordingSnapshotter{}
+
+	p := &Publisher{
+		APIToken: "fake-token", AccountID: "fake-account", ProjectName: "test-project",
+		BaseURL: server.URL + "/client/v4", AssetsURL: server.URL + "/client/v4",
+		Profiler: profiler,
+	}
+	if err := p.Publish(tmpDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !slices.Contains(profiler.phases, "upload.after-upload-files") {
+		t.Fatalf("expected upload.after-upload-files in cached upload phases %v", profiler.phases)
 	}
 }
 
@@ -386,4 +467,115 @@ func TestPublish_UsesCurrentAndSkipsKindFiles(t *testing.T) {
 	}
 
 	assertCurrentManifest(t, manifest)
+}
+
+func TestUploadConfigFromEnv_DefaultsMatchCurrentConstants(t *testing.T) {
+	t.Setenv(uploadBucketSizeBytesEnv, "")
+	t.Setenv(uploadConcurrencyEnv, "")
+
+	cfg, err := UploadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("UploadConfigFromEnv returned error: %v", err)
+	}
+	if cfg.BucketSizeBytes != maxBucketSize {
+		t.Fatalf("BucketSizeBytes = %d, want %d", cfg.BucketSizeBytes, maxBucketSize)
+	}
+	if cfg.Concurrency != uploadConcurrency {
+		t.Fatalf("Concurrency = %d, want %d", cfg.Concurrency, uploadConcurrency)
+	}
+}
+
+func TestUploadConfigFromEnv_ParsesOverrides(t *testing.T) {
+	t.Setenv(uploadBucketSizeBytesEnv, "10485760")
+	t.Setenv(uploadConcurrencyEnv, "1")
+
+	cfg, err := UploadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("UploadConfigFromEnv returned error: %v", err)
+	}
+	if cfg.BucketSizeBytes != 10*1024*1024 {
+		t.Fatalf("BucketSizeBytes = %d, want %d", cfg.BucketSizeBytes, 10*1024*1024)
+	}
+	if cfg.Concurrency != 1 {
+		t.Fatalf("Concurrency = %d, want 1", cfg.Concurrency)
+	}
+}
+
+func TestUploadConfigFromEnv_RejectsInvalidValues(t *testing.T) {
+	t.Setenv(uploadBucketSizeBytesEnv, "0")
+	t.Setenv(uploadConcurrencyEnv, "1")
+
+	_, err := UploadConfigFromEnv()
+	if err == nil {
+		t.Fatal("expected invalid bucket size error")
+	}
+	if !strings.Contains(err.Error(), uploadBucketSizeBytesEnv) {
+		t.Fatalf("expected error to mention %s, got %v", uploadBucketSizeBytesEnv, err)
+	}
+}
+
+func TestPlanUploadBuckets_UsesConfiguredBucketSize(t *testing.T) {
+	files := []*fileEntry{
+		{relPath: "a", hash: "a", size: 6},
+		{relPath: "b", hash: "b", size: 5},
+		{relPath: "c", hash: "c", size: 4},
+	}
+	p := &Publisher{UploadBucketSizeBytes: 10, UploadConcurrency: 1}
+
+	buckets := p.planUploadBuckets(files)
+	if len(buckets) != 2 {
+		t.Fatalf("expected 2 buckets, got %d", len(buckets))
+	}
+	if got := len(buckets[0].files); got != 1 {
+		t.Fatalf("first bucket file count = %d, want 1", got)
+	}
+	if got := len(buckets[1].files); got != 2 {
+		t.Fatalf("second bucket file count = %d, want 2", got)
+	}
+}
+
+func TestBuildUploadBucketBody_WritesExpectedPayload(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.json")
+	secondPath := filepath.Join(dir, "second.html")
+	if err := os.WriteFile(firstPath, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondPath, []byte(`<html></html>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := buildUploadBucketBody([]*fileEntry{
+		{hash: "hash-json", absPath: firstPath, size: 7, contentType: "application/json"},
+		{hash: "hash-html", absPath: secondPath, size: 13, contentType: "text/html; charset=utf-8"},
+	})
+	if err != nil {
+		t.Fatalf("buildUploadBucketBody returned error: %v", err)
+	}
+
+	var payload []struct {
+		Key      string            `json:"key"`
+		Value    string            `json:"value"`
+		Metadata map[string]string `json:"metadata"`
+		Base64   bool              `json:"base64"`
+	}
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+
+	if len(payload) != 2 {
+		t.Fatalf("payload length = %d, want 2", len(payload))
+	}
+	if payload[0].Key != "hash-json" || payload[0].Value != base64.StdEncoding.EncodeToString([]byte(`{"a":1}`)) {
+		t.Fatalf("unexpected first payload item: %+v", payload[0])
+	}
+	if payload[0].Metadata["contentType"] != "application/json" || !payload[0].Base64 {
+		t.Fatalf("unexpected first metadata/base64: %+v", payload[0])
+	}
+	if payload[1].Key != "hash-html" || payload[1].Value != base64.StdEncoding.EncodeToString([]byte(`<html></html>`)) {
+		t.Fatalf("unexpected second payload item: %+v", payload[1])
+	}
+	if payload[1].Metadata["contentType"] != "text/html; charset=utf-8" || !payload[1].Base64 {
+		t.Fatalf("unexpected second metadata/base64: %+v", payload[1])
+	}
 }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/sholdee/crd-schema-publisher/diagnostics"
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/metrics"
 	"github.com/sholdee/crd-schema-publisher/publisher"
@@ -42,6 +43,7 @@ type Config struct {
 	Metrics    *metrics.Metrics    // nil = no metrics recording
 	CRDLister  extractor.CRDLister // nil = derive from Client
 	Filter     extractor.SchemaFilter
+	Profiler   diagnostics.Snapshotter
 }
 
 // Run starts the watcher with leader election and health server.
@@ -266,6 +268,7 @@ func publishCycle(cfg Config) (retErr error) {
 		BasePath:  cfg.BasePath,
 		Render:    os.Getenv("SKIP_RENDER") != "true",
 		Filter:    cfg.Filter,
+		Profiler:  cfg.Profiler,
 	})
 	if err != nil {
 		return err
@@ -281,6 +284,9 @@ func publishCycle(cfg Config) (retErr error) {
 
 	// Upload (if publisher configured)
 	if cfg.Publisher != nil {
+		if cfg.Publisher.Profiler == nil {
+			cfg.Publisher.Profiler = cfg.Profiler
+		}
 		if err := cfg.Publisher.Publish(cfg.OutputDir); err != nil {
 			return fmt.Errorf("publishing: %w", err)
 		}


### PR DESCRIPTION
## What

- Reduce Cloudflare Pages upload memory by streaming hashing and upload body construction instead of retaining duplicate encoded payloads.
- Add opt-in heap profiling snapshots used for the investigation.
- Add upload bucket size and concurrency tuning via env vars and Helm values, with existing defaults preserved.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified; not modified)