### PR TITLE
fix: avoid merging grafana dashboard selectors

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -288,7 +288,6 @@ jobs:
           OPERATOR_RENDER=$(helm template test charts/crd-schema-publisher \
             --set existingSecret.name=test \
             --set grafana.dashboard.operator.enabled=true \
-            --set-string grafana.dashboard.operator.instanceSelector.matchLabels.dashboards=grafana \
             --set-string 'grafana.dashboard.operator.datasources[0].inputName=DS_PROMETHEUS' \
             --set-string 'grafana.dashboard.operator.datasources[0].datasourceName=VictoriaMetrics')
 
@@ -306,6 +305,81 @@ jobs:
           DASHBOARD_KEY=$(yq 'select(.kind == "GrafanaDashboard") | .spec.configMapRef.key' <<< "${OPERATOR_RENDER}")
           if [[ "${DASHBOARD_KEY}" != "crd-schema-publisher.json" ]]; then
             echo "ERROR: GrafanaDashboard should reference crd-schema-publisher.json"
+            exit 1
+          fi
+
+          DEFAULT_SELECTOR=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector.matchLabels.dashboards' <<< "${OPERATOR_RENDER}")
+          if [[ "${DEFAULT_SELECTOR}" != "grafana" ]]; then
+            echo "ERROR: GrafanaDashboard should render the default dashboards=grafana selector when no selector is provided"
+            exit 1
+          fi
+
+          CUSTOM_SELECTOR_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.operator.enabled=true \
+            --set-string 'grafana.dashboard.operator.instanceSelector.matchLabels.grafana\.internal/instance=home')
+
+          CUSTOM_SELECTOR=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector.matchLabels."grafana.internal/instance"' <<< "${CUSTOM_SELECTOR_RENDER}")
+          if [[ "${CUSTOM_SELECTOR}" != "home" ]]; then
+            echo "ERROR: GrafanaDashboard should render custom instanceSelector.matchLabels"
+            exit 1
+          fi
+
+          UNWANTED_DEFAULT_SELECTOR=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector.matchLabels.dashboards' <<< "${CUSTOM_SELECTOR_RENDER}")
+          if [[ "${UNWANTED_DEFAULT_SELECTOR}" != "null" ]]; then
+            echo "ERROR: custom instanceSelector.matchLabels should not be ANDed with the default dashboards=grafana selector"
+            exit 1
+          fi
+
+          EXPRESSION_SELECTOR_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.operator.enabled=true \
+            --set-string 'grafana.dashboard.operator.instanceSelector.matchExpressions[0].key=grafana.internal/instance' \
+            --set-string 'grafana.dashboard.operator.instanceSelector.matchExpressions[0].operator=In' \
+            --set-string 'grafana.dashboard.operator.instanceSelector.matchExpressions[0].values[0]=home')
+
+          EXPRESSION_SELECTOR_KEY=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector.matchExpressions[0].key' <<< "${EXPRESSION_SELECTOR_RENDER}")
+          if [[ "${EXPRESSION_SELECTOR_KEY}" != "grafana.internal/instance" ]]; then
+            echo "ERROR: GrafanaDashboard should render custom instanceSelector.matchExpressions"
+            exit 1
+          fi
+
+          EXPRESSION_UNWANTED_DEFAULT_SELECTOR=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector.matchLabels.dashboards' <<< "${EXPRESSION_SELECTOR_RENDER}")
+          if [[ "${EXPRESSION_UNWANTED_DEFAULT_SELECTOR}" != "null" ]]; then
+            echo "ERROR: custom instanceSelector.matchExpressions should not be ANDed with the default dashboards=grafana selector"
+            exit 1
+          fi
+
+          MATCH_ALL_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.operator.enabled=true \
+            --set grafana.dashboard.operator.defaultInstanceSelector.enabled=false)
+
+          MATCH_ALL_SELECTOR_KEY_COUNT=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector | keys | length' <<< "${MATCH_ALL_RENDER}")
+          if [[ "${MATCH_ALL_SELECTOR_KEY_COUNT}" != "0" ]]; then
+            echo "ERROR: disabling the default selector with no custom selector should render instanceSelector: {}"
+            exit 1
+          fi
+
+          NULL_DEFAULT_SELECTOR_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.operator.enabled=true \
+            --set-json grafana.dashboard.operator.defaultInstanceSelector=null)
+
+          NULL_DEFAULT_SELECTOR_KEY_COUNT=$(yq 'select(.kind == "GrafanaDashboard") | .spec.instanceSelector | keys | length' <<< "${NULL_DEFAULT_SELECTOR_RENDER}")
+          if [[ "${NULL_DEFAULT_SELECTOR_KEY_COUNT}" != "0" ]]; then
+            echo "ERROR: null defaultInstanceSelector should render instanceSelector: {}"
+            exit 1
+          fi
+
+          FOLDER_RENDER=$(helm template test charts/crd-schema-publisher \
+            --set existingSecret.name=test \
+            --set grafana.dashboard.operator.enabled=true \
+            --set-string grafana.dashboard.operator.folder=Platform)
+
+          DASHBOARD_FOLDER=$(yq 'select(.kind == "GrafanaDashboard") | .spec.folder' <<< "${FOLDER_RENDER}")
+          if [[ "${DASHBOARD_FOLDER}" != "Platform" ]]; then
+            echo "ERROR: grafana.dashboard.operator.folder should render GrafanaDashboard spec.folder"
             exit 1
           fi
 
