### PR TITLE
refactor: split watcher lifecycle

### DIFF
--- a/watcher/debounce.go
+++ b/watcher/debounce.go
@@ -1,0 +1,165 @@
+package watcher
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sholdee/crd-schema-publisher/metrics"
+)
+
+func signalTrigger(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+		// Channel already has a pending signal
+	}
+}
+
+// drainTimeout bounds how long we wait for an in-flight publish to finish
+// during shutdown. Must be less than terminationGracePeriodSeconds (default 30s)
+// to leave time for health server shutdown and process cleanup.
+const drainTimeout = 25 * time.Second
+
+type debounceClock interface {
+	NewTimer(time.Duration) debounceTimer
+	NewTicker(time.Duration) debounceTicker
+	After(time.Duration) <-chan time.Time
+}
+
+type debounceTimer interface {
+	Stop() bool
+	Reset(time.Duration) bool
+	C() <-chan time.Time
+}
+
+type debounceTicker interface {
+	Stop()
+	C() <-chan time.Time
+}
+
+type realDebounceClock struct{}
+
+func (realDebounceClock) NewTimer(d time.Duration) debounceTimer {
+	return realDebounceTimer{timer: time.NewTimer(d)}
+}
+
+func (realDebounceClock) NewTicker(d time.Duration) debounceTicker {
+	return realDebounceTicker{ticker: time.NewTicker(d)}
+}
+
+func (realDebounceClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+type realDebounceTimer struct {
+	timer *time.Timer
+}
+
+func (t realDebounceTimer) Stop() bool {
+	return t.timer.Stop()
+}
+
+func (t realDebounceTimer) Reset(d time.Duration) bool {
+	return t.timer.Reset(d)
+}
+
+func (t realDebounceTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+type realDebounceTicker struct {
+	ticker *time.Ticker
+}
+
+func (t realDebounceTicker) Stop() {
+	t.ticker.Stop()
+}
+
+func (t realDebounceTicker) C() <-chan time.Time {
+	return t.ticker.C
+}
+
+func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func() error, m *metrics.Metrics, done <-chan struct{}) {
+	debounceLoopWithClock(trigger, duration, publish, m, done, realDebounceClock{})
+}
+
+func debounceLoopWithClock(trigger <-chan struct{}, duration time.Duration, publish func() error, m *metrics.Metrics, done <-chan struct{}, clock debounceClock) {
+	var timer debounceTimer
+	var timerC <-chan time.Time
+	var publishing atomic.Bool
+	var wg sync.WaitGroup
+	first := true
+	if clock == nil {
+		clock = realDebounceClock{}
+	}
+	heartbeat := clock.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+	heartbeatC := heartbeat.C()
+	m.Heartbeat() // initial heartbeat on loop entry
+
+	for {
+		select {
+		case <-done:
+			if timer != nil {
+				timer.Stop()
+			}
+			// Wait for in-flight publish to complete, bounded by drainTimeout
+			drained := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(drained)
+			}()
+			select {
+			case <-drained:
+			case <-clock.After(drainTimeout):
+				slog.Warn("drain timeout exceeded, abandoning in-flight publish")
+			}
+			return
+		case <-trigger:
+			m.Heartbeat()
+			d := duration
+			if first {
+				d = 0
+				first = false
+			}
+			if timer == nil {
+				timer = clock.NewTimer(d)
+				timerC = timer.C()
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C():
+					default:
+					}
+				}
+				timer.Reset(d)
+			}
+		case <-heartbeatC:
+			m.Heartbeat()
+		case <-timerC:
+			m.Heartbeat()
+			timer = nil
+			timerC = nil
+			startPublishIfIdle(&publishing, &wg, publish, m)
+		}
+	}
+}
+
+func startPublishIfIdle(publishing *atomic.Bool, wg *sync.WaitGroup, publish func() error, m *metrics.Metrics) {
+	if !publishing.CompareAndSwap(false, true) {
+		slog.Warn("publish already in progress, skipping")
+		m.RecordSkip()
+		return
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer publishing.Store(false)
+		slog.Info("running publish cycle")
+		if err := publish(); err != nil {
+			slog.Error("publish cycle failed", "error", err)
+		}
+	}()
+}

