### PR TITLE
feat: add built-in site serving

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -141,6 +141,148 @@ jobs:
           echo "${DASHBOARD}" | python3 -m json.tool > /dev/null
           echo "Dashboard JSON embedded and valid"
 
+      - name: Verify built-in site server rendering
+        run: |
+          SERVE_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set serve.enabled=true)
+
+          SITE_ENV=$(yq 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "crd-schema-publisher") | .env[] | select(.name == "SERVE_SITE") | .value' <<< "${SERVE_RENDER}")
+          if [[ "${SITE_ENV}" != "true" ]]; then
+            echo "ERROR: serve.enabled should render SERVE_SITE=true"
+            exit 1
+          fi
+
+          ACCESS_LOG_ENV=$(yq 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "crd-schema-publisher") | .env[] | select(.name == "SERVE_ACCESS_LOG") | .value' <<< "${SERVE_RENDER}")
+          if [[ "${ACCESS_LOG_ENV}" != "false" ]]; then
+            echo "ERROR: serve.enabled should render SERVE_ACCESS_LOG=false by default"
+            exit 1
+          fi
+
+          ACCESS_LOG_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set serve.enabled=true \
+            --set serve.accessLog.enabled=true)
+          ACCESS_LOG_ENABLED=$(yq 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "crd-schema-publisher") | .env[] | select(.name == "SERVE_ACCESS_LOG") | .value' <<< "${ACCESS_LOG_RENDER}")
+          if [[ "${ACCESS_LOG_ENABLED}" != "true" ]]; then
+            echo "ERROR: serve.accessLog.enabled should render SERVE_ACCESS_LOG=true"
+            exit 1
+          fi
+
+          SITE_PORT=$(yq 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "crd-schema-publisher") | .ports[] | select(.name == "site") | .containerPort' <<< "${SERVE_RENDER}")
+          if [[ "${SITE_PORT}" != "8081" ]]; then
+            echo "ERROR: serve.enabled should render site container port 8081"
+            exit 1
+          fi
+
+          STRATEGY_TYPE=$(yq 'select(.kind == "Deployment") | .spec.strategy.type' <<< "${SERVE_RENDER}")
+          if [[ "${STRATEGY_TYPE}" != "Recreate" ]]; then
+            echo "ERROR: serve.enabled should force Recreate deployment strategy"
+            exit 1
+          fi
+
+          SERVICE_PORT=$(yq 'select(.kind == "Service") | .spec.ports[] | select(.name == "site") | .port' <<< "${SERVE_RENDER}")
+          if [[ "${SERVICE_PORT}" != "8081" ]]; then
+            echo "ERROR: serve.enabled should render site Service port 8081"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher --set mode=cronjob --set serve.enabled=true 2>/dev/null; then
+            echo "ERROR: serve.enabled should be rejected in cronjob mode"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher --set serve.enabled=true --set replicaCount=2 2>/dev/null; then
+            echo "ERROR: serve.enabled should require replicaCount=1"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher --set serve.enabled=true --set serve.port=8080 --set config.healthPort=8080 2>/dev/null; then
+            echo "ERROR: serve.port should not be allowed to equal config.healthPort"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher --set serve.enabled=true --set serve.port=80 2>/dev/null; then
+            echo "ERROR: serve.port should reject privileged ports"
+            exit 1
+          fi
+
+          NETWORK_POLICY_SITE_PORT=$(helm template test charts/crd-schema-publisher \
+            --set serve.enabled=true \
+            --set networkPolicy.enabled=true \
+            | yq 'select(.kind == "NetworkPolicy") | .spec.ingress[].ports[]? | select(.port == 8081) | .port')
+          if [[ "${NETWORK_POLICY_SITE_PORT}" != "8081" ]]; then
+            echo "ERROR: networkPolicy should allow the built-in site port when serve.enabled=true"
+            exit 1
+          fi
+
+          CILIUM_POLICY_SITE_PORT=$(helm template test charts/crd-schema-publisher \
+            --set serve.enabled=true \
+            --set ciliumNetworkPolicy.enabled=true \
+            | yq 'select(.kind == "CiliumNetworkPolicy") | .spec.ingress[].toPorts[].ports[]? | select(.port == "8081") | .port')
+          if [[ "${CILIUM_POLICY_SITE_PORT}" != "8081" ]]; then
+            echo "ERROR: ciliumNetworkPolicy should allow the built-in site port when serve.enabled=true"
+            exit 1
+          fi
+
+          HTTP_ROUTE_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set serve.enabled=true \
+            --set serve.httpRoute.enabled=true \
+            --set 'serve.httpRoute.parentRefs[0].name=envoy-gateway' \
+            --set 'serve.httpRoute.parentRefs[0].namespace=gateway' \
+            --set 'serve.httpRoute.parentRefs[0].sectionName=https' \
+            --set-string 'serve.httpRoute.hostnames[0]=kube-schemas-test.mgmt.sholdee.net' \
+            --set 'serve.httpRoute.filters[0].type=RequestHeaderModifier' \
+            --set 'serve.httpRoute.filters[0].requestHeaderModifier.add[0].name=X-Test' \
+            --set-string 'serve.httpRoute.filters[0].requestHeaderModifier.add[0].value=e2e')
+
+          HTTP_ROUTE_NAME=$(yq 'select(.kind == "HTTPRoute") | .metadata.name' <<< "${HTTP_ROUTE_RENDER}")
+          if [[ "${HTTP_ROUTE_NAME}" != "test-crd-schema-publisher" ]]; then
+            echo "ERROR: serve.httpRoute.enabled should render an HTTPRoute named after the release"
+            exit 1
+          fi
+
+          HTTP_ROUTE_PARENT=$(yq 'select(.kind == "HTTPRoute") | .spec.parentRefs[0].name' <<< "${HTTP_ROUTE_RENDER}")
+          if [[ "${HTTP_ROUTE_PARENT}" != "envoy-gateway" ]]; then
+            echo "ERROR: HTTPRoute should render configured parentRefs"
+            exit 1
+          fi
+
+          HTTP_ROUTE_HOSTNAME=$(yq 'select(.kind == "HTTPRoute") | .spec.hostnames[0]' <<< "${HTTP_ROUTE_RENDER}")
+          if [[ "${HTTP_ROUTE_HOSTNAME}" != "kube-schemas-test.mgmt.sholdee.net" ]]; then
+            echo "ERROR: HTTPRoute should render configured hostnames"
+            exit 1
+          fi
+
+          HTTP_ROUTE_MATCH_PATH=$(yq 'select(.kind == "HTTPRoute") | .spec.rules[0].matches[0].path.value' <<< "${HTTP_ROUTE_RENDER}")
+          if [[ "${HTTP_ROUTE_MATCH_PATH}" != "/" ]]; then
+            echo "ERROR: HTTPRoute should default to a / PathPrefix match"
+            exit 1
+          fi
+
+          HTTP_ROUTE_BACKEND_PORT=$(yq 'select(.kind == "HTTPRoute") | .spec.rules[0].backendRefs[0].port' <<< "${HTTP_ROUTE_RENDER}")
+          if [[ "${HTTP_ROUTE_BACKEND_PORT}" != "8081" ]]; then
+            echo "ERROR: HTTPRoute should route to the built-in site Service port"
+            exit 1
+          fi
+
+          HTTP_ROUTE_FILTER=$(yq 'select(.kind == "HTTPRoute") | .spec.rules[0].filters[0].type' <<< "${HTTP_ROUTE_RENDER}")
+          if [[ "${HTTP_ROUTE_FILTER}" != "RequestHeaderModifier" ]]; then
+            echo "ERROR: HTTPRoute should render configured filters"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher --set serve.httpRoute.enabled=true --set 'serve.httpRoute.parentRefs[0].name=envoy-gateway' 2>/dev/null; then
+            echo "ERROR: serve.httpRoute.enabled should require serve.enabled=true"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher --set serve.enabled=true --set serve.httpRoute.enabled=true 2>/dev/null; then
+            echo "ERROR: serve.httpRoute.enabled should require at least one parentRef"
+            exit 1
+          fi
+
       - name: Verify existingClaim suppresses PVC creation
         run: |
           PVC_COUNT=$(helm template test charts/crd-schema-publisher \
@@ -174,6 +316,11 @@ jobs:
             --set externalSecret.enabled=true \
             --set externalSecret.secretStoreRef.name=test \
             --set ciliumNetworkPolicy.enabled=true \
+            --set serve.enabled=true \
+            --set serve.httpRoute.enabled=true \
+            --set 'serve.httpRoute.parentRefs[0].name=envoy-gateway' \
+            --set 'serve.httpRoute.parentRefs[0].namespace=gateway' \
+            --set-string 'serve.httpRoute.hostnames[0]=kube-schemas-test.mgmt.sholdee.net' \
             --set metrics.podMonitor.enabled=true \
             --set metrics.prometheusRule.enabled=true \
             | kubeconform "${SCHEMA_ARGS[@]}"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run it as:
 - a CronJob for scheduled extraction
 - a local CLI for extracting from a live cluster or converting YAML files
 
-Exports schemas for IDE validation with yaml-language-server and CI linting with kubeconform. Cloudflare Pages is built in; S3, git repos, and local serving are supported via sidecar.
+Exports schemas for IDE validation with yaml-language-server and CI linting with kubeconform. Cloudflare Pages and local serving are built in; S3, git repos, and custom web servers are supported via sidecar.
 
 > **Upgrading direct-volume deployments:** the active site now lives at `OUTPUT_DIR/current`. Existing sidecars or scripts that read the shared output volume directly must be updated. Cloudflare Pages users do not need to change anything.
 
@@ -163,7 +163,21 @@ Controller mode still watches all CRDs, then applies the filter to each generate
 
 #### Optional features
 
-Persistent output volume (`persistence`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
+Persistent output volume (`persistence`), built-in static serving (`serve`), Gateway API HTTPRoute (`serve.httpRoute`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
+
+#### Built-in static serving
+
+For simple in-cluster deployments, the controller can serve the active generated site directly from `OUTPUT_DIR/current`:
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set serve.enabled=true
+```
+
+The site is exposed on the chart Service port named `site` and defaults to non-privileged port `8081`; health and metrics stay on the `health` port. Built-in serving is controller-only, requires `replicaCount=1`, and switches the Deployment strategy to `Recreate` so traffic is not routed to a new pod before it has published its first site.
+
+Use [`examples/built-in-server/values.yaml`](examples/built-in-server/values.yaml) for a complete values file with persistence and Gateway API `HTTPRoute` setup.
 
 #### Examples: Alternative backends via sidecar pattern
 
@@ -272,6 +286,9 @@ Deployment/runtime configuration is primarily via environment variables. For loc
 | `POD_NAMESPACE` | Yes (watch) | — | Namespace for leader lease (set via downward API) |
 | `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
+| `SERVE_SITE` | No | — | Set to `true` to serve `OUTPUT_DIR/current` from watch mode |
+| `SITE_PORT` | No | `8081` | Non-privileged static site server port when `SERVE_SITE=true` |
+| `SERVE_ACCESS_LOG` | No | — | Set to `true` to log each request served by the built-in static site server |
 | `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address for preview server (preview mode) |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
 | `UPLOAD_BUCKET_SIZE_BYTES` | No | `41943040` | Cloudflare upload bucket size in bytes. Lower values reduce peak upload memory at the cost of more requests |

--- a/charts/crd-schema-publisher/templates/_helpers.tpl
+++ b/charts/crd-schema-publisher/templates/_helpers.tpl
@@ -150,6 +150,27 @@ Validate that networkPolicy and ciliumNetworkPolicy are not both enabled.
 {{- end }}
 
 {{/*
+Validate built-in static site serving options.
+*/}}
+{{- define "crd-schema-publisher.validateServe" -}}
+{{- if and .Values.serve.enabled (ne .Values.mode "controller") }}
+{{- fail "serve.enabled is only supported in controller mode" }}
+{{- end }}
+{{- if and .Values.serve.enabled (ne (int .Values.replicaCount) 1) }}
+{{- fail "serve.enabled requires replicaCount=1 because only the leader writes OUTPUT_DIR/current" }}
+{{- end }}
+{{- if and .Values.serve.enabled (eq (int .Values.serve.port) (int .Values.config.healthPort)) }}
+{{- fail "serve.port must be different from config.healthPort" }}
+{{- end }}
+{{- if and .Values.serve.httpRoute.enabled (not .Values.serve.enabled) }}
+{{- fail "serve.httpRoute.enabled requires serve.enabled=true because the HTTPRoute targets the built-in site port" }}
+{{- end }}
+{{- if and .Values.serve.httpRoute.enabled (empty .Values.serve.httpRoute.parentRefs) }}
+{{- fail "serve.httpRoute.enabled requires at least one serve.httpRoute.parentRefs entry" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Pod anti-affinity preset.
 Generates preferred (soft) or required (hard) pod anti-affinity rules
 using selector labels and kubernetes.io/hostname topology key.

--- a/charts/crd-schema-publisher/templates/ciliumnetworkpolicy.yaml
+++ b/charts/crd-schema-publisher/templates/ciliumnetworkpolicy.yaml
@@ -22,6 +22,10 @@ spec:
         - ports:
             - port: {{ .Values.config.healthPort | quote }}
               protocol: TCP
+            {{- if .Values.serve.enabled }}
+            - port: {{ .Values.serve.port | quote }}
+              protocol: TCP
+            {{- end }}
     {{- end }}
     {{- with .Values.ciliumNetworkPolicy.extraIngress }}
     {{- toYaml . | nindent 4 }}

--- a/charts/crd-schema-publisher/templates/deployment.yaml
+++ b/charts/crd-schema-publisher/templates/deployment.yaml
@@ -11,9 +11,14 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.serve.enabled }}
+  strategy:
+    type: Recreate
+  {{- else }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
@@ -54,6 +59,14 @@ spec:
               value: {{ .Values.config.debounceSeconds | quote }}
             - name: HEALTH_PORT
               value: {{ .Values.config.healthPort | quote }}
+            {{- if .Values.serve.enabled }}
+            - name: SERVE_SITE
+              value: "true"
+            - name: SITE_PORT
+              value: {{ .Values.serve.port | quote }}
+            - name: SERVE_ACCESS_LOG
+              value: {{ .Values.serve.accessLog.enabled | quote }}
+            {{- end }}
             - name: LEASE_NAME
               value: {{ .Values.config.leaseName | quote }}
             - name: POD_NAME
@@ -68,6 +81,11 @@ spec:
             - name: health
               containerPort: {{ .Values.config.healthPort }}
               protocol: TCP
+            {{- if .Values.serve.enabled }}
+            - name: site
+              containerPort: {{ .Values.serve.port }}
+              protocol: TCP
+            {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/crd-schema-publisher/templates/httproute.yaml
+++ b/charts/crd-schema-publisher/templates/httproute.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.serve.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "crd-schema-publisher.fullname" . }}
+  labels:
+    {{- include "crd-schema-publisher.labels" . | nindent 4 }}
+    {{- with .Values.serve.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serve.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.serve.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.serve.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - {{- with .Values.serve.httpRoute.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serve.httpRoute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "crd-schema-publisher.fullname" . }}
+          port: {{ .Values.serve.port }}
+{{- end }}

--- a/charts/crd-schema-publisher/templates/networkpolicy.yaml
+++ b/charts/crd-schema-publisher/templates/networkpolicy.yaml
@@ -28,6 +28,10 @@ spec:
     - ports:
         - port: {{ .Values.config.healthPort }}
           protocol: TCP
+        {{- if .Values.serve.enabled }}
+        - port: {{ .Values.serve.port }}
+          protocol: TCP
+        {{- end }}
     {{- end }}
     {{- with .Values.networkPolicy.extraIngress }}
     {{- toYaml . | nindent 4 }}

--- a/charts/crd-schema-publisher/templates/serve-validation.yaml
+++ b/charts/crd-schema-publisher/templates/serve-validation.yaml
@@ -1,0 +1,1 @@
+{{- include "crd-schema-publisher.validateServe" . -}}

--- a/charts/crd-schema-publisher/templates/service.yaml
+++ b/charts/crd-schema-publisher/templates/service.yaml
@@ -12,6 +12,12 @@ spec:
       port: {{ .Values.config.healthPort }}
       targetPort: health
       protocol: TCP
+    {{- if .Values.serve.enabled }}
+    - name: site
+      port: {{ .Values.serve.port }}
+      targetPort: site
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "crd-schema-publisher.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -302,6 +302,119 @@
       "type": "object",
       "description": "Readiness probe configuration (controller mode only)"
     },
+    "serve": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Serve OUTPUT_DIR/current from the main controller container"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Non-privileged static site server port",
+          "minimum": 1024,
+          "maximum": 65535
+        },
+        "accessLog": {
+          "type": "object",
+          "description": "Request logging for the built-in static site server",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Log each request served by the built-in static site server"
+            }
+          }
+        },
+        "httpRoute": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Gateway API HTTPRoute for the built-in static site server",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create an HTTPRoute for the built-in static site server"
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for the HTTPRoute",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Additional annotations for the HTTPRoute",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "parentRefs": {
+              "type": "array",
+              "description": "Gateway parentRefs for the HTTPRoute",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "group": {
+                    "type": "string",
+                    "description": "Gateway API group"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "description": "Gateway parent kind"
+                  },
+                  "namespace": {
+                    "type": "string",
+                    "description": "Gateway namespace"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Gateway name"
+                  },
+                  "sectionName": {
+                    "type": "string",
+                    "description": "Gateway listener section name"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Gateway listener port"
+                  }
+                }
+              }
+            },
+            "hostnames": {
+              "type": "array",
+              "description": "Hostnames for the HTTPRoute",
+              "items": {
+                "type": "string"
+              }
+            },
+            "matches": {
+              "type": "array",
+              "description": "HTTPRoute matches for the site rule",
+              "items": {
+                "type": "object"
+              }
+            },
+            "filters": {
+              "type": "array",
+              "description": "HTTPRoute filters for the site rule",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
     "annotations": {
       "type": "object",
       "description": "Annotations added to the Deployment or CronJob metadata"

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -178,6 +178,41 @@ readinessProbe:
   initialDelaySeconds: 3
   periodSeconds: 5
 
+# ---------------------------------------------------------------------------
+# Built-in static site server
+# ---------------------------------------------------------------------------
+serve:
+  # -- Serve OUTPUT_DIR/current from the main controller container
+  enabled: false
+  # -- Non-privileged static site server port
+  port: 8081
+  accessLog:
+    # -- Log each request served by the built-in static site server
+    enabled: false
+  # -- Gateway API HTTPRoute for the built-in static site server
+  httpRoute:
+    # -- Create an HTTPRoute for the built-in static site server
+    enabled: false
+    # -- Additional labels for the HTTPRoute
+    labels: {}
+    # -- Additional annotations for the HTTPRoute
+    annotations: {}
+    # -- Gateway parentRefs. Required when serve.httpRoute.enabled=true.
+    parentRefs: []
+    #  - name: envoy-gateway
+    #    namespace: gateway
+    #    sectionName: https
+    # -- Hostnames for the HTTPRoute
+    hostnames: []
+    #  - kube-schemas.example.com
+    # -- HTTPRoute matches for the site rule
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- HTTPRoute filters for the site rule
+    filters: []
+
 # -- Annotations added to the Deployment or CronJob metadata (e.g. reloader.stakater.com/auto)
 annotations: {}
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sholdee/crd-schema-publisher/extractor"
+	"github.com/sholdee/crd-schema-publisher/site"
 )
 
 func init() {
@@ -45,17 +46,7 @@ func runPreview(args []string) error {
 	defer cleanup()
 
 	addr := getEnv("PREVIEW_ADDR", "127.0.0.1:8989")
-	var handler http.Handler
-	if basePath != "" {
-		mux := http.NewServeMux()
-		mux.Handle(basePath+"/", http.StripPrefix(basePath, http.FileServer(http.Dir(serveDir))))
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, basePath+"/", http.StatusFound)
-		})
-		handler = mux
-	} else {
-		handler = http.FileServer(http.Dir(serveDir))
-	}
+	handler := site.NewStaticHandler(serveDir, basePath)
 	srv := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/run_flow_test.go
+++ b/cmd/run_flow_test.go
@@ -426,6 +426,98 @@ func TestRunWatch_OutputDirFlagOverridesEnvVar(t *testing.T) {
 	}
 }
 
+func TestParseSiteServingConfig_DisabledByDefault(t *testing.T) {
+	enabled, port, accessLog, err := parseSiteServingConfig("8080")
+	if err != nil {
+		t.Fatalf("parseSiteServingConfig error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected site serving to be disabled by default")
+	}
+	if port != "" {
+		t.Fatalf("expected empty site port when disabled, got %q", port)
+	}
+	if accessLog {
+		t.Fatal("expected access logging to be disabled by default")
+	}
+}
+
+func TestParseSiteServingConfig_EnabledWithDefaultPort(t *testing.T) {
+	t.Setenv("SERVE_SITE", "true")
+
+	enabled, port, accessLog, err := parseSiteServingConfig("8080")
+	if err != nil {
+		t.Fatalf("parseSiteServingConfig error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected site serving to be enabled")
+	}
+	if port != "8081" {
+		t.Fatalf("expected default site port 8081, got %q", port)
+	}
+	if accessLog {
+		t.Fatal("expected access logging to be disabled by default")
+	}
+}
+
+func TestParseSiteServingConfig_EnablesAccessLog(t *testing.T) {
+	t.Setenv("SERVE_SITE", "true")
+	t.Setenv("SERVE_ACCESS_LOG", "true")
+
+	enabled, port, accessLog, err := parseSiteServingConfig("8080")
+	if err != nil {
+		t.Fatalf("parseSiteServingConfig error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected site serving to be enabled")
+	}
+	if port != "8081" {
+		t.Fatalf("expected default site port 8081, got %q", port)
+	}
+	if !accessLog {
+		t.Fatal("expected access logging to be enabled")
+	}
+}
+
+func TestParseSiteServingConfig_RejectsHealthPortConflict(t *testing.T) {
+	t.Setenv("SERVE_SITE", "true")
+	t.Setenv("SITE_PORT", "8080")
+
+	_, _, _, err := parseSiteServingConfig("8080")
+	if err == nil {
+		t.Fatal("expected port conflict error")
+	}
+	if !strings.Contains(err.Error(), "SITE_PORT") || !strings.Contains(err.Error(), "HEALTH_PORT") {
+		t.Fatalf("expected SITE_PORT/HEALTH_PORT guidance, got %v", err)
+	}
+}
+
+func TestParseSiteServingConfig_RejectsPrivilegedPort(t *testing.T) {
+	t.Setenv("SERVE_SITE", "true")
+	t.Setenv("SITE_PORT", "1023")
+
+	_, _, _, err := parseSiteServingConfig("8080")
+	if err == nil {
+		t.Fatal("expected privileged port error")
+	}
+	if !strings.Contains(err.Error(), "non-privileged") {
+		t.Fatalf("expected non-privileged port guidance, got %v", err)
+	}
+}
+
+func TestParseSiteServingConfig_RejectsInvalidPort(t *testing.T) {
+	t.Setenv("SERVE_SITE", "true")
+	t.Setenv("SITE_PORT", "not-a-port")
+
+	_, _, _, err := parseSiteServingConfig("8080")
+	if err == nil {
+		t.Fatal("expected invalid port error")
+	}
+	if !strings.Contains(err.Error(), "invalid SITE_PORT") {
+		t.Fatalf("expected SITE_PORT guidance, got %v", err)
+	}
+}
+
 func TestPreparePreviewSite_CreatesSampleGenerationUnderCurrent(t *testing.T) {
 	renderOrig := renderPreviewFunc
 	indexOrig := generatePreviewFunc

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -110,6 +110,21 @@ func parseRuntimeCommandArgs(cmd string, args []string, fallbackOutputDir string
 	}, nil
 }
 
+func parseSiteServingConfig(healthPort string) (bool, string, bool, error) {
+	if os.Getenv("SERVE_SITE") != "true" {
+		return false, "", false, nil
+	}
+	sitePort := getEnv("SITE_PORT", "8081")
+	if sitePort == healthPort {
+		return false, "", false, fmt.Errorf("SITE_PORT must be different from HEALTH_PORT when SERVE_SITE=true")
+	}
+	parsedPort, err := strconv.Atoi(sitePort)
+	if err != nil || parsedPort < 1024 || parsedPort > 65535 {
+		return false, "", false, fmt.Errorf("invalid SITE_PORT %q: must be a non-privileged integer port between 1024 and 65535", sitePort)
+	}
+	return true, sitePort, os.Getenv("SERVE_ACCESS_LOG") == "true", nil
+}
+
 func runBuild(outputDir string, filter extractor.SchemaFilter) (extractor.SiteBuildResult, error) {
 	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
 	kubeContext := os.Getenv("KUBECTL_CONTEXT")
@@ -206,6 +221,13 @@ func runWatch(args []string) error {
 
 	leaseName := getEnv("LEASE_NAME", "crd-schema-publisher")
 	healthPort := getEnv("HEALTH_PORT", "8080")
+	serveSite, sitePort, serveAccessLog, err := parseSiteServingConfig(healthPort)
+	if err != nil {
+		return err
+	}
+	if serveSite {
+		slog.Info("site serving enabled", "site_port", sitePort, "access_log", serveAccessLog)
+	}
 
 	cfg, err := extractor.BuildConfig(kubeContext)
 	if err != nil {
@@ -240,18 +262,20 @@ func runWatch(args []string) error {
 	defer cancel()
 
 	return watcher.Run(ctx, watcher.Config{
-		Client:     client,
-		KubeConfig: cfg,
-		OutputDir:  opts.OutputDir,
-		BasePath:   basePath,
-		Publisher:  pub,
-		Debounce:   time.Duration(debounceSeconds) * time.Second,
-		Namespace:  podNamespace,
-		LeaseName:  leaseName,
-		PodName:    podName,
-		HealthPort: healthPort,
-		Filter:     opts.Filter,
-		Profiler:   profiler,
+		Client:        client,
+		KubeConfig:    cfg,
+		OutputDir:     opts.OutputDir,
+		BasePath:      basePath,
+		Publisher:     pub,
+		Debounce:      time.Duration(debounceSeconds) * time.Second,
+		Namespace:     podNamespace,
+		LeaseName:     leaseName,
+		PodName:       podName,
+		HealthPort:    healthPort,
+		SitePort:      sitePort,
+		SiteAccessLog: serveAccessLog,
+		Filter:        opts.Filter,
+		Profiler:      profiler,
 	})
 }
 

--- a/examples/built-in-server/values.yaml
+++ b/examples/built-in-server/values.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sholdee/crd-schema-publisher/refs/heads/main/charts/crd-schema-publisher/values.schema.json
+#
+# Built-in server example - serve CRD schemas from the main controller container
+# Includes a Gateway API HTTPRoute; adapt parentRefs and hostnames to your Gateway.
+#
+# Install:
+#   helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+#     --namespace crd-schema-publisher --create-namespace \
+#     -f values.yaml
+
+serve:
+  enabled: true
+  port: 8081
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: envoy-gateway
+        namespace: gateway
+        sectionName: https
+    hostnames:
+      - kube-schemas.example.com
+
+# Optional, but useful if you want generated schemas to survive pod restarts.
+persistence:
+  enabled: true
+  size: 512Mi

--- a/site/server.go
+++ b/site/server.go
@@ -1,0 +1,103 @@
+package site
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+)
+
+// NewStaticHandler serves generated site files from serveDir.
+// The generated _meta directory is internal and intentionally hidden.
+func NewStaticHandler(serveDir, basePath string) http.Handler {
+	fileHandler := hideMeta(http.FileServer(http.Dir(serveDir)))
+	if basePath == "" {
+		return fileHandler
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(basePath+"/", http.StripPrefix(basePath, fileHandler))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, basePath+"/", http.StatusFound)
+	})
+	return mux
+}
+
+func hideMeta(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clean := path.Clean("/" + strings.TrimPrefix(r.URL.Path, "/"))
+		if clean == "/_meta" || strings.HasPrefix(clean, "/_meta/") {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+type accessLogResponseWriter struct {
+	http.ResponseWriter
+	status int
+	bytes  int64
+}
+
+func (w *accessLogResponseWriter) WriteHeader(status int) {
+	if w.status != 0 {
+		return
+	}
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *accessLogResponseWriter) Write(body []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(body)
+	w.bytes += int64(n)
+	return n, err
+}
+
+func (w *accessLogResponseWriter) statusCode() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func (w *accessLogResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func WithAccessLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		recorder := &accessLogResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(recorder, r)
+		slog.Info("site request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", recorder.statusCode(),
+			"bytes", recorder.bytes,
+			"duration", time.Since(start),
+			"remote_addr", r.RemoteAddr,
+			"user_agent", r.UserAgent(),
+		)
+	})
+}
+
+func StartServer(addr string, handler http.Handler) (*http.Server, error) {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	server := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			slog.Error("site server error", "error", err)
+		}
+	}()
+	return server, nil
+}

--- a/site/server_test.go
+++ b/site/server_test.go
@@ -1,0 +1,141 @@
+package site
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSiteFile(t *testing.T, root, rel, body string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestStaticHandlerServesFilesAndHidesMeta(t *testing.T) {
+	dir := t.TempDir()
+	writeSiteFile(t, dir, "index.html", "index")
+	writeSiteFile(t, dir, "_meta/kinds.json", "{}")
+
+	handler := NewStaticHandler(dir, "")
+
+	ok := httptest.NewRecorder()
+	handler.ServeHTTP(ok, httptest.NewRequest(http.MethodGet, "/", nil))
+	if ok.Code != http.StatusOK {
+		t.Fatalf("expected / status 200, got %d", ok.Code)
+	}
+	if got := ok.Body.String(); got != "index" {
+		t.Fatalf("expected index body, got %q", got)
+	}
+
+	hidden := httptest.NewRecorder()
+	handler.ServeHTTP(hidden, httptest.NewRequest(http.MethodGet, "/_meta/kinds.json", nil))
+	if hidden.Code != http.StatusNotFound {
+		t.Fatalf("expected /_meta/kinds.json status 404, got %d", hidden.Code)
+	}
+}
+
+func TestStaticHandlerBasePathRedirectsRootAndServesPrefixedFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeSiteFile(t, dir, "index.html", "index")
+
+	handler := NewStaticHandler(dir, "/iac")
+
+	redirect := httptest.NewRecorder()
+	handler.ServeHTTP(redirect, httptest.NewRequest(http.MethodGet, "/", nil))
+	if redirect.Code != http.StatusFound {
+		t.Fatalf("expected root redirect status 302, got %d", redirect.Code)
+	}
+	if got := redirect.Header().Get("Location"); got != "/iac/" {
+		t.Fatalf("expected redirect to /iac/, got %q", got)
+	}
+
+	ok := httptest.NewRecorder()
+	handler.ServeHTTP(ok, httptest.NewRequest(http.MethodGet, "/iac/", nil))
+	if ok.Code != http.StatusOK {
+		t.Fatalf("expected /iac/ status 200, got %d", ok.Code)
+	}
+
+	hidden := httptest.NewRecorder()
+	handler.ServeHTTP(hidden, httptest.NewRequest(http.MethodGet, "/iac/_meta/kinds.json", nil))
+	if hidden.Code != http.StatusNotFound {
+		t.Fatalf("expected /iac/_meta/kinds.json status 404, got %d", hidden.Code)
+	}
+}
+
+func TestAccessLogHandlerRecordsRequestMetadata(t *testing.T) {
+	var logs bytes.Buffer
+	orig := slog.Default()
+	defer slog.SetDefault(orig)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+
+	handler := WithAccessLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("body"))
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/schemas/cert_v1.json?ignored=true", nil)
+	req.RemoteAddr = "192.0.2.10:54321"
+	req.Header.Set("User-Agent", "schema-client/1.0")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var entry map[string]any
+	if err := json.Unmarshal(logs.Bytes(), &entry); err != nil {
+		t.Fatalf("decode access log: %v", err)
+	}
+	if entry["msg"] != "site request" {
+		t.Fatalf("expected site request log message, got %#v", entry["msg"])
+	}
+	if entry["method"] != http.MethodGet {
+		t.Fatalf("expected method GET, got %#v", entry["method"])
+	}
+	if entry["path"] != "/schemas/cert_v1.json" {
+		t.Fatalf("expected request path, got %#v", entry["path"])
+	}
+	if entry["status"] != float64(http.StatusTeapot) {
+		t.Fatalf("expected status 418, got %#v", entry["status"])
+	}
+	if entry["bytes"] != float64(4) {
+		t.Fatalf("expected 4 response bytes, got %#v", entry["bytes"])
+	}
+	if entry["remote_addr"] != "192.0.2.10:54321" {
+		t.Fatalf("expected remote addr, got %#v", entry["remote_addr"])
+	}
+	if entry["user_agent"] != "schema-client/1.0" {
+		t.Fatalf("expected user agent, got %#v", entry["user_agent"])
+	}
+	if _, ok := entry["duration"]; !ok {
+		t.Fatal("expected duration in access log")
+	}
+}
+
+func TestStartServerReturnsListenError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	server, err := StartServer(listener.Addr().String(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	if err == nil {
+		if server != nil {
+			_ = server.Close()
+		}
+		t.Fatal("expected StartServer to return a listen error")
+	}
+	if server != nil {
+		t.Fatalf("expected nil server on listen error, got %#v", server)
+	}
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sholdee/crd-schema-publisher/extractor"
 	"github.com/sholdee/crd-schema-publisher/metrics"
 	"github.com/sholdee/crd-schema-publisher/publisher"
+	"github.com/sholdee/crd-schema-publisher/site"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -30,20 +31,22 @@ import (
 
 // Config holds the configuration for the CRD watcher.
 type Config struct {
-	Client     *apiextensionsclient.Clientset
-	KubeConfig *rest.Config
-	OutputDir  string
-	BasePath   string
-	Publisher  *publisher.Publisher // nil = extract-only
-	Debounce   time.Duration
-	Namespace  string
-	LeaseName  string
-	PodName    string
-	HealthPort string
-	Metrics    *metrics.Metrics    // nil = no metrics recording
-	CRDLister  extractor.CRDLister // nil = derive from Client
-	Filter     extractor.SchemaFilter
-	Profiler   diagnostics.Snapshotter
+	Client        *apiextensionsclient.Clientset
+	KubeConfig    *rest.Config
+	OutputDir     string
+	BasePath      string
+	Publisher     *publisher.Publisher // nil = extract-only
+	Debounce      time.Duration
+	Namespace     string
+	LeaseName     string
+	PodName       string
+	HealthPort    string
+	SitePort      string // empty = disabled
+	SiteAccessLog bool
+	Metrics       *metrics.Metrics    // nil = no metrics recording
+	CRDLister     extractor.CRDLister // nil = derive from Client
+	Filter        extractor.SchemaFilter
+	Profiler      diagnostics.Snapshotter
 }
 
 // Run starts the watcher with leader election and health server.
@@ -59,7 +62,30 @@ func Run(ctx context.Context, cfg Config) error {
 	// Start health server before leader election
 	healthReady := &atomic.Bool{}
 	cfg.Metrics = metrics.New()
-	healthServer := startHealthServer(cfg.HealthPort, healthReady, cfg.Metrics)
+	siteReady := func() bool { return true }
+	if cfg.SitePort != "" {
+		siteReady = newSiteReadyChecker(cfg.OutputDir)
+	}
+	healthServer := startHealthServer(cfg.HealthPort, healthReady, cfg.Metrics, siteReady)
+	var siteServer *http.Server
+	if cfg.SitePort != "" {
+		siteDir := extractor.ActiveOutputDir(cfg.OutputDir)
+		handler := site.NewStaticHandler(siteDir, cfg.BasePath)
+		if cfg.SiteAccessLog {
+			handler = site.WithAccessLog(handler)
+		}
+		var err error
+		siteServer, err = site.StartServer(":"+cfg.SitePort, handler)
+		if err != nil {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutdownCancel()
+			if shutdownErr := healthServer.Shutdown(shutdownCtx); shutdownErr != nil {
+				slog.Error("health server shutdown error", "error", shutdownErr)
+			}
+			return fmt.Errorf("starting site server: %w", err)
+		}
+		slog.Info("site server started", "port", cfg.SitePort, "dir", siteDir, "base_path", cfg.BasePath, "access_log", cfg.SiteAccessLog)
+	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg.KubeConfig)
 	if err != nil {
@@ -122,9 +148,32 @@ func Run(ctx context.Context, cfg Config) error {
 	if err := healthServer.Shutdown(shutdownCtx); err != nil {
 		slog.Error("health server shutdown error", "error", err)
 	}
+	if siteServer != nil {
+		siteShutdownCtx, siteShutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer siteShutdownCancel()
+		if err := siteServer.Shutdown(siteShutdownCtx); err != nil {
+			slog.Error("site server shutdown error", "error", err)
+		}
+	}
 
 	slog.Info("shutdown complete")
 	return nil
+}
+
+func activeSiteReady(outputDir string) bool {
+	_, err := os.Stat(filepath.Join(extractor.ActiveOutputDir(outputDir), "index.html"))
+	return err == nil
+}
+
+func newSiteReadyChecker(outputDir string) func() bool {
+	var logged atomic.Bool
+	return func() bool {
+		ready := activeSiteReady(outputDir)
+		if ready && logged.CompareAndSwap(false, true) {
+			slog.Info("site ready", "dir", extractor.ActiveOutputDir(outputDir))
+		}
+		return ready
+	}
 }
 
 func runLeader(ctx context.Context, cfg Config) {
@@ -312,14 +361,14 @@ func cleanDir(dir string) error {
 	return nil
 }
 
-func startHealthServer(port string, ready *atomic.Bool, m *metrics.Metrics) *http.Server {
+func startHealthServer(port string, ready *atomic.Bool, m *metrics.Metrics, extraReady func() bool) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-		if ready.Load() {
+		if ready.Load() && extraReady() {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 		} else {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -1,8 +1,11 @@
 package watcher
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -368,6 +371,77 @@ func TestPublishCycle_UploadError(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "publishing") {
 		t.Fatalf("expected error containing 'publishing', got: %s", got)
+	}
+}
+
+func TestActiveSiteReadyRequiresCurrentIndex(t *testing.T) {
+	dir := t.TempDir()
+	if activeSiteReady(dir) {
+		t.Fatal("expected site to be unready before current/index.html exists")
+	}
+
+	generationDir := filepath.Join(dir, ".generations", "ready")
+	if err := os.MkdirAll(generationDir, 0o755); err != nil {
+		t.Fatalf("mkdir generation: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(generationDir, "index.html"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(".generations", "ready"), filepath.Join(dir, "current")); err != nil {
+		t.Fatalf("symlink current: %v", err)
+	}
+
+	if !activeSiteReady(dir) {
+		t.Fatal("expected site to be ready when current/index.html exists")
+	}
+}
+
+func TestSiteReadyCheckerLogsOnceWhenSiteBecomesReady(t *testing.T) {
+	var logs bytes.Buffer
+	orig := slog.Default()
+	defer slog.SetDefault(orig)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+
+	dir := t.TempDir()
+	checkReady := newSiteReadyChecker(dir)
+	if checkReady() {
+		t.Fatal("expected site to be unready before current/index.html exists")
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("expected no readiness log before site is ready, got %q", logs.String())
+	}
+
+	generationDir := filepath.Join(dir, ".generations", "ready")
+	if err := os.MkdirAll(generationDir, 0o755); err != nil {
+		t.Fatalf("mkdir generation: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(generationDir, "index.html"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(".generations", "ready"), filepath.Join(dir, "current")); err != nil {
+		t.Fatalf("symlink current: %v", err)
+	}
+
+	if !checkReady() {
+		t.Fatal("expected site to be ready when current/index.html exists")
+	}
+	if !checkReady() {
+		t.Fatal("expected site to stay ready")
+	}
+
+	lines := strings.Split(strings.TrimSpace(logs.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly one readiness log, got %d: %q", len(lines), logs.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("decode readiness log: %v", err)
+	}
+	if entry["msg"] != "site ready" {
+		t.Fatalf("expected site ready log message, got %#v", entry["msg"])
+	}
+	if entry["dir"] != filepath.Join(dir, "current") {
+		t.Fatalf("expected active dir in log, got %#v", entry["dir"])
 	}
 }
 


### PR DESCRIPTION
## What

Adds optional built-in local serving in controller mode for the generated static site, using the shared preview static handler and hiding `_meta`.

Adds Helm `serve` values for the site port, access logging, Service/NetworkPolicy/CiliumNetworkPolicy wiring, HTTPRoute support, and validation for controller-only single-replica usage with non-privileged ports.

Updates the built-in server example and Helm CI validation, including render assertions and kubeconform for HTTPRoute-enabled manifests.

E2E validation deployed the current chart to a dedicated test namespace and verified route serving, `_meta` protection, Cloudflare Pages publishing, readiness behavior, and access logs.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified)

Additional checks run:

- [x] `go vet ./...`
- [x] `helm lint charts/crd-schema-publisher --set existingSecret.name=test`
- [x] `actionlint -shellcheck=shellcheck`
- [x] `jq empty charts/crd-schema-publisher/values.schema.json`
- [x] Helm render assertions for `serve.enabled`, access logging, network policies, HTTPRoute, and invalid serve values
- [x] kubeconform against rendered controller and cronjob manifests, including HTTPRoute-enabled controller mode