@@ -348,6 +422,22 @@ jobs:
             --set grafana.dashboard.operator.folderUID=folder-uid \
             2>/dev/null; then
             echo "ERROR: folderRef and folderUID should be mutually exclusive"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher \
+            --set grafana.dashboard.operator.folder=Platform \
+            --set grafana.dashboard.operator.folderRef=folder-ref \
+            2>/dev/null; then
+            echo "ERROR: folder and folderRef should be mutually exclusive"
+            exit 1
+          fi
+
+          if helm template test charts/crd-schema-publisher \
+            --set grafana.dashboard.operator.folder=Platform \
+            --set grafana.dashboard.operator.folderUID=folder-uid \
+            2>/dev/null; then
+            echo "ERROR: folder and folderUID should be mutually exclusive"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,23 @@ helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-sch
   --set grafana.dashboard.operator.enabled=true
 ```
 
-Operator mode renders a `GrafanaDashboard` that references the embedded dashboard `ConfigMap`. Use `grafana.dashboard.operator.instanceSelector` if your Grafana instance uses labels other than the default `dashboards: grafana`, and use `grafana.dashboard.operator.folderRef` or `grafana.dashboard.operator.folderUID` to place the dashboard in a specific folder. If your Grafana datasource name is not resolved automatically, map the bundled dashboard input with:
+Operator mode renders a `GrafanaDashboard` that references the embedded dashboard `ConfigMap`. It selects Grafana instances with `dashboards: grafana` by default. Custom `grafana.dashboard.operator.instanceSelector` values replace that fallback instead of being merged with it:
+
+```yaml
+grafana:
+  dashboard:
+    operator:
+      enabled: true
+      instanceSelector:
+        matchLabels:
+          grafana.internal/instance: home
+```
+
+To intentionally match all Grafana instances visible to the operator, set `grafana.dashboard.operator.defaultInstanceSelector.enabled=false`.
+
+Use `grafana.dashboard.operator.folder` for a Grafana folder title, `grafana.dashboard.operator.folderRef` for a `GrafanaFolder` resource reference, or `grafana.dashboard.operator.folderUID` for an existing Grafana folder UID. Set only one folder option.
+
+If your Grafana datasource name is not resolved automatically, map the bundled dashboard input with:
 
 ```yaml
 grafana:

--- a/charts/crd-schema-publisher/templates/_helpers.tpl
+++ b/charts/crd-schema-publisher/templates/_helpers.tpl
@@ -171,14 +171,34 @@ Validate built-in static site serving options.
 {{- end }}
 
 {{/*
+Render the GrafanaDashboard instanceSelector.
+User-provided matchLabels or matchExpressions take precedence. The default
+selector is intentionally separate from instanceSelector so Helm does not
+deep-merge fallback labels into custom user selectors.
+*/}}
+{{- define "crd-schema-publisher.grafanaDashboardInstanceSelector" -}}
+{{- $selector := .Values.grafana.dashboard.operator.instanceSelector | default dict -}}
+{{- $defaultSelector := .Values.grafana.dashboard.operator.defaultInstanceSelector | default dict -}}
+{{- if or (hasKey $selector "matchLabels") (hasKey $selector "matchExpressions") -}}
+{{- toYaml $selector -}}
+{{- else if (get $defaultSelector "enabled") -}}
+matchLabels:
+  dashboards: grafana
+{{- else -}}
+{}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate Grafana dashboard options.
 */}}
 {{- define "crd-schema-publisher.validateGrafanaDashboard" -}}
 {{- if and .Values.grafana.dashboard.enabled .Values.grafana.dashboard.operator.enabled }}
 {{- fail "grafana.dashboard.enabled and grafana.dashboard.operator.enabled are mutually exclusive - enable only one dashboard provisioning mode" }}
 {{- end }}