--- a/watcher/lifecycle.go
+++ b/watcher/lifecycle.go
@@ -1,0 +1,97 @@
+package watcher
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+	"github.com/sholdee/crd-schema-publisher/metrics"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+func activeSiteReady(outputDir string) bool {
+	_, err := os.Stat(filepath.Join(extractor.ActiveOutputDir(outputDir), "index.html"))
+	return err == nil
+}
+
+func newSiteReadyChecker(outputDir string) func() bool {
+	var logged atomic.Bool
+	return func() bool {
+		ready := activeSiteReady(outputDir)
+		if ready && logged.CompareAndSwap(false, true) {
+			slog.Info("site ready", "dir", extractor.ActiveOutputDir(outputDir))
+		}
+		return ready
+	}
+}
+
+func runLeader(ctx context.Context, cfg Config) {
+	// Set up CRD informer
+	trigger := make(chan struct{}, 1)
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (k8sruntime.Object, error) {
+			return cfg.Client.ApiextensionsV1().CustomResourceDefinitions().List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return cfg.Client.ApiextensionsV1().CustomResourceDefinitions().Watch(ctx, opts)
+		},
+	}
+
+	notify := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { signalTrigger(trigger) },
+		UpdateFunc: func(old, new interface{}) { signalTrigger(trigger) },
+		DeleteFunc: func(obj interface{}) { signalTrigger(trigger) },
+	}
+
+	_, controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: lw,
+		ObjectType:    &apiextensionsv1.CustomResourceDefinition{},
+		Handler:       notify,
+	})
+
+	go controller.Run(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), controller.HasSynced) {
+		slog.Error("failed to sync informer cache")
+		return
+	}
+	slog.Info("CRD informer synced, watching for changes")
+
+	debounceLoop(trigger, cfg.Debounce, func() error {
+		return publishCycle(cfg)
+	}, cfg.Metrics, ctx.Done())
+}
+
+func startHealthServer(port string, ready *atomic.Bool, m *metrics.Metrics, extraReady func() bool) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if ready.Load() && extraReady() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+		}
+	})
+	mux.Handle("/metrics", m.Handler())
+	server := &http.Server{Addr: ":" + port, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("health server error", "error", err)
+		}
+	}()
+	return server
+}

