### PR TITLE
ci: add release smoke gate

### DIFF
--- a/.github/workflows/release-smoke-rehearsal.yaml
+++ b/.github/workflows/release-smoke-rehearsal.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release Smoke Rehearsal
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_repository:
+        description: Container image repository to install during rehearsal
+        required: true
+        type: string
+        default: ghcr.io/sholdee/crd-schema-publisher
+      image_digest:
+        description: Image digest to install during rehearsal, e.g. sha256:<64 hex chars>
+        required: true
+        type: string
+
+concurrency:
+  group: release-smoke-rehearsal-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  rehearsal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      IMAGE_REPOSITORY: ${{ inputs.image_repository }}
+      IMAGE_DIGEST: ${{ inputs.image_digest }}
+      CF_PAGES_E2E_ACCOUNT_ID: ${{ secrets.CF_PAGES_E2E_ACCOUNT_ID }}
+      CF_PAGES_E2E_API_TOKEN: ${{ secrets.CF_PAGES_E2E_API_TOKEN }}
+      CF_PAGES_E2E_PROJECT: ${{ secrets.CF_PAGES_E2E_PROJECT }}
+      RUN_MARKER: rehearsal-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+      MARKER_GROUP: rehearsal-${{ github.run_id }}-${{ github.run_attempt }}.ci.crd-schema-publisher.dev
+      NAMESPACE: crd-schema-publisher-rehearsal-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate rehearsal inputs and secrets
+        run: |
+          test -n "${IMAGE_REPOSITORY}" || { echo "image_repository input is required"; exit 1; }
+          if [[ ! "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "image_digest input must match sha256:<64 lowercase hex chars>"
+            exit 1
+          fi
+          test -n "${CF_PAGES_E2E_ACCOUNT_ID}" || { echo "CF_PAGES_E2E_ACCOUNT_ID is required"; exit 1; }
+          test -n "${CF_PAGES_E2E_API_TOKEN}" || { echo "CF_PAGES_E2E_API_TOKEN is required"; exit 1; }
+          test -n "${CF_PAGES_E2E_PROJECT}" || { echo "CF_PAGES_E2E_PROJECT is required"; exit 1; }
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Set up kubectl
+        uses: Azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: crd-schema-publisher-release-smoke-rehearsal
+          wait: 120s
+
+      - name: Run release smoke rehearsal
+        run: hack/release-smoke/validate.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/helm-lint.yml
 
   binaries:
-    needs: [test, build]
+    needs: [test, build, release-smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -160,8 +160,48 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  release-smoke:
+    needs: [build, helm-lint]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+      IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
+      CF_PAGES_E2E_ACCOUNT_ID: ${{ secrets.CF_PAGES_E2E_ACCOUNT_ID }}
+      CF_PAGES_E2E_API_TOKEN: ${{ secrets.CF_PAGES_E2E_API_TOKEN }}
+      CF_PAGES_E2E_PROJECT: ${{ secrets.CF_PAGES_E2E_PROJECT }}
+      RUN_MARKER: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+      MARKER_GROUP: smoke-${{ github.run_id }}-${{ github.run_attempt }}.ci.crd-schema-publisher.dev
+      NAMESPACE: crd-schema-publisher-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate release smoke secrets
+        run: |
+          test -n "${CF_PAGES_E2E_ACCOUNT_ID}" || { echo "CF_PAGES_E2E_ACCOUNT_ID is required"; exit 1; }
+          test -n "${CF_PAGES_E2E_API_TOKEN}" || { echo "CF_PAGES_E2E_API_TOKEN is required"; exit 1; }
+          test -n "${CF_PAGES_E2E_PROJECT}" || { echo "CF_PAGES_E2E_PROJECT is required"; exit 1; }
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Set up kubectl
+        uses: Azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: crd-schema-publisher-release-smoke
+          wait: 120s
+
+      - name: Run release smoke
+        run: hack/release-smoke/validate.sh
+
   sign:
-    needs: [build]
+    needs: [build, release-smoke]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -187,7 +227,7 @@ jobs:
           cosign sign --yes "${FULL_IMAGE}:latest@${DIGEST}"
 
   helm-package:
-    needs: [helm-lint, build, sign]
+    needs: [helm-lint, build, sign, release-smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Four workflow files in `.github/workflows/`:
 | `test.yml` | `workflow_call` | Reusable: actionlint, markdownlint-cli2, golangci-lint, go mod verify/tidy, go test, go vet, govulncheck |
 | `helm-lint.yml` | `workflow_call` | Reusable: `helm lint`, `helm template` in controller/cronjob/all-features modes, mode isolation checks, schema validation, dashboard JSON embedding, kubeconform |
 | `ci.yaml` | PR + push to `main` | Orchestrator: calls `test.yml` and `helm-lint.yml`, runs detect/build/renovate/gate |
-| `release.yaml` | `workflow_dispatch` | Orchestrator: calls `test.yml` and `helm-lint.yml`, runs build/sign/helm-package/release |
+| `release.yaml` | `workflow_dispatch` | Orchestrator: calls `test.yml` and `helm-lint.yml`, builds the candidate image, runs release-smoke, then signs/packages/releases |
 
 **`ci.yaml`** jobs:
 
@@ -180,11 +180,12 @@ Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR
 | --- | --------- | ------- |
 | `test` | Always | Calls `test.yml` — re-runs all linting and Go tests as a safety net before building |
 | `helm-lint` | Always | Calls `helm-lint.yml` — re-runs all Helm validation before packaging |
-| `binaries` | After `test` and `build` pass | Cross-compiles static binaries for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, generates `checksums-sha256.txt`, signs the checksum manifest with cosign keyless blob signing, uploads `dist/` as artifacts for the `release` job, and publishes GitHub/Sigstore build provenance for the binaries via the attestations service. |
-| `build` | After `test` passes | Multi-arch Docker build (amd64 + arm64), pushes `vYYYY.MDD.HMMSS` + `latest` to GHCR. Verifies distroless base image digest with cosign before building. |
-| `sign` | After `build` | Cosign keyless signing via GitHub OIDC |
-| `helm-package` | After `helm-lint`, `build`, and `sign` | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
-| `release` | After `build`, `sign`, `helm-package`, `binaries` | Creates git tag, GitHub Release with auto-generated notes, image digest, chart OCI reference, signed checksum manifest, binary provenance link, and standalone binaries. Note: tag push will fail if the tagged commit includes workflow file changes — create the tag manually in that case. |
+| `build` | After `test` passes | Multi-arch Docker build (amd64 + arm64), pushes `vYYYY.MDD.HMMSS` + `latest` to GHCR. Verifies distroless base image digest with cosign before building. This creates the unsigned candidate image used by release-smoke. |
+| `release-smoke` | After `build` and `helm-lint` pass | Starts a temporary kind cluster, applies a unique marker CRD, installs the chart in controller/watch mode using the candidate image digest and dedicated Cloudflare CI credentials, then fetches the published Pages deployment to verify the current marker and core site assets. Blocks all promotional artifacts if it fails. |
+| `sign` | After `build` and `release-smoke` pass | Cosign keyless signing via GitHub OIDC |
+| `helm-package` | After `helm-lint`, `build`, `release-smoke`, and `sign` pass | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
+| `binaries` | After `build` and `release-smoke` pass | Cross-compiles static binaries for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, generates `checksums-sha256.txt`, signs the checksum manifest with cosign keyless blob signing, uploads `dist/` as artifacts for the `release` job, and publishes GitHub/Sigstore build provenance for the binaries via the attestations service. |
+| `release` | After `build`, `sign`, `helm-package`, and `binaries` pass | Creates git tag, GitHub Release with auto-generated notes, image digest, chart OCI reference, signed checksum manifest, binary provenance link, and standalone binaries. |
 
 App image and Helm chart are always released together with the same CalVer version. Releases are decoupled from CI — trigger the release workflow when changes warrant a new version. The release workflow re-runs all tests before building as a safety net. A concurrency group prevents simultaneous releases from racing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Everything else in `go.mod` is transitive. The project still leans heavily on th
 
 ### Pipeline Architecture
 
-Four workflow files in `.github/workflows/`:
+Five workflow files in `.github/workflows/`:
 
 | File | Trigger | Purpose |
 | --- | ------- | ------- |
@@ -160,6 +160,7 @@ Four workflow files in `.github/workflows/`:
 | `helm-lint.yml` | `workflow_call` | Reusable: `helm lint`, `helm template` in controller/cronjob/all-features modes, mode isolation checks, schema validation, dashboard JSON embedding, kubeconform |
 | `ci.yaml` | PR + push to `main` | Orchestrator: calls `test.yml` and `helm-lint.yml`, runs detect/build/renovate/gate |
 | `release.yaml` | `workflow_dispatch` | Orchestrator: calls `test.yml` and `helm-lint.yml`, builds the candidate image, runs release-smoke, then signs/packages/releases |
+| `release-smoke-rehearsal.yaml` | `workflow_dispatch` | Manual pre-release rehearsal that runs the same smoke script against a maintainer-supplied image digest without creating release artifacts |
 
 **`ci.yaml`** jobs:
 
@@ -188,6 +189,14 @@ Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR
 | `release` | After `build`, `sign`, `helm-package`, and `binaries` pass | Creates git tag, GitHub Release with auto-generated notes, image digest, chart OCI reference, signed checksum manifest, binary provenance link, and standalone binaries. |
 
 App image and Helm chart are always released together with the same CalVer version. Releases are decoupled from CI — trigger the release workflow when changes warrant a new version. The release workflow re-runs all tests before building as a safety net. A concurrency group prevents simultaneous releases from racing.
+
+**`release-smoke-rehearsal.yaml`** jobs:
+
+| Job | Runs when | Purpose |
+| --- | --------- | ------- |
+| `rehearsal` | Manual dispatch with `image_repository` and `image_digest` inputs | Starts a temporary kind cluster and runs `hack/release-smoke/validate.sh` against an existing image digest using dedicated Cloudflare CI credentials. Produces no release artifacts and does not push tags, images, charts, binaries, or GitHub Releases. |
+
+The rehearsal workflow is for validating the external smoke path before a release: kind, Helm install, watch mode, Cloudflare upload, marker freshness, and HTTP checks. It requires the same dedicated repository secrets as the release gate: `CF_PAGES_E2E_ACCOUNT_ID`, `CF_PAGES_E2E_API_TOKEN`, and `CF_PAGES_E2E_PROJECT`. The `image_digest` input must be a `sha256:<64 lowercase hex chars>` digest; the workflow intentionally does not resolve tags.
 
 ### Tags
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ ghcr.io/sholdee/crd-schema-publisher:latest
 
 Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. PR builds get `pr-N` tags for testing.
 
+The manual release workflow also runs a release smoke gate before signing images, pushing the Helm chart, creating binary provenance, tagging the commit, or creating the GitHub Release. The smoke gate starts a temporary kind cluster, installs the candidate image by digest with the Helm chart in controller/watch mode, publishes a unique marker CRD catalog to a dedicated Cloudflare Pages project, and fetches the published site to verify the current marker and core static assets.
+
+Maintainers must configure dedicated CI-only Cloudflare Pages secrets before triggering releases:
+
+- `CF_PAGES_E2E_ACCOUNT_ID`
+- `CF_PAGES_E2E_API_TOKEN`
+- `CF_PAGES_E2E_PROJECT`
+
+Use a dedicated Pages project and a token scoped only to the permissions needed to edit that project. Missing smoke secrets fail the release workflow before any promotional artifacts are created beyond the unsigned candidate image tag.
+
 Images use `gcr.io/distroless/static:nonroot` as the runtime base — no shell, no package manager, runs as UID 65534. Production images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing via GitHub Actions OIDC:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -258,17 +258,7 @@ Pre-built multi-arch images (amd64 + arm64) are published to GHCR:
 ghcr.io/sholdee/crd-schema-publisher:latest
 ```
 
-Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. PR builds get `pr-N` tags for testing.
-
-The manual release workflow also runs a release smoke gate before signing images, pushing the Helm chart, creating binary provenance, tagging the commit, or creating the GitHub Release. The smoke gate starts a temporary kind cluster, installs the candidate image by digest with the Helm chart in controller/watch mode, publishes a unique marker CRD catalog to a dedicated Cloudflare Pages project, and fetches the published site to verify the current marker and core static assets.
-
-Maintainers must configure dedicated CI-only Cloudflare Pages secrets before triggering releases:
-
-- `CF_PAGES_E2E_ACCOUNT_ID`
-- `CF_PAGES_E2E_API_TOKEN`
-- `CF_PAGES_E2E_PROJECT`
-
-Use a dedicated Pages project and a token scoped only to the permissions needed to edit that project. Missing smoke secrets fail the release workflow before any promotional artifacts are created beyond the unsigned candidate image tag.
+Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. The workflow runs an internal smoke gate before release artifacts are promoted. PR builds get `pr-N` tags for testing.
 
 Images use `gcr.io/distroless/static:nonroot` as the runtime base — no shell, no package manager, runs as UID 65534. Production images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing via GitHub Actions OIDC:
 

--- a/hack/release-smoke/marker-crd.yaml
+++ b/hack/release-smoke/marker-crd.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: releasesmokes.__MARKER_GROUP__
+spec:
+  group: __MARKER_GROUP__
+  names:
+    plural: releasesmokes
+    singular: releasesmoke
+    kind: ReleaseSmoke
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: "crd-schema-publisher release smoke __RUN_MARKER__"
+          properties:
+            spec:
+              type: object
+              description: "Release smoke validation payload"
+              properties:
+                runID:
+                  type: string
+                  enum:
+                    - "__RUN_MARKER__"
+                  description: "Current release smoke run marker __RUN_MARKER__"

--- a/hack/release-smoke/validate.sh
+++ b/hack/release-smoke/validate.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE="${ROOT_DIR}/hack/release-smoke/marker-crd.yaml"
+
+required_env=(
+  IMAGE_REPOSITORY
+  IMAGE_DIGEST
+  CF_PAGES_E2E_ACCOUNT_ID
+  CF_PAGES_E2E_API_TOKEN
+  CF_PAGES_E2E_PROJECT
+  RUN_MARKER
+  MARKER_GROUP
+  NAMESPACE
+)
+
+required_tools=(
+  curl
+  grep
+  helm
+  kind
+  kubectl
+  sed
+)
+
+fail() {
+  echo "release smoke error: $*" >&2
+  exit 1
+}
+
+require_env() {
+  local name
+  for name in "${required_env[@]}"; do
+    if [ -z "${!name:-}" ]; then
+      fail "required environment variable ${name} is not set"
+    fi
+  done
+}
+
+require_tools() {
+  local tool
+  for tool in "${required_tools[@]}"; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      fail "required tool ${tool} is not installed"
+    fi
+  done
+}
+
+render_marker_crd() {
+  sed \
+    -e "s/__MARKER_GROUP__/${MARKER_GROUP}/g" \
+    -e "s/__RUN_MARKER__/${RUN_MARKER}/g" \
+    "${FIXTURE}"
+}
+
+create_cloudflare_secret() {
+  kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n "${NAMESPACE}" create secret generic cloudflare-pages-e2e \
+    --from-literal=CLOUDFLARE_ACCOUNT_ID="${CF_PAGES_E2E_ACCOUNT_ID}" \
+    --from-literal=CLOUDFLARE_API_TOKEN="${CF_PAGES_E2E_API_TOKEN}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+install_marker_crd() {
+  local rendered
+  rendered="$(mktemp)"
+  render_marker_crd > "${rendered}" || {
+    rm -f "${rendered}"
+    return 1
+  }
+  trap 'rm -f "${rendered}"; trap - ERR RETURN' ERR RETURN
+
+  kubectl apply -f "${rendered}"
+  kubectl wait \
+    --for=condition=Established \
+    "crd/releasesmokes.${MARKER_GROUP}" \
+    --timeout=60s
+}
+
+install_chart() {
+  helm upgrade --install crd-schema-publisher "${ROOT_DIR}/charts/crd-schema-publisher" \
+    --namespace "${NAMESPACE}" \
+    --create-namespace \
+    --wait \
+    --timeout 2m \
+    --set mode=controller \
+    --set replicaCount=1 \
+    --set image.repository="${IMAGE_REPOSITORY}" \
+    --set-string image.digest="${IMAGE_DIGEST}" \
+    --set image.pullPolicy=Always \
+    --set existingSecret.name=cloudflare-pages-e2e \
+    --set config.cfPagesProject="${CF_PAGES_E2E_PROJECT}" \
+    --set-string config.debounceSeconds=1 \
+    --set-string config.filter.group="${MARKER_GROUP}"
+}
+
+deployment_logs() {
+  kubectl -n "${NAMESPACE}" logs deployment/crd-schema-publisher --all-containers=true --since=10m 2>/dev/null || true
+}
+
+deployment_url_from_logs() {
+  deployment_logs \
+    | sed -n 's/.*"url":"\([^"]*\)".*/\1/p' \
+    | tail -n 1
+}
+
+fetch() {
+  local url="$1"
+  curl -fsSL --retry 3 --retry-delay 2 "${url}"
+}
+
+assert_url_contains() {
+  local url="$1"
+  local expected="$2"
+  local body
+  body="$(fetch "${url}")" || return 1
+  if ! grep -Fq "${expected}" <<<"${body}"; then
+    echo "Expected ${url} to contain ${expected}" >&2
+    return 1
+  fi
+}
+
+assert_url_reachable() {
+  local url="$1"
+  fetch "${url}" >/dev/null
+}
+
+validate_site_at() {
+  local raw_base="$1"
+  local base="${raw_base%/}"
+
+  echo "Validating release smoke site at ${base}"
+  assert_url_contains "${base}/index.html" "${MARKER_GROUP}" || return 1
+  assert_url_contains "${base}/${MARKER_GROUP}/releasesmoke_v1.json" "${RUN_MARKER}" || return 1
+  assert_url_contains "${base}/${MARKER_GROUP}/releasesmoke_v1.html" "${RUN_MARKER}" || return 1
+  assert_url_contains "${base}/master-standalone/${MARKER_GROUP}-releasesmoke-stable-v1.json" "${RUN_MARKER}" || return 1
+  assert_url_reachable "${base}/schema-search.js" || return 1
+  assert_url_reachable "${base}/favicon.svg" || return 1
+}
+
+dump_debug_state() {
+  echo "::group::release smoke kubernetes state"
+  kubectl -n "${NAMESPACE}" get all || true
+  kubectl get "crd/releasesmokes.${MARKER_GROUP}" -o yaml || true
+  echo "::endgroup::"
+
+  echo "::group::release smoke logs"
+  deployment_logs || true
+  echo "::endgroup::"
+}
+
+wait_for_site() {
+  local fixed_url="https://${CF_PAGES_E2E_PROJECT}.pages.dev"
+  local log_url=""
+  local i
+
+  for i in $(seq 1 48); do
+    log_url="$(deployment_url_from_logs)"
+
+    if [ -n "${log_url}" ] && validate_site_at "${log_url}"; then
+      echo "Release smoke validated deployment URL: ${log_url}"
+      return 0
+    fi
+
+    if validate_site_at "${fixed_url}"; then
+      echo "Release smoke validated fallback project URL: ${fixed_url}"
+      return 0
+    fi
+
+    echo "Waiting for current marker ${RUN_MARKER} to be published (${i}/48)"
+    sleep 5
+  done
+
+  dump_debug_state
+  fail "published Cloudflare Pages site did not expose marker ${RUN_MARKER}"
+}
+
+main() {
+  require_env
+  require_tools
+
+  if [ ! -f "${FIXTURE}" ]; then
+    fail "marker fixture not found at ${FIXTURE}"
+  fi
+
+  create_cloudflare_secret
+  install_marker_crd
+  install_chart
+  wait_for_site
+}
+
+main "$@"


### PR DESCRIPTION
## What

Adds a manual-release-only smoke gate that:

- starts a temporary kind cluster
- applies a unique marker CRD
- installs the chart in controller/watch mode with the candidate image digest
- publishes to a dedicated Cloudflare Pages CI project
- validates the published site contains the current marker and core assets

The smoke gate blocks signing, chart packaging, binaries, tagging, and GitHub Release creation if it fails.

Also adds a manual Release Smoke Rehearsal workflow for validating the same external smoke path against a maintainer-supplied existing image digest before running a release.

## Secrets

Uses repository secrets:

- `CF_PAGES_E2E_ACCOUNT_ID`
- `CF_PAGES_E2E_API_TOKEN`
- `CF_PAGES_E2E_PROJECT`

## Verification

- [x] `bash -n hack/release-smoke/validate.sh`
- [x] `actionlint .github/workflows/release.yaml .github/workflows/release-smoke-rehearsal.yaml`
- [x] `npx --yes markdownlint-cli2@0.22.1 README.md AGENTS.md`
- [x] `helm template ...` with release-smoke values and image digest
- [x] digest image grep
- [x] `go run ./hack/chartassert`
- [x] `go test ./...`
- [x] `golangci-lint run`

Review agents approved the implementation slices and final branch review.