-{{- if and .Values.grafana.dashboard.operator.folderRef .Values.grafana.dashboard.operator.folderUID }}
-{{- fail "grafana.dashboard.operator.folderRef and grafana.dashboard.operator.folderUID are mutually exclusive - set only one" }}
+{{- $folderTargets := list .Values.grafana.dashboard.operator.folder .Values.grafana.dashboard.operator.folderRef .Values.grafana.dashboard.operator.folderUID | compact -}}
+{{- if gt (len $folderTargets) 1 }}
+{{- fail "grafana.dashboard.operator.folder, grafana.dashboard.operator.folderRef, and grafana.dashboard.operator.folderUID are mutually exclusive - set only one" }}
 {{- end }}
 {{- end }}
 

--- a/charts/crd-schema-publisher/templates/grafana-dashboard.yaml
+++ b/charts/crd-schema-publisher/templates/grafana-dashboard.yaml
@@ -14,12 +14,15 @@ metadata:
   {{- end }}
 spec:
   instanceSelector:
-    {{- toYaml .Values.grafana.dashboard.operator.instanceSelector | nindent 4 }}
+    {{- include "crd-schema-publisher.grafanaDashboardInstanceSelector" . | nindent 4 }}
   {{- if .Values.grafana.dashboard.operator.resyncPeriod }}
   resyncPeriod: {{ .Values.grafana.dashboard.operator.resyncPeriod | quote }}
   {{- end }}
   {{- if .Values.grafana.dashboard.operator.allowCrossNamespaceImport }}
   allowCrossNamespaceImport: true
+  {{- end }}
+  {{- if .Values.grafana.dashboard.operator.folder }}
+  folder: {{ .Values.grafana.dashboard.operator.folder | quote }}
   {{- end }}
   {{- if .Values.grafana.dashboard.operator.folderRef }}
   folderRef: {{ .Values.grafana.dashboard.operator.folderRef | quote }}

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -588,7 +588,7 @@
                 },
                 "instanceSelector": {
                   "type": "object",
-                  "description": "Grafana Operator instance selector used by the GrafanaDashboard",
+                  "description": "Grafana Operator instance selector used by the GrafanaDashboard. When empty, defaultInstanceSelector is used.",
                   "additionalProperties": false,
                   "properties": {
                     "matchLabels": {
@@ -632,9 +632,24 @@
                     }
                   }
                 },
+                "defaultInstanceSelector": {
+                  "type": "object",
+                  "description": "Fallback Grafana Operator instance selector controls used only when instanceSelector has no matchLabels or matchExpressions",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Render the fallback dashboards=grafana selector when instanceSelector is empty"
+                    }
+                  }
+                },
                 "resyncPeriod": {
                   "type": "string",
                   "description": "Grafana Operator dashboard resync period"
+                },
+                "folder": {
+                  "type": "string",
+                  "description": "Grafana folder title for dashboard placement"
                 },
                 "folderRef": {
                   "type": "string",

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -300,12 +300,15 @@ grafana:
     operator:
       # -- Install the Grafana dashboard as a Grafana Operator GrafanaDashboard
       enabled: false
-      # -- Grafana Operator instance selector used by the GrafanaDashboard
-      instanceSelector:
-        matchLabels:
-          dashboards: grafana
+      # -- Grafana Operator instance selector used by the GrafanaDashboard. When empty, defaultInstanceSelector is used.
+      instanceSelector: {}
+      # -- Render the fallback dashboards=grafana selector when instanceSelector has no matchLabels or matchExpressions
+      defaultInstanceSelector:
+        enabled: true
       # -- Grafana Operator dashboard resync period
       resyncPeriod: 10m
+      # -- Grafana folder title for dashboard placement
+      folder: ""
       # -- GrafanaFolder resource name for dashboard placement
       folderRef: ""
       # -- Grafana folder UID for dashboard placement


### PR DESCRIPTION
## What

Fixes Grafana Operator dashboard rendering so custom instance selectors replace the chart fallback instead of being ANDed with `dashboards=grafana`.

- moves the fallback selector behind `grafana.dashboard.operator.defaultInstanceSelector.enabled`
- renders `spec.folder` correctly and keeps `folder`, `folderRef`, and `folderUID` mutually exclusive
- adds Helm CI assertions for selector fallback, custom selectors, `defaultInstanceSelector=null`, folder rendering, and validation failures

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified)

Additional validation:
- [x] `helm lint charts/crd-schema-publisher --set existingSecret.name=test`
- [x] `actionlint -shellcheck=shellcheck`
- [x] `jq empty charts/crd-schema-publisher/values.schema.json`
- [x] targeted Helm selector assertions for default, custom, disabled fallback, and null fallback
- [x] review agent re-review: ready to merge