--- a/watcher/publish.go
+++ b/watcher/publish.go
@@ -1,0 +1,59 @@
+package watcher
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+)
+
+func publishCycle(cfg Config) (retErr error) {
+	start := time.Now()
+	defer func() {
+		cfg.Metrics.RecordPublishCycle(time.Since(start), retErr)
+	}()
+	// Reset discovery gauges so they reflect each cycle, not stale previous values
+	cfg.Metrics.RecordDiscovery(0, 0)
+
+	var lister extractor.CRDLister
+	if cfg.CRDLister != nil {
+		lister = cfg.CRDLister
+	} else {
+		lister = cfg.Client.ApiextensionsV1().CustomResourceDefinitions()
+	}
+
+	result, err := extractor.BuildSite(extractor.SiteBuildOptions{
+		Lister:    lister,
+		OutputDir: cfg.OutputDir,
+		BasePath:  cfg.BasePath,
+		Render:    os.Getenv("SKIP_RENDER") != "true",
+		Filter:    cfg.Filter,
+		Profiler:  cfg.Profiler,
+	})
+	if err != nil {
+		return err
+	}
+	if result.Status == extractor.BuildResultNoop {
+		slog.Info("no CRDs found, leaving existing output untouched")
+		return nil
+	}
+
+	cfg.Metrics.RecordDiscovery(result.CRDCount, result.SchemaCount)
+	slog.Info("wrote schemas", "count", result.SchemaCount)
+	slog.Info("generated index")
+
+	// Upload (if publisher configured)
+	if cfg.Publisher != nil {
+		if cfg.Publisher.Profiler == nil {
+			cfg.Publisher.Profiler = cfg.Profiler
+		}
+		if err := cfg.Publisher.Publish(cfg.OutputDir); err != nil {
+			return fmt.Errorf("publishing: %w", err)
+		}
+	}
+
+	slog.Info("publish cycle complete", "duration", time.Since(start).Round(time.Millisecond))
+	return nil
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,14 +16,10 @@ import (
 	"github.com/sholdee/crd-schema-publisher/publisher"
 	"github.com/sholdee/crd-schema-publisher/site"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
@@ -160,191 +155,6 @@ func Run(ctx context.Context, cfg Config) error {
 	return nil
 }
 
-func activeSiteReady(outputDir string) bool {
-	_, err := os.Stat(filepath.Join(extractor.ActiveOutputDir(outputDir), "index.html"))
-	return err == nil
-}
-
-func newSiteReadyChecker(outputDir string) func() bool {
-	var logged atomic.Bool
-	return func() bool {
-		ready := activeSiteReady(outputDir)
-		if ready && logged.CompareAndSwap(false, true) {
-			slog.Info("site ready", "dir", extractor.ActiveOutputDir(outputDir))
-		}
-		return ready
-	}
-}
-
-func runLeader(ctx context.Context, cfg Config) {
-	// Set up CRD informer
-	trigger := make(chan struct{}, 1)
-	lw := &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (k8sruntime.Object, error) {
-			return cfg.Client.ApiextensionsV1().CustomResourceDefinitions().List(ctx, opts)
-		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return cfg.Client.ApiextensionsV1().CustomResourceDefinitions().Watch(ctx, opts)
-		},
-	}
-
-	notify := cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { signalTrigger(trigger) },
-		UpdateFunc: func(old, new interface{}) { signalTrigger(trigger) },
-		DeleteFunc: func(obj interface{}) { signalTrigger(trigger) },
-	}
-
-	_, controller := cache.NewInformerWithOptions(cache.InformerOptions{
-		ListerWatcher: lw,
-		ObjectType:    &apiextensionsv1.CustomResourceDefinition{},
-		Handler:       notify,
-	})
-
-	go controller.Run(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), controller.HasSynced) {
-		slog.Error("failed to sync informer cache")
-		return
-	}
-	slog.Info("CRD informer synced, watching for changes")
-
-	debounceLoop(trigger, cfg.Debounce, func() error {
-		return publishCycle(cfg)
-	}, cfg.Metrics, ctx.Done())
-}
-
-func signalTrigger(ch chan struct{}) {
-	select {
-	case ch <- struct{}{}:
-	default:
-		// Channel already has a pending signal
-	}
-}
-
-// drainTimeout bounds how long we wait for an in-flight publish to finish
-// during shutdown. Must be less than terminationGracePeriodSeconds (default 30s)
-// to leave time for health server shutdown and process cleanup.
-const drainTimeout = 25 * time.Second
-
-func debounceLoop(trigger <-chan struct{}, duration time.Duration, publish func() error, m *metrics.Metrics, done <-chan struct{}) {
-	var timer *time.Timer
-	var timerC <-chan time.Time
-	var publishing atomic.Bool
-	var wg sync.WaitGroup
-	first := true
-	heartbeat := time.NewTicker(30 * time.Second)
-	defer heartbeat.Stop()
-	m.Heartbeat() // initial heartbeat on loop entry
-
-	for {
-		select {
-		case <-done:
-			if timer != nil {
-				timer.Stop()
-			}
-			// Wait for in-flight publish to complete, bounded by drainTimeout
-			drained := make(chan struct{})
-			go func() {
-				wg.Wait()
-				close(drained)
-			}()
-			select {
-			case <-drained:
-			case <-time.After(drainTimeout):
-				slog.Warn("drain timeout exceeded, abandoning in-flight publish")
-			}
-			return
-		case <-trigger:
-			m.Heartbeat()
-			d := duration
-			if first {
-				d = 0
-				first = false
-			}
-			if timer == nil {
-				timer = time.NewTimer(d)
-				timerC = timer.C
-			} else {
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				timer.Reset(d)
-			}
-		case <-heartbeat.C:
-			m.Heartbeat()
-		case <-timerC:
-			m.Heartbeat()
-			timer = nil
-			timerC = nil
-			if !publishing.CompareAndSwap(false, true) {
-				slog.Warn("publish already in progress, skipping")
-				m.RecordSkip()
-				continue
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				defer publishing.Store(false)
-				slog.Info("running publish cycle")
-				if err := publish(); err != nil {
-					slog.Error("publish cycle failed", "error", err)
-				}
-			}()
-		}
-	}
-}
-
-func publishCycle(cfg Config) (retErr error) {
-	start := time.Now()
-	defer func() {
-		cfg.Metrics.RecordPublishCycle(time.Since(start), retErr)
-	}()
-	// Reset discovery gauges so they reflect each cycle, not stale previous values
-	cfg.Metrics.RecordDiscovery(0, 0)
-
-	var lister extractor.CRDLister
-	if cfg.CRDLister != nil {
-		lister = cfg.CRDLister
-	} else {
-		lister = cfg.Client.ApiextensionsV1().CustomResourceDefinitions()
-	}
-
-	result, err := extractor.BuildSite(extractor.SiteBuildOptions{
-		Lister:    lister,
-		OutputDir: cfg.OutputDir,
-		BasePath:  cfg.BasePath,
-		Render:    os.Getenv("SKIP_RENDER") != "true",
-		Filter:    cfg.Filter,
-		Profiler:  cfg.Profiler,
-	})
-	if err != nil {
-		return err
-	}
-	if result.Status == extractor.BuildResultNoop {
-		slog.Info("no CRDs found, leaving existing output untouched")
-		return nil
-	}
-
-	cfg.Metrics.RecordDiscovery(result.CRDCount, result.SchemaCount)
-	slog.Info("wrote schemas", "count", result.SchemaCount)
-	slog.Info("generated index")
-
-	// Upload (if publisher configured)
-	if cfg.Publisher != nil {
-		if cfg.Publisher.Profiler == nil {
-			cfg.Publisher.Profiler = cfg.Profiler
-		}
-		if err := cfg.Publisher.Publish(cfg.OutputDir); err != nil {
-			return fmt.Errorf("publishing: %w", err)
-		}
-	}
-
-	slog.Info("publish cycle complete", "duration", time.Since(start).Round(time.Millisecond))
-	return nil
-}
-
 func cleanDir(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -359,29 +169,4 @@ func cleanDir(dir string) error {
 		}
 	}
 	return nil
