### PR TITLE
ci: run build and test in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   build:
-    needs: [test, detect]
+    needs: detect
     if: github.event_name == 'pull_request' && needs.detect.outputs.app == 'true'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Let the PR image build depend only on path detection instead of the full test job
- Keep the final CI gate waiting on both test and build results

## Verification
- actionlint -shellcheck="shellcheck" .github/workflows/ci.yaml