### PR TITLE
ci: build PR images without pushing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -76,33 +73,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate tags
-        id: tags
-        env:
-          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          {
-            echo 'tags<<TAGS_EOF'
-            echo "${FULL_IMAGE}:pr-${PR_NUMBER}"
-            echo 'TAGS_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push
+      - name: Build image
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          push: false
           annotations: |
             index:org.opencontainers.image.description=Extracts CRD JSON schemas from Kubernetes and publishes to Cloudflare Pages
             index:org.opencontainers.image.source=https://github.com/sholdee/crd-schema-publisher

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,12 +171,12 @@ Five workflow files in `.github/workflows/`:
 | --- | --------- | ------- |
 | `detect` | Always | `dorny/paths-filter` classifies changes: `app` (Go, go.mod/sum, Dockerfile), `chart` (charts/**), `renovate` (config only). |
 | `test` | Always | Calls `test.yml` — safety net, ensures Go code compiles on every PR, even docs-only |
-| `build` | PR + `app == true` | Multi-arch Docker build (amd64 + arm64), pushes `pr-N` tag to GHCR. Verifies distroless base image digest with cosign before building. |
+| `build` | PR + `app == true` | Read-only multi-arch Docker build (amd64 + arm64), no GHCR login or push. Verifies distroless base image digest with cosign before building. |
 | `renovate` | `renovate == true` | Validates `.github/renovate.json5` with `renovate-config-validator --strict` |
 | `helm-lint` | `chart == true` | Calls `helm-lint.yml` |
 | `gate` | Always | Evaluates all job results — only `success` and `skipped` pass. Single required status check for branch protection. |
 
-Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR builds produce `pr-N` images for testing.
+Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR builds verify the image build without package write credentials or GHCR push.
 
 **`release.yaml`** jobs:
 
@@ -205,7 +205,7 @@ The rehearsal workflow is for validating the external smoke path before a releas
 ### Tags
 
 - **Production:** `vYYYY.MDD.HMMSS` (UTC, no leading zeros in numeric components — e.g. `v2026.413.65435`) + `latest` — created by manual release workflow
-- **PR:** `pr-N` — created on every PR with app code changes
+- **PR:** no image tag — PR CI builds the image without pushing to GHCR
 
 ### Renovate (`.github/renovate.json5`)
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Pre-built multi-arch images (amd64 + arm64) are published to GHCR:
 ghcr.io/sholdee/crd-schema-publisher:latest
 ```
 
-Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. The workflow runs an internal smoke gate before release artifacts are promoted. PR builds get `pr-N` tags for testing.
+Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. The workflow runs an internal smoke gate before release artifacts are promoted.
 
 Images use `gcr.io/distroless/static:nonroot` as the runtime base — no shell, no package manager, runs as UID 65534. Production images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing via GitHub Actions OIDC:
 


### PR DESCRIPTION
## Summary
- make PR Docker builds read-only and build-only
- remove GHCR login, package write permission, and pr-N tag push from CI
- update CI docs to describe release-only image publishing

## Test plan
- actionlint -shellcheck="shellcheck"
- pre-commit hook: golangci-lint