-}
-
-func startHealthServer(port string, ready *atomic.Bool, m *metrics.Metrics, extraReady func() bool) *http.Server {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-		if ready.Load() && extraReady() {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte("not ready"))
-		}
-	})
-	mux.Handle("/metrics", m.Handler())
-	server := &http.Server{Addr: ":" + port, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
-	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("health server error", "error", err)
-		}
-	}()
-	return server
 }

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -59,114 +59,279 @@ func testCRD() apiextensionsv1.CustomResourceDefinition {
 	}
 }
 
-// --- debounce tests ---
-
-func TestDebounce_FirstTriggerFiresImmediately(t *testing.T) {
-	var fired atomic.Bool
-	trigger := make(chan struct{}, 1)
-	done := make(chan struct{})
-
-	go debounceLoop(trigger, 200*time.Millisecond, func() error {
-		fired.Store(true)
-		return nil
-	}, nil, done)
-
-	trigger <- struct{}{}
-
-	// First trigger should fire well before the 200ms debounce duration
-	time.Sleep(50 * time.Millisecond)
-	if !fired.Load() {
-		t.Fatal("expected first trigger to fire immediately, but it did not")
+func waitUntil(t *testing.T, deadline time.Duration, cond func() bool) {
+	t.Helper()
+	timeout := time.After(deadline)
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("condition not met before deadline")
+		case <-tick.C:
+			if cond() {
+				return
+			}
+		}
 	}
-	close(done)
 }
 
