### PR TITLE
ci: pin workflow runtime tools

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,15 @@
     },
     {
       description: 'Automerge minor/patch CI tool updates',
-      matchPackageNames: ['rhysd/actionlint', 'markdownlint-cli2', 'golang/vuln', 'yannh/kubeconform'],
+      matchPackageNames: [
+        'rhysd/actionlint',
+        'markdownlint-cli2',
+        'golang/vuln',
+        'yannh/kubeconform',
+        'helm/helm',
+        'kubernetes/kubernetes',
+        'kubernetes-sigs/kind',
+      ],
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
     },
@@ -73,6 +81,40 @@
       ],
       datasourceTemplate: 'npm',
       versioningTemplate: 'npm',
+    },
+    {
+      customType: 'regex',
+      description: ['Process Helm setup versions in CI workflows'],
+      managerFilePatterns: ['/\\.github/workflows/.*\\.ya?ml$/'],
+      matchStrings: [
+        'uses: azure/setup-helm@[^\\n]+\\n\\s+with:\\n\\s+version: v(?<currentValue>[\\d.]+)',
+      ],
+      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      description: ['Process kubectl setup versions in CI workflows'],
+      managerFilePatterns: ['/\\.github/workflows/.*\\.ya?ml$/'],
+      matchStrings: [
+        'uses: Azure/setup-kubectl@[^\\n]+\\n\\s+with:\\n\\s+version: v(?<currentValue>[\\d.]+)',
+        'uses: helm/kind-action@[^\\n]+\\n\\s+with:\\n(?:\\s+version: v[\\d.]+\\n)?\\s+kubectl_version: v(?<currentValue>[\\d.]+)',
+      ],
+      depNameTemplate: 'kubernetes/kubernetes',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      description: ['Process kind versions in CI workflows'],
+      managerFilePatterns: ['/\\.github/workflows/.*\\.ya?ml$/'],
+      matchStrings: [
+        'uses: helm/kind-action@[^\\n]+\\n\\s+with:\\n\\s+version: v(?<currentValue>[\\d.]+)',
+      ],
+      depNameTemplate: 'kubernetes-sigs/kind',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver',
     },
   ],
 }

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v4.1.4
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -47,6 +49,15 @@ jobs:
             --set replicaCount=3 \
             --set podAntiAffinityPreset=soft \
             --set persistence.enabled=true
+
+      - name: Template values.yaml examples
+        run: |
+          set -euo pipefail
+
+          find examples -type f -name values.yaml -print | sort | while IFS= read -r values; do
+            echo "Rendering ${values}"
+            helm template example charts/crd-schema-publisher -f "${values}" >/dev/null
+          done
 
       - name: Verify chart render contracts
         run: go run ./hack/chartassert

--- a/.github/workflows/release-smoke-rehearsal.yaml
+++ b/.github/workflows/release-smoke-rehearsal.yaml
@@ -51,13 +51,19 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v4.1.4
 
       - name: Set up kubectl
         uses: Azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+        with:
+          version: v1.35.0
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: v0.31.0
+          kubectl_version: v1.35.0
           cluster_name: crd-schema-publisher-release-smoke-rehearsal
           wait: 120s
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,13 +187,19 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v4.1.4
 
       - name: Set up kubectl
         uses: Azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+        with:
+          version: v1.35.0
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: v0.31.0
+          kubectl_version: v1.35.0
           cluster_name: crd-schema-publisher-release-smoke
           wait: 120s
 
@@ -239,6 +245,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v4.1.4
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Automated dependency management with platform automerge.
 | GitHub Actions | Commit SHA + version comment | `actions/checkout@<sha> # v4` |
 | Dockerfile base images | Tag + manifest digest | `golang:1.26.2@sha256:...` |
 | Go modules | `go.mod` + `go.sum`, verified with `go mod verify` | Standard |
-| CI tools (`go install`) | Semver tag, tracked by Renovate custom manager | `actionlint@v1.7.12` |
+| CI tools (`go install`, `npx`, workflow setup inputs) | Semver tag, tracked by Renovate custom manager | `actionlint@v1.7.12`, `helm v4.1.4` |
 
 ### OCI Labels
 


### PR DESCRIPTION
## What

Hardens CI/release reproducibility by:

- pinning Helm setup runtime versions to `v4.1.4`
- pinning kubectl setup runtime versions to `v1.35.0`
- pinning kind runtime version to `v0.31.0` and kind-managed kubectl to `v1.35.0`
- adding Renovate custom managers for Helm, kubectl, and kind setup inputs
- including those tools in the existing minor/patch CI-tool automerge rule
- adding `Template values.yaml examples` to render first-party example values files during Helm lint

The existing `renovate@43.141.6` validator pin is unchanged.

## Verification

- [x] `actionlint .github/workflows/ci.yaml .github/workflows/helm-lint.yml .github/workflows/release.yaml .github/workflows/release-smoke-rehearsal.yaml`
- [x] `npx --yes --package renovate@43.141.6 -- renovate-config-validator --strict`
- [x] `go run ./hack/chartassert`
- [x] `npx --yes markdownlint-cli2@0.22.1 AGENTS.md`
- [x] exact local render loop for all four `examples/*/values.yaml` files
- [x] `git diff --check`
- [x] pre-commit `golangci-lint`

Review agent approved the branch and the added example render step.
