### PR TITLE
ci: run all theme javascript tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
-      - name: Run schema search JS tests
-        run: node --test theme/schema_search.test.js
+      - name: Run theme JS tests
+        run: node --test theme/*.test.js
 
       - name: Run tests
         run: go test -race ./... -v -coverprofile=coverage.txt -covermode=atomic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ git config core.hooksPath .githooks
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
 - All Go tests must pass: `go test ./...`
-- If you change `theme/schema_search.js` or `theme/schema_search.test.js`, also run: `node --test theme/schema_search.test.js`
+- If you change theme JavaScript or tests, also run: `node --test theme/*.test.js`
 - Linter must pass: `golangci-lint run`
 - Run `go mod tidy` when changing dependencies
 - All changes require a pull request to `main` -- direct pushes are blocked


### PR DESCRIPTION
## What

Run the full theme JavaScript test set in CI instead of only the schema search tests, and update contributor instructions to use the same command.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] GitHub Actions pinned by SHA with version comment (if modified)

Additional verification:

- [x] `node --test theme/*.test.js`
- [x] `actionlint .github/workflows/test.yml`
- [x] `npx --yes markdownlint-cli2@0.22.1 CONTRIBUTING.md`
- [x] `git diff --check`