-func TestDebounce_SubsequentTriggerIsDebounced(t *testing.T) {
+func waitForClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("channel did not close before deadline")
+	}
+}
+
+type fakeDebounceClock struct {
+	mu     sync.Mutex
+	timers []*fakeDebounceTimer
+	afters []chan time.Time
+}
+
+func (c *fakeDebounceClock) NewTimer(d time.Duration) debounceTimer {
+	timer := &fakeDebounceTimer{c: make(chan time.Time, 1), duration: d}
+	c.mu.Lock()
+	c.timers = append(c.timers, timer)
+	c.mu.Unlock()
+	return timer
+}
+
+func (c *fakeDebounceClock) NewTicker(time.Duration) debounceTicker {
+	return &fakeDebounceTicker{c: make(chan time.Time, 1)}
+}
+
+func (c *fakeDebounceClock) After(time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	c.mu.Lock()
+	c.afters = append(c.afters, ch)
+	c.mu.Unlock()
+	return ch
+}
+
+func (c *fakeDebounceClock) timerCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.timers)
+}
+
+func (c *fakeDebounceClock) afterCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.afters)
+}
+
+func (c *fakeDebounceClock) latestTimerDuration() time.Duration {
+	c.mu.Lock()
+	timer := c.timers[len(c.timers)-1]
+	c.mu.Unlock()
+	return timer.currentDuration()
+}
+
+func (c *fakeDebounceClock) latestTimerResetCount() int {
+	c.mu.Lock()
+	timer := c.timers[len(c.timers)-1]
+	c.mu.Unlock()
+	return timer.resetCount()
+}
+
+func (c *fakeDebounceClock) fireLatestTimer() {
+	c.mu.Lock()
+	timer := c.timers[len(c.timers)-1]
+	c.mu.Unlock()
+	timer.fire()
+}
+
+type fakeDebounceTimer struct {
+	mu       sync.Mutex
+	c        chan time.Time
+	duration time.Duration
+	stopped  bool
+	resets   int
+}
+
+func (t *fakeDebounceTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	active := !t.stopped
+	t.stopped = true
+	return active
+}
+
+func (t *fakeDebounceTimer) Reset(d time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	active := !t.stopped
+	t.duration = d
+	t.stopped = false
+	t.resets++
+	return active
+}
+
+func (t *fakeDebounceTimer) C() <-chan time.Time {
+	return t.c
+}
+
+func (t *fakeDebounceTimer) currentDuration() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.duration
+}
+
+func (t *fakeDebounceTimer) resetCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.resets
+}
+
+func (t *fakeDebounceTimer) fire() {
+	select {
+	case t.c <- time.Now():
+	default:
+	}
+}
+
+type fakeDebounceTicker struct {
+	c chan time.Time
+}
+
+func (t *fakeDebounceTicker) Stop() {}
+
+func (t *fakeDebounceTicker) C() <-chan time.Time {
+	return t.c
+}
+
+func startDebounceWithClock(trigger <-chan struct{}, duration time.Duration, publish func() error, m *metrics.Metrics, done <-chan struct{}, clock debounceClock) <-chan struct{} {
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		debounceLoopWithClock(trigger, duration, publish, m, done, clock)
+	}()
+	return loopDone
+}
+
+// --- debounce tests ---
+
+func TestDebounceClock_FirstTriggerFiresImmediately(t *testing.T) {
 	var count atomic.Int32
 	trigger := make(chan struct{}, 1)
 	done := make(chan struct{})
+	clock := &fakeDebounceClock{}
 
-	go debounceLoop(trigger, 200*time.Millisecond, func() error {
+	loopDone := startDebounceWithClock(trigger, time.Hour, func() error {
 		count.Add(1)
 		return nil
-	}, nil, done)
+	}, nil, done, clock)
+
+	trigger <- struct{}{}
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 1 })
+
+	if got := clock.latestTimerDuration(); got != 0 {
+		t.Fatalf("expected first trigger to use zero-duration timer, got %s", got)
+	}
+	clock.fireLatestTimer()
+	waitUntil(t, time.Second, func() bool { return count.Load() == 1 })
+	close(done)
+	waitForClosed(t, loopDone)
+}
+
+func TestDebounceClock_SubsequentTriggerWaitsForTimer(t *testing.T) {
+	var count atomic.Int32
+	trigger := make(chan struct{}, 1)
+	done := make(chan struct{})
+	clock := &fakeDebounceClock{}
+	debounceDuration := time.Hour
+
+	loopDone := startDebounceWithClock(trigger, debounceDuration, func() error {
+		count.Add(1)
+		return nil
+	}, nil, done, clock)
 
 	// First trigger — fires immediately
 	trigger <- struct{}{}
-	time.Sleep(50 * time.Millisecond)
-	if c := count.Load(); c != 1 {
-		t.Fatalf("expected 1 publish after first trigger, got %d", c)
-	}
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 1 })
+	clock.fireLatestTimer()
+	waitUntil(t, time.Second, func() bool { return count.Load() == 1 })
 
 	// Second trigger — should be debounced
 	trigger <- struct{}{}
