### PR TITLE
feat: add grafana operator dashboard support

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -283,6 +283,82 @@ jobs:
             exit 1
           fi
 
+      - name: Verify Grafana Operator dashboard rendering
+        run: |
+          OPERATOR_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.operator.enabled=true \
+            --set-string grafana.dashboard.operator.instanceSelector.matchLabels.dashboards=grafana \
+            --set-string 'grafana.dashboard.operator.datasources[0].inputName=DS_PROMETHEUS' \
+            --set-string 'grafana.dashboard.operator.datasources[0].datasourceName=VictoriaMetrics')
+
+          if ! grep -q "^kind: GrafanaDashboard$" <<< "${OPERATOR_RENDER}"; then
+            echo "ERROR: Grafana Operator mode should render a GrafanaDashboard"
+            exit 1
+          fi
+
+          DASHBOARD_REF=$(yq 'select(.kind == "GrafanaDashboard") | .spec.configMapRef.name' <<< "${OPERATOR_RENDER}")
+          if [[ "${DASHBOARD_REF}" != "test-crd-schema-publisher-dashboard" ]]; then
+            echo "ERROR: GrafanaDashboard should reference the embedded dashboard ConfigMap"
+            exit 1
+          fi
+
+          DASHBOARD_KEY=$(yq 'select(.kind == "GrafanaDashboard") | .spec.configMapRef.key' <<< "${OPERATOR_RENDER}")
+          if [[ "${DASHBOARD_KEY}" != "crd-schema-publisher.json" ]]; then
+            echo "ERROR: GrafanaDashboard should reference crd-schema-publisher.json"
+            exit 1
+          fi
+
+          CROSS_NAMESPACE=$(yq 'select(.kind == "GrafanaDashboard") | .spec.allowCrossNamespaceImport' <<< "${OPERATOR_RENDER}")
+          if [[ "${CROSS_NAMESPACE}" != "true" ]]; then
+            echo "ERROR: GrafanaDashboard should allow cross-namespace import by default"
+            exit 1
+          fi
+
+          DATASOURCE_INPUT=$(yq 'select(.kind == "GrafanaDashboard") | .spec.datasources[0].inputName' <<< "${OPERATOR_RENDER}")
+          if [[ "${DATASOURCE_INPUT}" != "DS_PROMETHEUS" ]]; then
+            echo "ERROR: GrafanaDashboard should include the configured datasource input mapping"
+            exit 1
+          fi
+
+          DATASOURCE_NAME=$(yq 'select(.kind == "GrafanaDashboard") | .spec.datasources[0].datasourceName' <<< "${OPERATOR_RENDER}")
+          if [[ "${DATASOURCE_NAME}" != "VictoriaMetrics" ]]; then
+            echo "ERROR: GrafanaDashboard should include the configured datasource name mapping"
+            exit 1
+          fi
+
+          CM_MANAGER=$(yq 'select(.kind == "ConfigMap" and .metadata.name == "test-crd-schema-publisher-dashboard") | .metadata.labels."app.kubernetes.io/managed-by"' <<< "${OPERATOR_RENDER}")
+          if [[ "${CM_MANAGER}" != "grafana-operator" ]]; then
+            echo "ERROR: operator dashboard ConfigMap should use the Grafana Operator cache label"
+            exit 1
+          fi
+
+      - name: Verify Grafana dashboard option validation
+        run: |
+          if helm template test charts/crd-schema-publisher \
+            --set grafana.dashboard.enabled=true \
+            --set grafana.dashboard.operator.enabled=true \
+            2>/dev/null; then
+            echo "ERROR: sidecar and operator dashboard modes should be mutually exclusive"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher \
+            --set grafana.dashboard.operator.folderRef=folder \
+            --set grafana.dashboard.operator.folderUID=folder-uid \
+            2>/dev/null; then
+            echo "ERROR: folderRef and folderUID should be mutually exclusive"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher \
+            --set grafana.dashboard.operator.enabled=true \
+            --set grafana.dashboard.operator.instanceSelector.mathLabels.dashboards=grafana \
+            2>/dev/null; then
+            echo "ERROR: invalid instanceSelector keys should be rejected by the values schema"
+            exit 1
+          fi
+
       - name: Verify existingClaim suppresses PVC creation
         run: |
           PVC_COUNT=$(helm template test charts/crd-schema-publisher \
@@ -323,6 +399,9 @@ jobs:
             --set-string 'serve.httpRoute.hostnames[0]=kube-schemas-test.mgmt.sholdee.net' \
             --set metrics.podMonitor.enabled=true \
             --set metrics.prometheusRule.enabled=true \
+            --set grafana.dashboard.operator.enabled=true \
+            --set-string 'grafana.dashboard.operator.datasources[0].inputName=DS_PROMETHEUS' \
+            --set-string 'grafana.dashboard.operator.datasources[0].datasourceName=VictoriaMetrics' \
             | kubeconform "${SCHEMA_ARGS[@]}"
 
           echo "Validating cronjob mode..."

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Controller mode still watches all CRDs, then applies the filter to each generate
 
 #### Optional features
 
-Persistent output volume (`persistence`), built-in static serving (`serve`), Gateway API HTTPRoute (`serve.httpRoute`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
+Persistent output volume (`persistence`), built-in static serving (`serve`), Gateway API HTTPRoute (`serve.httpRoute`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap or Grafana Operator `GrafanaDashboard`), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
 
 #### Built-in static serving
 
@@ -408,6 +408,39 @@ spec:
 ```
 
 For vanilla Prometheus, add `prometheus.io/*` annotations to the pod template or configure a static scrape target.
+
+#### Grafana dashboard
+
+The Helm chart can install the included Grafana dashboard in either sidecar-discovery mode or Grafana Operator mode.
+
+For Grafana sidecars that discover dashboard `ConfigMap` objects:
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set grafana.dashboard.enabled=true
+```
+
+For Grafana Operator:
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set grafana.dashboard.operator.enabled=true
+```
+
+Operator mode renders a `GrafanaDashboard` that references the embedded dashboard `ConfigMap`. Use `grafana.dashboard.operator.instanceSelector` if your Grafana instance uses labels other than the default `dashboards: grafana`, and use `grafana.dashboard.operator.folderRef` or `grafana.dashboard.operator.folderUID` to place the dashboard in a specific folder. If your Grafana datasource name is not resolved automatically, map the bundled dashboard input with:
+
+```yaml
+grafana:
+  dashboard:
+    operator:
+      datasources:
+        - inputName: DS_PROMETHEUS
+          datasourceName: Prometheus
+```
+
+Grafana Operator and its CRDs must already be installed in the cluster.
 
 ### Output Structure
 

--- a/charts/crd-schema-publisher/templates/_helpers.tpl
+++ b/charts/crd-schema-publisher/templates/_helpers.tpl
@@ -171,6 +171,18 @@ Validate built-in static site serving options.
 {{- end }}
 
 {{/*
+Validate Grafana dashboard options.
+*/}}
+{{- define "crd-schema-publisher.validateGrafanaDashboard" -}}
+{{- if and .Values.grafana.dashboard.enabled .Values.grafana.dashboard.operator.enabled }}
+{{- fail "grafana.dashboard.enabled and grafana.dashboard.operator.enabled are mutually exclusive - enable only one dashboard provisioning mode" }}
+{{- end }}
+{{- if and .Values.grafana.dashboard.operator.folderRef .Values.grafana.dashboard.operator.folderUID }}
+{{- fail "grafana.dashboard.operator.folderRef and grafana.dashboard.operator.folderUID are mutually exclusive - set only one" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Pod anti-affinity preset.
 Generates preferred (soft) or required (hard) pod anti-affinity rules
 using selector labels and kubernetes.io/hostname topology key.

--- a/charts/crd-schema-publisher/templates/grafana-dashboard-cm.yaml
+++ b/charts/crd-schema-publisher/templates/grafana-dashboard-cm.yaml
@@ -1,12 +1,23 @@
-{{- if .Values.grafana.dashboard.enabled -}}
+{{- if or .Values.grafana.dashboard.enabled .Values.grafana.dashboard.operator.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "crd-schema-publisher.fullname" . }}-dashboard
   labels:
-    {{- include "crd-schema-publisher.labels" . | nindent 4 }}
+    helm.sh/chart: {{ include "crd-schema-publisher.chart" . }}
+    {{- include "crd-schema-publisher.selectorLabels" . | nindent 4 }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+    {{- if .Values.grafana.dashboard.operator.enabled }}
+    app.kubernetes.io/managed-by: grafana-operator
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    {{- if .Values.grafana.dashboard.enabled }}
     {{ .Values.grafana.dashboard.label }}: {{ .Values.grafana.dashboard.labelValue | quote }}
-  {{- if .Values.grafana.dashboard.folder }}
+    {{- end }}
+  {{- if and .Values.grafana.dashboard.enabled .Values.grafana.dashboard.folder }}
   annotations:
     grafana_folder: {{ .Values.grafana.dashboard.folder | quote }}
   {{- end }}

--- a/charts/crd-schema-publisher/templates/grafana-dashboard.yaml
+++ b/charts/crd-schema-publisher/templates/grafana-dashboard.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.grafana.dashboard.operator.enabled -}}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "crd-schema-publisher.fullname" . }}-dashboard
+  labels:
+    {{- include "crd-schema-publisher.labels" . | nindent 4 }}
+    {{- with .Values.grafana.dashboard.operator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.grafana.dashboard.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  instanceSelector:
+    {{- toYaml .Values.grafana.dashboard.operator.instanceSelector | nindent 4 }}
+  {{- if .Values.grafana.dashboard.operator.resyncPeriod }}
+  resyncPeriod: {{ .Values.grafana.dashboard.operator.resyncPeriod | quote }}
+  {{- end }}
+  {{- if .Values.grafana.dashboard.operator.allowCrossNamespaceImport }}
+  allowCrossNamespaceImport: true
+  {{- end }}
+  {{- if .Values.grafana.dashboard.operator.folderRef }}
+  folderRef: {{ .Values.grafana.dashboard.operator.folderRef | quote }}
+  {{- end }}
+  {{- if .Values.grafana.dashboard.operator.folderUID }}
+  folderUID: {{ .Values.grafana.dashboard.operator.folderUID | quote }}
+  {{- end }}
+  {{- with .Values.grafana.dashboard.operator.datasources }}
+  datasources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  configMapRef:
+    name: {{ include "crd-schema-publisher.fullname" . }}-dashboard
+    key: crd-schema-publisher.json
+{{- end }}

--- a/charts/crd-schema-publisher/templates/validations.yaml
+++ b/charts/crd-schema-publisher/templates/validations.yaml
@@ -1,0 +1,1 @@
+{{- include "crd-schema-publisher.validateGrafanaDashboard" . -}}

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -577,6 +577,112 @@
             "folder": {
               "type": "string",
               "description": "Folder annotation for the Grafana sidecar"
+            },
+            "operator": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Install the Grafana dashboard as a Grafana Operator GrafanaDashboard"
+                },
+                "instanceSelector": {
+                  "type": "object",
+                  "description": "Grafana Operator instance selector used by the GrafanaDashboard",
+                  "additionalProperties": false,
+                  "properties": {
+                    "matchLabels": {
+                      "type": "object",
+                      "description": "Label key-value pairs used to match Grafana instances",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "matchExpressions": {
+                      "type": "array",
+                      "description": "Label selector requirements used to match Grafana instances",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Exists",
+                              "DoesNotExist"
+                            ]
+                          },
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "resyncPeriod": {
+                  "type": "string",
+                  "description": "Grafana Operator dashboard resync period"
+                },
+                "folderRef": {
+                  "type": "string",
+                  "description": "GrafanaFolder resource name for dashboard placement"
+                },
+                "folderUID": {
+                  "type": "string",
+                  "description": "Grafana folder UID for dashboard placement"
+                },
+                "allowCrossNamespaceImport": {
+                  "type": "boolean",
+                  "description": "Allow the operator to match Grafana instances outside this namespace"
+                },
+                "datasources": {
+                  "type": "array",
+                  "description": "Grafana Operator datasource mappings for dashboard template inputs",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "inputName",
+                      "datasourceName"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "inputName": {
+                        "type": "string"
+                      },
+                      "datasourceName": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "labels": {
+                  "type": "object",
+                  "description": "Additional labels for the GrafanaDashboard resource",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "annotations": {
+                  "type": "object",
+                  "description": "Additional annotations for the GrafanaDashboard resource",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         }

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -289,7 +289,7 @@ metrics:
 # ---------------------------------------------------------------------------
 grafana:
   dashboard:
-    # -- Install the Grafana dashboard as a ConfigMap
+    # -- Install the Grafana dashboard as a ConfigMap for sidecar discovery
     enabled: false
     # -- Label key for Grafana sidecar discovery
     label: grafana_dashboard
@@ -297,6 +297,29 @@ grafana:
     labelValue: "1"
     # -- Folder annotation for the Grafana sidecar
     folder: ""
+    operator:
+      # -- Install the Grafana dashboard as a Grafana Operator GrafanaDashboard
+      enabled: false
+      # -- Grafana Operator instance selector used by the GrafanaDashboard
+      instanceSelector:
+        matchLabels:
+          dashboards: grafana
+      # -- Grafana Operator dashboard resync period
+      resyncPeriod: 10m
+      # -- GrafanaFolder resource name for dashboard placement
+      folderRef: ""
+      # -- Grafana folder UID for dashboard placement
+      folderUID: ""
+      # -- Allow the operator to match Grafana instances outside this namespace
+      allowCrossNamespaceImport: true
+      # -- Grafana Operator datasource mappings for dashboard template inputs
+      datasources: []
+      #  - inputName: DS_PROMETHEUS
+      #    datasourceName: Prometheus
+      # -- Additional labels for the GrafanaDashboard resource
+      labels: {}
+      # -- Additional annotations for the GrafanaDashboard resource
+      annotations: {}
 
 # ---------------------------------------------------------------------------
 # Network policies


### PR DESCRIPTION
## What

Adds optional Grafana Operator dashboard provisioning for the Helm chart. When enabled, the chart renders a `GrafanaDashboard` that references the embedded dashboard ConfigMap.

Keeps the existing sidecar ConfigMap dashboard mode, adds operator-focused options for selectors, folders, resync period, datasource mappings, and cross-namespace import, and validates mutually exclusive dashboard modes.

Updates Helm CI validation with Grafana Operator render assertions and kubeconform coverage for rendered CRD-backed resources.

E2E validation deployed the current chart to dedicated test namespaces with Grafana Operator installed and verified the dashboard custom resource synchronized into Grafana.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified)

Additional checks run:

- [x] `go vet ./...`
- [x] `helm lint charts/crd-schema-publisher --set existingSecret.name=test`
- [x] `actionlint -shellcheck=shellcheck`
- [x] `jq empty charts/crd-schema-publisher/values.schema.json`
- [x] Helm render assertions for `GrafanaDashboard`, `configMapRef`, datasource mappings, operator cache labels, and invalid dashboard options
- [x] kubeconform against rendered controller and cronjob manifests, including HTTPRoute and GrafanaDashboard-enabled controller mode
