### PR TITLE
refactor: move favicon asset into theme

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -33,34 +33,6 @@ type indexData struct {
 
 const metadataDirName = "_meta"
 
-const faviconSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-<line x1="16" y1="3" x2="28.38" y2="7.96" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<line x1="28.38" y1="7.96" x2="27.02" y2="21.53" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<line x1="27.02" y1="21.53" x2="19.04" y2="28.51" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<line x1="19.04" y1="28.51" x2="12.96" y2="28.51" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<line x1="12.96" y1="28.51" x2="4.98" y2="21.53" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<line x1="4.98" y1="21.53" x2="3.62" y2="7.96" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<line x1="3.62" y1="7.96" x2="16" y2="3" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="16" cy="3" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="28.38" cy="7.96" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="27.02" cy="21.53" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="19.04" cy="28.51" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="12.96" cy="28.51" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="4.98" cy="21.53" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="3.62" cy="7.96" r="4" fill="#6bc1fe" opacity="0.2"/>
-<circle cx="16" cy="3" r="2.5" fill="#fff"/>
-<circle cx="28.38" cy="7.96" r="2.5" fill="#fff"/>
-<circle cx="27.02" cy="21.53" r="2.5" fill="#fff"/>
-<circle cx="19.04" cy="28.51" r="2.5" fill="#fff"/>
-<circle cx="12.96" cy="28.51" r="2.5" fill="#fff"/>
-<circle cx="4.98" cy="21.53" r="2.5" fill="#fff"/>
-<circle cx="3.62" cy="7.96" r="2.5" fill="#fff"/>
-</svg>`
-
-func writeFavicon(outputDir string) error {
-	return os.WriteFile(filepath.Join(outputDir, "favicon.svg"), []byte(faviconSVG), 0o644)
-}
-
 var indexTemplate = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -271,7 +243,7 @@ func Generate(outputDir, basePath string) error {
 	}
 	sort.Slice(sortedGroups, func(i, j int) bool { return sortedGroups[i].Name < sortedGroups[j].Name })
 
-	if err := writeFavicon(outputDir); err != nil {
+	if err := theme.WriteFavicon(outputDir); err != nil {
 		return fmt.Errorf("writing favicon: %w", err)
 	}
 

--- a/theme/favicon.go
+++ b/theme/favicon.go
@@ -1,0 +1,34 @@
+package theme
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const faviconSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+<line x1="16" y1="3" x2="28.38" y2="7.96" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="28.38" y1="7.96" x2="27.02" y2="21.53" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="27.02" y1="21.53" x2="19.04" y2="28.51" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="19.04" y1="28.51" x2="12.96" y2="28.51" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="12.96" y1="28.51" x2="4.98" y2="21.53" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="4.98" y1="21.53" x2="3.62" y2="7.96" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="3.62" y1="7.96" x2="16" y2="3" stroke="#6bc1fe" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="16" cy="3" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="28.38" cy="7.96" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="27.02" cy="21.53" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="19.04" cy="28.51" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="12.96" cy="28.51" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="4.98" cy="21.53" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="3.62" cy="7.96" r="4" fill="#6bc1fe" opacity="0.2"/>
+<circle cx="16" cy="3" r="2.5" fill="#fff"/>
+<circle cx="28.38" cy="7.96" r="2.5" fill="#fff"/>
+<circle cx="27.02" cy="21.53" r="2.5" fill="#fff"/>
+<circle cx="19.04" cy="28.51" r="2.5" fill="#fff"/>
+<circle cx="12.96" cy="28.51" r="2.5" fill="#fff"/>
+<circle cx="4.98" cy="21.53" r="2.5" fill="#fff"/>
+<circle cx="3.62" cy="7.96" r="2.5" fill="#fff"/>
+</svg>`
+
+func WriteFavicon(outputDir string) error {
+	return os.WriteFile(filepath.Join(outputDir, "favicon.svg"), []byte(faviconSVG), 0o644)
+}


### PR DESCRIPTION
## Summary
- Move the shared favicon SVG and writer from index into theme
- Keep index generation behavior unchanged by calling theme.WriteFavicon

## Verification
- git diff --check
- go test ./index ./theme
- go test ./...