-	time.Sleep(50 * time.Millisecond)
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 2 })
+	if got := clock.latestTimerDuration(); got != debounceDuration {
+		t.Fatalf("expected subsequent trigger to wait %s, got %s", debounceDuration, got)
+	}
 	if c := count.Load(); c != 1 {
 		t.Fatalf("expected second trigger to be debounced (still 1), got %d", c)
 	}
 
-	// Wait for debounce to fire
-	time.Sleep(300 * time.Millisecond)
-	if c := count.Load(); c != 2 {
-		t.Fatalf("expected 2 publishes after debounce, got %d", c)
-	}
+	clock.fireLatestTimer()
+	waitUntil(t, time.Second, func() bool { return count.Load() == 2 })
 	close(done)
+	waitForClosed(t, loopDone)
 }
 
-func TestDebounce_CoalescesRapidEvents(t *testing.T) {
+func TestDebounceClock_CoalescesRapidEvents(t *testing.T) {
 	var count atomic.Int32
 	trigger := make(chan struct{}, 10)
 	done := make(chan struct{})
+	clock := &fakeDebounceClock{}
 
-	go debounceLoop(trigger, 100*time.Millisecond, func() error {
+	loopDone := startDebounceWithClock(trigger, time.Hour, func() error {
 		count.Add(1)
 		return nil
-	}, nil, done)
+	}, nil, done, clock)
 
-	// First trigger fires immediately
 	trigger <- struct{}{}
-	time.Sleep(50 * time.Millisecond)
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 1 })
+	clock.fireLatestTimer()
+	waitUntil(t, time.Second, func() bool { return count.Load() == 1 })
 
-	// Send 4 more events in rapid succession — these should coalesce into 1 debounced publish
-	for range 4 {
+	for range 3 {
 		trigger <- struct{}{}
-		time.Sleep(10 * time.Millisecond)
 	}
+	waitUntil(t, time.Second, func() bool {
+		return clock.timerCount() == 2 && clock.latestTimerResetCount() == 2
+	})
 
-	// Wait for debounce to fire
-	time.Sleep(300 * time.Millisecond)
+	clock.fireLatestTimer()
+	waitUntil(t, time.Second, func() bool { return count.Load() == 2 })
 	close(done)
-
-	// 1 immediate + 1 debounced = 2 total (not 5)
-	if c := count.Load(); c != 2 {
-		t.Fatalf("expected 2 publish cycles (1 immediate + 1 debounced), got %d", c)
-	}
+	waitForClosed(t, loopDone)
 }
 
