### PR TITLE
refactor: deepen runtime config parsing

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -29,17 +29,17 @@ func init() {
 }
 
 func runPreview(args []string) error {
-	outputDir, explicit, err := parseOutputDirArg("preview", args, "")
+	cfg, err := parsePreviewConfig(args)
 	if err != nil {
 		return err
 	}
-	if explicit {
-		if err := requireExistingOutputDir(outputDir, "Pass --output-dir to a pre-created directory"); err != nil {
+	if cfg.ExplicitOutputDir {
+		if err := requireExistingOutputDir(cfg.OutputDir, "Pass --output-dir to a pre-created directory"); err != nil {
 			return err
 		}
 	}
 	basePath := normalizeBasePath(os.Getenv("BASE_PATH"))
-	serveDir, cleanup, err := preparePreviewSiteFunc(outputDir, basePath, os.Getenv("SKIP_RENDER") != "true")
+	serveDir, cleanup, err := preparePreviewSiteFunc(cfg.OutputDir, basePath, os.Getenv("SKIP_RENDER") != "true")
 	if err != nil {
 		return err
 	}

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -24,11 +23,6 @@ const (
 	schemaFilterVersionEnv = "SCHEMA_FILTER_VERSION"
 )
 
-type runtimeCommandOptions struct {
-	OutputDir string
-	Filter    extractor.SchemaFilter
-}
-
 func init() {
 	registerCommand("run", runAll)
 	registerCommand("extract", runExtract)
@@ -42,40 +36,26 @@ func init() {
 }
 
 func runExtract(args []string) error {
-	fs := newCommandFlagSet("extract")
-	var outputDir string
-	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", os.Getenv("OUTPUT_DIR"), "output directory")
-	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
-	kubeContext := fs.String("context", os.Getenv("KUBECTL_CONTEXT"), "Kubernetes context")
-	skipRender := fs.Bool("skip-render", os.Getenv("SKIP_RENDER") == "true", "skip HTML rendering")
-	kind := fs.String("kind", os.Getenv(schemaFilterKindEnv), "filter by kind (comma-separated, case-insensitive)")
-	group := fs.String("group", os.Getenv(schemaFilterGroupEnv), "filter by group (comma-separated, case-insensitive)")
-	version := fs.String("version", os.Getenv(schemaFilterVersionEnv), "filter by version (comma-separated, case-insensitive)")
-
-	if err := fs.Parse(args); err != nil {
+	cfg, err := parseExtractConfig(args, os.Getenv)
+	if err != nil {
 		return err
 	}
-	if extras := fs.Args(); len(extras) > 0 {
-		return fmt.Errorf("unexpected arguments for extract: %s", strings.Join(extras, " "))
-	}
-	if err := requireConfiguredOutputDir(outputDir, "Provide a writable directory for extracted schemas"); err != nil {
+	if err := requireConfiguredOutputDir(cfg.OutputDir, "Provide a writable directory for extracted schemas"); err != nil {
 		return err
 	}
 
 	slog.Info("building kubernetes client")
-	client, err := buildClientFunc(*kubeContext)
+	client, err := buildClientFunc(cfg.KubeContext)
 	if err != nil {
 		return fmt.Errorf("building client: %w", err)
 	}
 
-	filter := extractor.ParseFilter(*kind, *group, *version)
-
 	result, err := buildSiteFunc(extractor.SiteBuildOptions{
 		Lister:    client.ApiextensionsV1().CustomResourceDefinitions(),
-		OutputDir: outputDir,
-		BasePath:  normalizeBasePath(*basePath),
-		Render:    !*skipRender,
-		Filter:    filter,
+		OutputDir: cfg.OutputDir,
+		BasePath:  normalizeBasePath(cfg.BasePath),
+		Render:    cfg.Render,
+		Filter:    cfg.Filter,
 		Profiler:  diagnostics.NewFromEnv(),
 	})
 	if err != nil {
@@ -86,28 +66,12 @@ func runExtract(args []string) error {
 		return nil
 	}
 
-	slog.Info("extract complete", "count", result.SchemaCount, "dir", outputDir)
+	slog.Info("extract complete", "count", result.SchemaCount, "dir", cfg.OutputDir)
 	return nil
 }
 
 func parseRuntimeCommandArgs(cmd string, args []string, fallbackOutputDir string) (runtimeCommandOptions, error) {
-	fs := newCommandFlagSet(cmd)
-	var outputDir string
-	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", fallbackOutputDir, "output directory")
-	kind := fs.String("kind", os.Getenv(schemaFilterKindEnv), "filter by kind (comma-separated, case-insensitive)")
-	group := fs.String("group", os.Getenv(schemaFilterGroupEnv), "filter by group (comma-separated, case-insensitive)")
-	version := fs.String("version", os.Getenv(schemaFilterVersionEnv), "filter by version (comma-separated, case-insensitive)")
-	if err := fs.Parse(args); err != nil {
-		return runtimeCommandOptions{}, err
-	}
-	if extras := fs.Args(); len(extras) > 0 {
-		return runtimeCommandOptions{}, fmt.Errorf("unexpected arguments for %s: %s", cmd, strings.Join(extras, " "))
-	}
-
-	return runtimeCommandOptions{
-		OutputDir: outputDir,
-		Filter:    extractor.ParseFilter(*kind, *group, *version),
-	}, nil
+	return parseRuntimeConfig(cmd, args, fallbackOutputDir, os.Getenv)
 }
 
 func parseSiteServingConfig(healthPort string) (bool, string, bool, error) {
@@ -156,11 +120,11 @@ func runBuild(outputDir string, filter extractor.SchemaFilter) (extractor.SiteBu
 }
 
 func runUpload(args []string) error {
-	outputDir, _, err := parseOutputDirArg("upload", args, getEnv("OUTPUT_DIR", "/output"))
+	cfg, err := parseUploadCommandConfig(args, os.Getenv)
 	if err != nil {
 		return err
 	}
-	if err := requireExistingOutputDir(outputDir, "Set OUTPUT_DIR or pass --output-dir to a pre-created directory"); err != nil {
+	if err := requireExistingOutputDir(cfg.OutputDir, "Set OUTPUT_DIR or pass --output-dir to a pre-created directory"); err != nil {
 		return err
 	}
 
@@ -187,7 +151,7 @@ func runUpload(args []string) error {
 		UploadConcurrency:     uploadConfig.Concurrency,
 	}
 
-	return p.Publish(outputDir)
+	return p.Publish(cfg.OutputDir)
 }
 
 func runWatch(args []string) error {

--- a/cmd/runtime_config.go
+++ b/cmd/runtime_config.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+)
+
+type envGetter func(string) string
+
+type runtimeConfig struct {
+	OutputDir string
+	Filter    extractor.SchemaFilter
+}
+
+type runtimeCommandOptions = runtimeConfig
+
+type extractConfig struct {
+	OutputDir   string
+	BasePath    string
+	KubeContext string
+	Render      bool
+	Filter      extractor.SchemaFilter
+}
+
+type uploadCommandConfig struct {
+	OutputDir         string
+	ExplicitOutputDir bool
+}
+
+type previewConfig struct {
+	OutputDir         string
+	ExplicitOutputDir bool
+}
+
+func envDefault(env envGetter, key, fallback string) string {
+	if env == nil {
+		return fallback
+	}
+	if v := env(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func parseRuntimeConfig(cmd string, args []string, fallbackOutputDir string, env envGetter) (runtimeConfig, error) {
+	fs := newCommandFlagSet(cmd)
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", fallbackOutputDir, "output directory")
+	kind := fs.String("kind", envDefault(env, schemaFilterKindEnv, ""), "filter by kind (comma-separated, case-insensitive)")
+	group := fs.String("group", envDefault(env, schemaFilterGroupEnv, ""), "filter by group (comma-separated, case-insensitive)")
+	version := fs.String("version", envDefault(env, schemaFilterVersionEnv, ""), "filter by version (comma-separated, case-insensitive)")
+	if err := fs.Parse(args); err != nil {
+		return runtimeConfig{}, err
+	}
+	if extras := fs.Args(); len(extras) > 0 {
+		return runtimeConfig{}, fmt.Errorf("unexpected arguments for %s: %s", cmd, strings.Join(extras, " "))
+	}
+	return runtimeConfig{
+		OutputDir: outputDir,
+		Filter:    extractor.ParseFilter(*kind, *group, *version),
+	}, nil
+}
+
+func parseExtractConfig(args []string, env envGetter) (extractConfig, error) {
+	fs := newCommandFlagSet("extract")
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", envDefault(env, "OUTPUT_DIR", ""), "output directory")
+	basePath := fs.String("base-path", envDefault(env, "BASE_PATH", ""), "URL path prefix for subpath deployments")
+	kubeContext := fs.String("context", envDefault(env, "KUBECTL_CONTEXT", ""), "Kubernetes context")
+	skipRender := fs.Bool("skip-render", envDefault(env, "SKIP_RENDER", "") == "true", "skip HTML rendering")
+	kind := fs.String("kind", envDefault(env, schemaFilterKindEnv, ""), "filter by kind (comma-separated, case-insensitive)")
+	group := fs.String("group", envDefault(env, schemaFilterGroupEnv, ""), "filter by group (comma-separated, case-insensitive)")
+	version := fs.String("version", envDefault(env, schemaFilterVersionEnv, ""), "filter by version (comma-separated, case-insensitive)")
+	if err := fs.Parse(args); err != nil {
+		return extractConfig{}, err
+	}
+	if extras := fs.Args(); len(extras) > 0 {
+		return extractConfig{}, fmt.Errorf("unexpected arguments for extract: %s", strings.Join(extras, " "))
+	}
+	return extractConfig{
+		OutputDir:   outputDir,
+		BasePath:    *basePath,
+		KubeContext: *kubeContext,
+		Render:      !*skipRender,
+		Filter:      extractor.ParseFilter(*kind, *group, *version),
+	}, nil
+}
+
+func parseUploadCommandConfig(args []string, env envGetter) (uploadCommandConfig, error) {
+	outputDir, explicit, err := parseOutputDirArg("upload", args, envDefault(env, "OUTPUT_DIR", "/output"))
+	if err != nil {
+		return uploadCommandConfig{}, err
+	}
+	return uploadCommandConfig{OutputDir: outputDir, ExplicitOutputDir: explicit}, nil
+}
+
+func parsePreviewConfig(args []string) (previewConfig, error) {
+	outputDir, explicit, err := parseOutputDirArg("preview", args, "")
+	if err != nil {
+		return previewConfig{}, err
+	}
+	return previewConfig{OutputDir: outputDir, ExplicitOutputDir: explicit}, nil
+}

--- a/cmd/runtime_config_test.go
+++ b/cmd/runtime_config_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func mapEnv(values map[string]string) envGetter {
+	return func(key string) string {
+		return values[key]
+	}
+}
+
+func TestRuntimeConfig_RunOutputDirFlagOverridesEnv(t *testing.T) {
+	cfg, err := parseRuntimeConfig("run", []string{"--output-dir", "/flag-output"}, "/env-output", mapEnv(nil))
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig: %v", err)
+	}
+	if cfg.OutputDir != "/flag-output" {
+		t.Fatalf("expected flag output dir, got %q", cfg.OutputDir)
+	}
+}
+
+func TestRuntimeConfig_RunFilterFlagsOverrideEnv(t *testing.T) {
+	env := mapEnv(map[string]string{
+		schemaFilterKindEnv:    "EnvKind",
+		schemaFilterGroupEnv:   "env.example.io",
+		schemaFilterVersionEnv: "v1alpha1",
+	})
+	cfg, err := parseRuntimeConfig("run", []string{"--kind", "FlagKind", "--group", "flag.example.io", "--version", "v1"}, "/output", env)
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig: %v", err)
+	}
+	if !cfg.Filter.Matches("FlagKind", "flag.example.io", "v1") {
+		t.Fatalf("expected filter to match flag values: %#v", cfg.Filter)
+	}
+	if cfg.Filter.Matches("EnvKind", "env.example.io", "v1alpha1") {
+		t.Fatalf("expected env filter to be overridden by flags: %#v", cfg.Filter)
+	}
+}
+
+func TestExtractConfig_UsesEnvDefaultsAndFlagOverrides(t *testing.T) {
+	env := mapEnv(map[string]string{
+		"OUTPUT_DIR":           "/env-output",
+		"BASE_PATH":            "/env-base",
+		"KUBECTL_CONTEXT":      "env-context",
+		"SKIP_RENDER":          "true",
+		schemaFilterKindEnv:    "EnvKind",
+		schemaFilterGroupEnv:   "env.example.io",
+		schemaFilterVersionEnv: "v1alpha1",
+	})
+	cfg, err := parseExtractConfig([]string{
+		"--output-dir", "/flag-output",
+		"--base-path", "/flag-base",
+		"--context", "flag-context",
+		"--skip-render=false",
+		"--kind", "FlagKind",
+	}, env)
+	if err != nil {
+		t.Fatalf("parseExtractConfig: %v", err)
+	}
+	if cfg.OutputDir != "/flag-output" || cfg.BasePath != "/flag-base" || cfg.KubeContext != "flag-context" || !cfg.Render {
+		t.Fatalf("unexpected extract config: %#v", cfg)
+	}
+	if !cfg.Filter.Matches("FlagKind", "env.example.io", "v1alpha1") {
+		t.Fatalf("expected mixed flag/env filter values: %#v", cfg.Filter)
+	}
+}
+
+func TestUploadConfig_FlagOutputDirOverridesEnv(t *testing.T) {
+	cfg, err := parseUploadCommandConfig([]string{"--output-dir", "/flag-output"}, mapEnv(map[string]string{"OUTPUT_DIR": "/env-output"}))
+	if err != nil {
+		t.Fatalf("parseUploadCommandConfig: %v", err)
+	}
+	if cfg.OutputDir != "/flag-output" || !cfg.ExplicitOutputDir {
+		t.Fatalf("unexpected upload config: %#v", cfg)
+	}
+}
+
+func TestPreviewConfig_IgnoresAmbientOutputDir(t *testing.T) {
+	cfg, err := parsePreviewConfig(nil)
+	if err != nil {
+		t.Fatalf("parsePreviewConfig: %v", err)
+	}
+	if cfg.OutputDir != "" || cfg.ExplicitOutputDir {
+		t.Fatalf("preview must ignore ambient OUTPUT_DIR unless a flag is passed: %#v", cfg)
+	}
+}
+
+func TestCommandConfig_RejectsUnexpectedArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{name: "run", run: func() error {
+			_, err := parseRuntimeConfig("run", []string{"unexpected"}, "/output", mapEnv(nil))
+			return err
+		}, want: "unexpected arguments for run: unexpected"},
+		{name: "extract", run: func() error { _, err := parseExtractConfig([]string{"unexpected"}, mapEnv(nil)); return err }, want: "unexpected arguments for extract: unexpected"},
+		{name: "upload", run: func() error { _, err := parseUploadCommandConfig([]string{"unexpected"}, mapEnv(nil)); return err }, want: "unexpected arguments for upload: unexpected"},
+		{name: "preview", run: func() error { _, err := parsePreviewConfig([]string{"unexpected"}); return err }, want: "unexpected arguments for preview: unexpected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Splits runtime CLI/env parsing from command execution while preserving command behavior. Verified with focused cmd tests and the release-candidate smoke suite.