-func TestDebounce_SkipsWhenPublishInProgress(t *testing.T) {
+func TestDebounceClock_SkipsWhenPublishInProgress(t *testing.T) {
 	var count atomic.Int32
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
 	m := metrics.New()
 	trigger := make(chan struct{}, 10)
 	done := make(chan struct{})
+	clock := &fakeDebounceClock{}
 
-	go debounceLoop(trigger, 50*time.Millisecond, func() error {
+	loopDone := startDebounceWithClock(trigger, time.Hour, func() error {
 		count.Add(1)
-		// Simulate slow publish
-		time.Sleep(300 * time.Millisecond)
+		close(publishStarted)
+		<-releasePublish
 		return nil
-	}, m, done)
+	}, m, done, clock)
 
-	// First event triggers publish
+	// First trigger fires immediately
 	trigger <- struct{}{}
-	time.Sleep(100 * time.Millisecond) // debounce fires, publish starts (takes 300ms)
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 1 })
+	clock.fireLatestTimer()
+	waitForClosed(t, publishStarted)
 
 	// Second event during publish — debounce fires but publish in progress, skip
 	trigger <- struct{}{}
-	time.Sleep(100 * time.Millisecond) // debounce fires while first publish still running
-
-	// Wait for everything to settle
-	time.Sleep(500 * time.Millisecond)
-	close(done)
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 2 })
+	clock.fireLatestTimer()
+	waitUntil(t, time.Second, func() bool {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		m.Handler().ServeHTTP(rec, req)
+		return strings.Contains(rec.Body.String(), "crdpublisher_publish_skipped_total 1")
+	})
 
 	// Only 1 publish should have run (second was skipped)
 	if c := count.Load(); c != 1 {
@@ -180,35 +345,44 @@ func TestDebounce_SkipsWhenPublishInProgress(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "crdpublisher_publish_skipped_total 1") {
 		t.Fatalf("expected publish_skipped_total=1 in:\n%s", rec.Body.String())
 	}
+	close(releasePublish)
+	close(done)
+	waitForClosed(t, loopDone)
 }
 
-func TestDebounce_DrainsInFlightPublishOnShutdown(t *testing.T) {
+func TestDebounceClock_ShutdownDrainsInFlightPublish(t *testing.T) {
 	var count atomic.Int32
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
 	trigger := make(chan struct{}, 10)
 	done := make(chan struct{})
+	clock := &fakeDebounceClock{}
 
-	var loopDone sync.WaitGroup
-	loopDone.Add(1)
-
-	go func() {
-		defer loopDone.Done()
-		debounceLoop(trigger, 50*time.Millisecond, func() error {
-			count.Add(1)
-			// Simulate slow publish
-			time.Sleep(500 * time.Millisecond)
-			return nil
-		}, nil, done)
-	}()
+	loopDone := startDebounceWithClock(trigger, time.Hour, func() error {
+		count.Add(1)
+		close(publishStarted)
+		<-releasePublish
+		return nil
+	}, nil, done, clock)
 
 	// Trigger a publish
 	trigger <- struct{}{}
-	time.Sleep(100 * time.Millisecond) // debounce fires, publish starts
+	waitUntil(t, time.Second, func() bool { return clock.timerCount() == 1 })
+	clock.fireLatestTimer()
+	waitForClosed(t, publishStarted)
 
 	// Shut down while publish is in progress
 	close(done)
+	waitUntil(t, time.Second, func() bool { return clock.afterCount() == 1 })
 
-	// debounceLoop should block until publish completes, then return
-	loopDone.Wait()
+	select {
+	case <-loopDone:
+		t.Fatal("debounceLoop returned before in-flight publish completed")
+	default:
+	}
+
+	close(releasePublish)
+	waitForClosed(t, loopDone)
 
 	// The in-flight publish must have completed (not been killed)
 	if c := count.Load(); c != 1 {


### PR DESCRIPTION
Splits watcher debounce, lifecycle, and publish-cycle responsibilities while preserving watch-mode behavior. Live k3s watch-mode smoke and focused watcher tests passed.