### PR TITLE
feat(convert): add --openapi mode for built-in Kubernetes types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 ## What This Is
 
-A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes cluster and builds a browsable static site. It can publish directly to Cloudflare Pages or run in extract-only mode for sidecar consumers such as local web servers, git sync, or object-storage sync. Runs as a long-lived Deployment (watch mode) or CronJob on Kubernetes. Deployed in a nonroot distroless container.
+A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes cluster, converts Kubernetes built-in schemas from OpenAPI v2, and builds a browsable static site. It can publish directly to Cloudflare Pages or run in extract-only mode for sidecar consumers such as local web servers, git sync, or object-storage sync. Runs as a long-lived Deployment (watch mode) or CronJob on Kubernetes. Deployed in a nonroot distroless container.
 
 ## Repository Layout
 
 ```text
 charts/         Helm chart (OCI-distributed via GHCR, cosign-signed)
 cmd/            Entrypoint and subcommand dispatch (run/extract/convert/upload/watch/preview)
-converter/      OpenAPI v3 -> JSON Schema transforms (ported from openapi2jsonschema.py)
-extractor/      client-go CRD listing, schema extraction, file writing, config builder, file/YAML parsing
+converter/      CRD OpenAPI v3 -> JSON Schema transforms
+extractor/      client-go CRD listing, OpenAPI v2 built-in extraction, schema writing, config builder, file/YAML parsing
 index/          HTML index generation (deepspace theme, client-side search, starfield/flare effects)
 jsonschema/     Shared JSON Schema traversal, type, required-property, and composition helpers
 publisher/      Cloudflare Pages publish orchestration, request adapter, upload planning, BLAKE3 hashing
@@ -57,6 +57,10 @@ sha256sum crd-schema-publisher-* > checksums-sha256.txt
 # Local extract (requires kubeconfig)
 KUBECTL_CONTEXT=my-context OUTPUT_DIR=./output go run ./cmd/ extract
 
+# Convert Kubernetes built-ins from a cluster OpenAPI document
+kubectl get --raw /openapi/v2 > swagger.json
+go run ./cmd/ convert --openapi swagger.json -o ./schemas --render
+
 # Preview index UI locally (no cluster needed)
 go run ./cmd/ preview
 
@@ -71,7 +75,7 @@ go run ./cmd/main.go --help
 
 - `run` (default) — extract + optional upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`/`-o`, `--kind`, `--group`, and `--version`; the output root must already exist.
 - `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir`/`-o` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version` filters and CLI flags (`--output-dir`/`-o`, `--context`, `--base-path`, `--skip-render`) that override env vars.
-- `convert` — convert CRD YAML files to JSON Schema without a cluster connection. Requires `--output-dir`/`-o`. Reads from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
+- `convert` — convert CRD YAML files and Kubernetes OpenAPI v2 built-ins to JSON Schema without a cluster connection. Requires `--output-dir`/`-o`. Reads CRDs from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`; reads built-ins from `--openapi <swagger.json>`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
 - `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`/`-o`; the output root must already exist.
 - `watch` — long-lived process: informer watches CRDs, debounces events, and runs extract plus optional upload cycles. Leader election for multi-replica safety. Accepts `--output-dir`/`-o`, `--kind`, `--group`, and `--version`; the output root must already exist. Filters are applied to generated output, not to the informer watch scope.
 - `preview` — generate sample data by default, or with explicit `--output-dir`/`-o` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
@@ -90,6 +94,9 @@ go run ./cmd/main.go --help
 | `POD_NAMESPACE` | Yes (watch) | — | Namespace for leader lease (set via downward API) |
 | `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
 | `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
+| `SERVE_SITE` | No | — | Set to `true` to serve `OUTPUT_DIR/current` from watch mode |
+| `SITE_PORT` | No | `8081` | Non-privileged static site server port when `SERVE_SITE=true` |
+| `SERVE_ACCESS_LOG` | No | — | Set to `true` to log requests served by the built-in static site server |
 | `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
 | `PROFILE_DIR` | No | — | Directory for opt-in heap profiles and phase memory logs |
 | `UPLOAD_BUCKET_SIZE_BYTES` | No | `41943040` | CF upload bucket size in bytes |
@@ -112,6 +119,7 @@ go run ./cmd/main.go --help
 | `--skip-render` | extract | `$SKIP_RENDER` | Skip HTML rendering |
 | `--file`, `-f` | convert | — | CRD YAML file(s), comma-separated. `-` for stdin |
 | `--dir`, `-d` | convert | — | Directory of CRD YAML files (non-recursive) |
+| `--openapi` | convert | — | Kubernetes OpenAPI v2 (swagger) file for built-in resource schemas |
 | `--render` | convert | `false` | Render HTML docs |
 | `--kind` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_KIND`; `convert`: — | Filter by kind (comma-separated, case-insensitive) |
 | `--group` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_GROUP`; `convert`: — | Filter by group (comma-separated, case-insensitive) |
@@ -122,10 +130,11 @@ go run ./cmd/main.go --help
 - **No CGO.** Binary is statically linked. BLAKE3 uses `github.com/zeebo/blake3` (pure Go).
 - **Cloudflare Pages direct upload API** is undocumented. Implementation reverse-engineered from wrangler source (`cloudflare/workers-sdk`). The upload flow uses JWT auth for asset operations and API token auth for deployment creation. `publisher/publisher.go` owns the publish orchestration, `publisher/cloudflare_client.go` owns Cloudflare request execution and retries, and `publisher/upload_plan.go` owns active-site file collection, manifest construction, bucket planning, and upload body construction.
 - **BLAKE3 file hashing** exactly matches wrangler's `hashFile`: `hex(blake3(base64(content) + extension))[0:32]`. Do not change this algorithm without verifying against wrangler source.
-- **OpenAPI v3 to JSON Schema conversion** is an improved port of `openapi2jsonschema.py` from datreeio/CRDs-catalog (via yannh/kubeconform). Three transforms applied in order: additionalProperties, replaceIntOrString, allowNullOptionalFields. Shared JSON Schema semantics that are used by both converter and renderer live in `jsonschema/`; keep traversal keyword sets, non-null type resolution, required-property lookup, and oneOf branch display de-duplication there instead of duplicating them in call sites. Known divergences from the Python original, all intentional improvements for kubeconform/IDE validation correctness: (1) `additionalProperties` uses schema-aware traversal, closing structural child object schemas while skipping same-instance validation overlays (`oneOf`/`anyOf`/`allOf`/`not`/dependencies/conditionals) and literal data-valued keywords such as `default` and `enum`; it also recurses into each property sub-schema individually — Python recurses into the `properties` map itself, so CRD fields named `properties` (or other JSON Schema keywords) get a spurious `additionalProperties: false` injected into the map, corrupting the schema; (2) nullable applies only to fields *not* in the required list — Python disables nullable for *all* siblings when any sibling is required; (3) `replaceIntOrString` preserves safe metadata but removes/replaces conflicting parent type and distributes type-specific assertions into the string or integer oneOf branch for Kubernetes int-or-string markers — Python discards the entire dict; (4) root object and array items are not made nullable — Python makes them nullable unnecessarily. Golden E2E tests (`extractor/testdata/golden_certificate_v1.json`, `golden_edgecase_v1.json`) freeze the converter output and catch regressions.
-- **Schema renderer** generates interactive HTML documentation pages (collapsible `<details>`/`<summary>` property trees, type/required badges, YAML boilerplate). Uses `html/template` with recursive `{{define "properties"}}` for nested schemas. Schema-page path search behavior lives in the extracted `theme/schema_search.js` asset, which `RenderAll` emits into the output root as `schema-search.js` and the page bootstrap loads at runtime. Enabled by default; disable with `SKIP_RENDER=true`.
+- **OpenAPI v3 to JSON Schema conversion** applies three transforms in order: additionalProperties, replaceIntOrString, allowNullOptionalFields. Shared JSON Schema semantics that are used by both converter and renderer live in `jsonschema/`; keep traversal keyword sets, non-null type resolution, required-property lookup, and oneOf branch display de-duplication there instead of duplicating them in call sites. Current behavior is intentionally tuned for kubeconform/IDE validation correctness: (1) `additionalProperties` uses schema-aware traversal, closing structural child object schemas while skipping same-instance validation overlays (`oneOf`/`anyOf`/`allOf`/`not`/dependencies/conditionals) and literal data-valued keywords such as `default` and `enum`; it also recurses into each property sub-schema individually so CRD fields named `properties` or other JSON Schema keywords do not corrupt the output; (2) nullable applies only to fields *not* in the required list, including optional pure `$ref` fields as `anyOf` ref-or-null wrappers; (3) `replaceIntOrString` preserves safe metadata but removes/replaces conflicting parent type and distributes type-specific assertions into the string or integer oneOf branch for Kubernetes int-or-string markers; (4) root object and array items are not made nullable. Golden E2E tests (`extractor/testdata/golden_certificate_v1.json`, `golden_edgecase_v1.json`) freeze the converter output and catch regressions.
+- **Kubernetes OpenAPI v2 built-ins** are converted only by `convert --openapi`. Definitions with authorable group/version/kind metadata and `apiVersion`/`kind` properties become per-kind schemas. The empty API group is normalized to `core`, referenced definitions are bundled into each schema, and CRD YAML inputs can be combined with `--openapi` into one flat output site.
+- **Schema renderer** generates interactive HTML documentation pages (collapsible `<details>`/`<summary>` property trees, type/required badges, YAML boilerplate). It resolves local `#/definitions/...` refs, array item refs, and nullable `anyOf`/`oneOf` wrappers with exactly one non-null branch so built-in fields such as `Pod.spec.containers` expand in HTML while the JSON stays validator-friendly. Uses `html/template` with recursive `{{define "properties"}}` for nested schemas. Schema-page path search behavior lives in the extracted `theme/schema_search.js` asset, which `RenderAll` emits into the output root as `schema-search.js` and the page bootstrap loads at runtime. Enabled by default; disable with `SKIP_RENDER=true`.
 - **Theme package** (`theme/`) holds shared CSS, HTML fragments, small JS helpers used by both index and renderer templates, and emitted static assets such as `schema-search.js`. CSS custom properties are the union of both pages' needs. The deepspace theme (starfield, flare, light/dark toggle) is defined once here.
-- **Output format** builds immutable site generations under `OUTPUT_DIR/.generations/<generation>/` and atomically switches `OUTPUT_DIR/current` to the active generation. Each generation contains both directory formats: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility), plus rendered `.html` documentation pages, `index.html`, static assets, and an internal `_meta/kinds.json` manifest used to preserve exact CRD Kind casing for re-render/preview paths. Direct-volume consumers should read from `OUTPUT_DIR/current`, not the flat root. First-party Cloudflare, git, S3, and Caddy examples exclude `_meta/` from public output.
+- **Output format** builds immutable site generations under `OUTPUT_DIR/.generations/<generation>/` and atomically switches `OUTPUT_DIR/current` to the active generation. Each generation contains both directory formats: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility), plus rendered `.html` documentation pages, `index.html`, static assets, and an internal `_meta/kinds.json` manifest used to preserve exact Kind casing for re-render/preview paths. Direct-volume consumers should read from `OUTPUT_DIR/current`, not the flat root. First-party Cloudflare, git, S3, and Caddy examples exclude `_meta/` from public output.
 - **Convert output cleanup** uses `_meta/convert-manifest.json` to remove only files generated by prior `convert` runs, then prunes empty generated directories. Files that existed before `convert` ran are preserved, even under generated directories. If the manifest exists but is corrupt, `convert` aborts instead of risking mixed stale-and-fresh output.
 - **Concurrency**: extractor uses 10 goroutines (buffered channel semaphore), publisher uses 3 concurrent upload workers, renderer uses 10 goroutines. These match the original tools' behavior.
 - **Watch mode uses first-trigger-immediate debounce.** The informer's initial List fires AddFunc for all existing CRDs, which signals the debounce loop. The first trigger fires immediately (zero delay), subsequent triggers are debounced. This produces exactly one publish cycle on startup — no explicit initial publish in runLeader.
@@ -240,6 +249,7 @@ Kubernetes manifests live in the `home-ops` repo under `apps/kubernetes-schemas/
 - Adding CGO dependencies — breaks static compilation and distroless compatibility
 - Modifying the CF Pages upload flow without checking current wrangler source — the API is undocumented and may change
 - Forgetting to update both output directory formats (primary + master-standalone) when changing schema file naming
+- Changing OpenAPI built-in or nullable-ref handling without validating both sides: kubeconform against the served JSON schemas and rendered HTML expansion for a built-in like `core/pod_v1.html`
 - When modifying shared CSS, hash-state helpers, or emitted frontend assets, update the `theme/` package source of truth — do not duplicate changes across `index/index.go` and `renderer/renderer.go`
 - If you change `theme/schema_search.js`, keep `theme/schema_search.test.js` in sync and run `node --test theme/schema_search.test.js`
 - The index template uses a deepspace-inspired theme (starfield via coprime-tiled radial gradients, light flare via stripe/rainbow interference). Both effects are pure CSS, dark-mode only, hidden in light mode via `.light body::before, .light .flare { display: none }` (`.light` class is on `<html>`, set in a `<head>` script to prevent FOUC)

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Commands:
 | `extract` | Supports `--context`, `--base-path`, and `--skip-render`. |
 | `convert` | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. |
 | `convert` | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links. |
+| `convert` | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
 
 ## 📋 Using Your Schemas
 
@@ -557,6 +558,13 @@ For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
 8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
 
 The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
+
+`--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (e.g. `kubectl get --raw /openapi/v2`). Each type declaring a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`, with referenced definitions bundled inline. It can be combined with `--file`/`--dir` to render CRDs and built-ins into one site.
+
+```sh
+kubectl get --raw /openapi/v2 > swagger.json
+crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
+```
 
 ## 🔧 Development
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://artifacthub.io/packages/helm/crd-schema-publisher/crd-schema-publisher"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/crd-schema-publisher" alt="Artifact Hub"></a>
 </p>
 
-Extracts CRD OpenAPI schemas from your Kubernetes API server or YAML files, converts them to JSON Schema, and publishes a searchable documentation site with interactive schema pages.
+Extracts CRD schemas from Kubernetes or YAML, converts Kubernetes built-in resource schemas from `/openapi/v2`, and publishes a searchable documentation site with interactive schema pages.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/sholdee/crd-schema-publisher/main/docs/screenshots/overview.gif" alt="Installing crd-schema-publisher, extracting CRD schemas, and browsing the generated schema site" width="720">
@@ -30,7 +30,7 @@ Run it as:
 
 - a Kubernetes-native controller for real-time CRD watching
 - a CronJob for scheduled extraction
-- a local CLI for extracting from a live cluster or converting YAML files
+- a local CLI for extracting from a live cluster, converting CRD YAML, or rendering built-in schemas from Kubernetes OpenAPI
 
 Exports schemas for IDE validation with yaml-language-server and CI linting with kubeconform. Cloudflare Pages and local serving are built in; S3, git repos, and custom web servers are supported via sidecar.
 
@@ -40,13 +40,13 @@ Exports schemas for IDE validation with yaml-language-server and CI linting with
 
 Most CRD schema solutions rely on static catalogs — community-maintained repositories that scrape schemas from popular Helm charts. Schemas go stale, internal CRDs are missing, and your validation pipeline depends on third-party infrastructure.
 
-- **Always accurate** — schemas reflect exactly what's installed in your cluster, including custom and internal CRDs, updated automatically when CRDs change
+- **Always accurate** — CRD schemas reflect what's installed in your cluster, including custom and internal CRDs, and built-in schemas can be pulled from the same cluster's OpenAPI document
 - **Self-hosted** — run in extract-only mode and serve schemas however you like, or publish directly to Cloudflare Pages
 - **Single static binary** — no runtime dependencies, no interpreters, no package managers. One binary in a distroless nonroot container with no shell
 - **Controller-grade runtime** — watch mode uses informers, leader election, debounced refresh cycles, and health probes. It's a proper workload, not a script on a timer
 - **No glue pipelines** — replaces multi-tool chains (CI runners, shell scripts, kubectl, CLI wrappers) with a single in-cluster binary. No external CI dependency, no cluster-admin runner pods, no scheduled workflow orchestration
 
-The JSON Schema conversion improves upon the widely-used [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) — see [How It Works](#%EF%B8%8F-how-it-works) for details.
+The JSON Schema conversion is built for kubeconform and yaml-language-server compatibility — see [How It Works](#%EF%B8%8F-how-it-works) for details.
 
 ## ⚡ Quickstart
 
@@ -71,7 +71,7 @@ Install the standalone CLI:
 curl -fsSL https://crdsp.shold.io | bash
 ```
 
-Extract schemas from a kubeconfig context or convert CRD YAML files without a cluster connection:
+Extract schemas from a kubeconfig context, convert CRD YAML, or render Kubernetes built-ins from the cluster OpenAPI document:
 
 ```bash
 # Extract from the current kubeconfig context
@@ -82,13 +82,17 @@ crd-schema-publisher extract --context my-cluster -o ./schemas
 
 # Convert CRD YAML without a cluster
 crd-schema-publisher convert -f crd.yaml -o ./schemas
+
+# Convert Kubernetes built-in resources from the current cluster
+kubectl get --raw /openapi/v2 > swagger.json
+crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 ```
 
 For source builds, use `go run ./cmd/` in place of `crd-schema-publisher`. See [Standalone Binary](#standalone-binary) for installer options and manual downloads, and [Configuration and CLI Reference](#configuration-and-cli-reference) for flags and command behavior.
 
 ### Use Published Schemas
 
-Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`.
+Once published, schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`, for example `cert-manager.io/certificate_v1.json` or `core/pod_v1.json`.
 
 ```yaml
 # yaml-language-server: $schema=https://kube-schemas.example.com/cert-manager.io/certificate_v1.json
@@ -363,7 +367,7 @@ crd-schema-publisher [command]
 Commands:
   run       Extract schemas and upload to Cloudflare Pages when credentials are configured (default)
   extract   Extract schemas from a Kubernetes cluster
-  convert   Convert CRD YAML files to JSON Schema
+  convert   Convert CRD YAML files and Kubernetes OpenAPI built-ins to JSON Schema
   upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
   watch     Watch for CRD changes and upload when credentials are configured
   preview   Serve a local preview of the documentation site
@@ -386,7 +390,7 @@ Commands:
 
 ## 📋 Using Your Schemas
 
-Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`. The published site also includes a browsable index with search and interactive HTML documentation for each schema.
+Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`. Core built-ins use the `core` group path, such as `core/pod_v1.json`. The published site also includes a browsable index with search and interactive HTML documentation for each schema.
 
 ### IDE Validation (yaml-language-server)
 
@@ -413,18 +417,20 @@ Or configure schemas globally in VS Code:
 
 ### CI Validation (kubeconform)
 
-Point kubeconform at your schema registry for CRD validation in CI:
+If your registry includes built-ins from `--openapi`, point kubeconform at both the `core` path and the grouped path:
 
 ```bash
 kubeconform \
-  -schema-location default \
+  -strict \
+  -ignore-missing-schemas \
+  -schema-location 'https://kube-schemas.example.com/core/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
   -schema-location 'https://kube-schemas.example.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
   manifests/*.yaml
 ```
 
 This project validates its own Helm chart manifests against its published schema registry in CI — see the `helm-lint` job in [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) for a working example.
 
-This validates built-in Kubernetes resources against the default schemas and CRDs against your published schemas.
+This validates Kubernetes built-ins and CRDs against the same published schema snapshot. If you publish only CRDs, keep `-schema-location default` before your custom registry path so kubeconform still validates built-ins.
 
 > **Note:** Schema files are written as lowercase (e.g., `certificate_v1.json`) while `{{.ResourceKind}}` expands to the original case (e.g., `Certificate`). This works on Cloudflare Pages because it serves paths case-insensitively — the same convention used by [datreeio/CRDs-catalog](https://github.com/datreeio/CRDs-catalog). If serving schemas from a case-sensitive host, use lowercase kind names in your template paths.
 
@@ -545,26 +551,28 @@ For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
 
 1. Connects to the Kubernetes API (in-cluster or via kubeconfig)
 2. Lists all CRDs and extracts `.spec.versions[].schema.openAPIV3Schema`
-3. Applies three JSON Schema transforms (improved from [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py)):
+3. Applies three JSON Schema transforms:
    - Adds `additionalProperties: false` to structural child objects with `properties` — recurses into schema-valued locations only, preserving validation overlays and literal `default`/`enum` data while fixing a bug in the original where CRD fields named `properties` or other JSON Schema keywords corrupt the output
    - Replaces Kubernetes int-or-string markers with a non-conflicting `oneOf` union, preserving safe metadata and moving type-specific assertions into the matching string or integer branch
-   - Allows null for optional fields (per-field precision, not per-parent)
+   - Allows null for optional fields (per-field precision, including optional `$ref` fields as ref-or-null `anyOf` wrappers)
 
-   These improve on the Python original's handling of nullable fields, int-or-string types, root objects, and keyword-colliding property names. A frozen golden test locks converter output to prevent regressions.
+   These transforms handle nullable fields, int-or-string types, root objects, and keyword-colliding property names. A frozen golden test locks converter output to prevent regressions.
 4. Writes schemas to both primary and kubeval-compatible directory formats inside a new generation snapshot
-5. Renders an interactive HTML documentation page for each schema with collapsible property trees, path-aware search, and autocomplete powered by a shared emitted `schema-search.js` asset
+5. Renders an interactive HTML documentation page for each schema with collapsible property trees, local `$ref` expansion, path-aware search, and autocomplete powered by a shared emitted `schema-search.js` asset
 6. Generates an HTML index grouped by API group with client-side search, schema statistics, and yaml-language-server usage examples
 7. Atomically switches `OUTPUT_DIR/current` to the completed generation so sidecars read a stable snapshot
 8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
 
 The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
 
-`--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (e.g. `kubectl get --raw /openapi/v2`). Each type declaring a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`, with referenced definitions bundled inline. It can be combined with `--file`/`--dir` to render CRDs and built-ins into one site.
+`--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (for example `kubectl get --raw /openapi/v2`). Each authorable type that declares a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`; the empty API group is written under `core/`. Referenced definitions are bundled into each schema so validation and rendered child fields work without external references.
 
 ```sh
 kubectl get --raw /openapi/v2 > swagger.json
 crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 ```
+
+Combine `--openapi` with `--file` or `--dir` when you want one local site containing both built-ins and CRDs.
 
 ## 🔧 Development
 
@@ -586,6 +594,10 @@ KUBECTL_CONTEXT=my-cluster \
 
 # Convert CRD YAML files to JSON Schema (no cluster needed)
 go run ./cmd/ convert -f crd.yaml -o ./schemas
+
+# Convert Kubernetes built-ins from a cluster OpenAPI document
+kubectl get --raw /openapi/v2 > swagger.json
+go run ./cmd/ convert --openapi swagger.json -o ./schemas --render
 
 # Convert all CRDs in a directory
 go run ./cmd/ convert -d ./crds/ -o ./schemas

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -183,6 +183,47 @@ func loadCRDs(fileList, dir string) ([]apiextensionsv1.CustomResourceDefinition,
 	return crds, nil
 }
 
+func loadFilteredCRDs(fileList, dir string, filter extractor.SchemaFilter) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	if fileList == "" && dir == "" {
+		return nil, nil
+	}
+	loaded, err := loadCRDs(fileList, dir)
+	if err != nil {
+		return nil, err
+	}
+	return extractor.FilterCRDs(loaded, filter), nil
+}
+
+func writeConvertInputs(crds []apiextensionsv1.CustomResourceDefinition, openapiPath, outputDir string, filter extractor.SchemaFilter) (int, error) {
+	var count int
+	if len(crds) > 0 {
+		n, err := extractor.WriteSchemas(crds, outputDir)
+		if err != nil {
+			return count, fmt.Errorf("writing schemas: %w", err)
+		}
+		count += n
+	}
+	if openapiPath != "" {
+		n, err := extractor.WriteOpenAPISchemas(openapiPath, outputDir, filter)
+		if err != nil {
+			return count, fmt.Errorf("writing openapi schemas: %w", err)
+		}
+		count += n
+	}
+	return count, nil
+}
+
+func renderConvertOutput(outputDir, basePath string) error {
+	normalizedBasePath := normalizeBasePath(basePath)
+	if err := renderer.RenderAll(outputDir, normalizedBasePath); err != nil {
+		return fmt.Errorf("rendering schemas: %w", err)
+	}
+	if err := index.Generate(outputDir, normalizedBasePath); err != nil {
+		return fmt.Errorf("generating index: %w", err)
+	}
+	return nil
+}
+
 func runConvert(args []string) error {
 	fs := newCommandFlagSet("convert")
 	var fileFlag string
@@ -213,13 +254,9 @@ func runConvert(args []string) error {
 	}
 
 	filter := extractor.ParseFilter(*kind, *group, *version)
-	var crds []apiextensionsv1.CustomResourceDefinition
-	if fileFlag != "" || dirFlag != "" {
-		loaded, err := loadCRDs(fileFlag, dirFlag)
-		if err != nil {
-			return err
-		}
-		crds = extractor.FilterCRDs(loaded, filter)
+	crds, err := loadFilteredCRDs(fileFlag, dirFlag, filter)
+	if err != nil {
+		return err
 	}
 
 	if err := cleanConvertArtifacts(outputDir); err != nil {
@@ -233,31 +270,14 @@ func runConvert(args []string) error {
 
 	preExisting := snapshotFiles(outputDir)
 
-	// CRD and OpenAPI inputs can be combined; both write into outputDir and
-	// their kinds manifests merge.
-	var count int
-	if len(crds) > 0 {
-		n, err := extractor.WriteSchemas(crds, outputDir)
-		if err != nil {
-			return fmt.Errorf("writing schemas: %w", err)
-		}
-		count += n
-	}
-	if *openapiFlag != "" {
-		n, err := extractor.WriteOpenAPISchemas(*openapiFlag, outputDir, filter)
-		if err != nil {
-			return fmt.Errorf("writing openapi schemas: %w", err)
-		}
-		count += n
+	count, err := writeConvertInputs(crds, *openapiFlag, outputDir, filter)
+	if err != nil {
+		return err
 	}
 
-	normalizedBasePath := normalizeBasePath(*basePath)
 	if *render {
-		if err := renderer.RenderAll(outputDir, normalizedBasePath); err != nil {
-			return fmt.Errorf("rendering schemas: %w", err)
-		}
-		if err := index.Generate(outputDir, normalizedBasePath); err != nil {
-			return fmt.Errorf("generating index: %w", err)
+		if err := renderConvertOutput(outputDir, *basePath); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -212,13 +212,14 @@ func runConvert(args []string) error {
 		return fmt.Errorf("one of --file, --dir, or --openapi is required")
 	}
 
+	filter := extractor.ParseFilter(*kind, *group, *version)
 	var crds []apiextensionsv1.CustomResourceDefinition
 	if fileFlag != "" || dirFlag != "" {
 		loaded, err := loadCRDs(fileFlag, dirFlag)
 		if err != nil {
 			return err
 		}
-		crds = extractor.FilterCRDs(loaded, extractor.ParseFilter(*kind, *group, *version))
+		crds = extractor.FilterCRDs(loaded, filter)
 	}
 
 	if err := cleanConvertArtifacts(outputDir); err != nil {
@@ -243,7 +244,7 @@ func runConvert(args []string) error {
 		count += n
 	}
 	if *openapiFlag != "" {
-		n, err := extractor.WriteOpenAPISchemas(*openapiFlag, outputDir)
+		n, err := extractor.WriteOpenAPISchemas(*openapiFlag, outputDir, filter)
 		if err != nil {
 			return fmt.Errorf("writing openapi schemas: %w", err)
 		}

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -189,6 +189,7 @@ func runConvert(args []string) error {
 	stringFlagWithAlias(fs, &fileFlag, "file", "f", "", "CRD YAML file(s), comma-separated (use - for stdin)")
 	var dirFlag string
 	stringFlagWithAlias(fs, &dirFlag, "dir", "d", "", "directory containing CRD YAML files")
+	openapiFlag := fs.String("openapi", "", "Kubernetes OpenAPI v2 (swagger) file; converts built-in types (combinable with --file/--dir)")
 	var outputDir string
 	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", "", "output directory for JSON schemas (required)")
 	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
@@ -207,31 +208,46 @@ func runConvert(args []string) error {
 	if err := extractor.ValidateOutputDir(outputDir); err != nil {
 		return err
 	}
-	if fileFlag == "" && dirFlag == "" {
-		return fmt.Errorf("at least one of --file or --dir is required")
+	if fileFlag == "" && dirFlag == "" && *openapiFlag == "" {
+		return fmt.Errorf("one of --file, --dir, or --openapi is required")
 	}
 
-	crds, err := loadCRDs(fileFlag, dirFlag)
-	if err != nil {
-		return err
+	var crds []apiextensionsv1.CustomResourceDefinition
+	if fileFlag != "" || dirFlag != "" {
+		loaded, err := loadCRDs(fileFlag, dirFlag)
+		if err != nil {
+			return err
+		}
+		crds = extractor.FilterCRDs(loaded, extractor.ParseFilter(*kind, *group, *version))
 	}
-
-	crds = extractor.FilterCRDs(crds, extractor.ParseFilter(*kind, *group, *version))
 
 	if err := cleanConvertArtifacts(outputDir); err != nil {
 		return fmt.Errorf("preparing output directory: %w", err)
 	}
 
-	if len(crds) == 0 {
+	if len(crds) == 0 && *openapiFlag == "" {
 		slog.Info("no CRDs matched filters")
 		return nil
 	}
 
 	preExisting := snapshotFiles(outputDir)
 
-	count, err := extractor.WriteSchemas(crds, outputDir)
-	if err != nil {
-		return fmt.Errorf("writing schemas: %w", err)
+	// CRD and OpenAPI inputs can be combined; both write into outputDir and
+	// their kinds manifests merge.
+	var count int
+	if len(crds) > 0 {
+		n, err := extractor.WriteSchemas(crds, outputDir)
+		if err != nil {
+			return fmt.Errorf("writing schemas: %w", err)
+		}
+		count += n
+	}
+	if *openapiFlag != "" {
+		n, err := extractor.WriteOpenAPISchemas(*openapiFlag, outputDir)
+		if err != nil {
+			return fmt.Errorf("writing openapi schemas: %w", err)
+		}
+		count += n
 	}
 
 	normalizedBasePath := normalizeBasePath(*basePath)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1164,6 +1164,46 @@ spec:
 	}
 }
 
+func TestRunConvert_OpenAPIHonorsFilters(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+	specPath := filepath.Join(dir, "swagger.json")
+	openAPI := `{
+  "definitions": {
+    "io.k8s.api.core.v1.Pod": {
+      "type": "object",
+      "x-kubernetes-group-version-kind": [{"group": "", "version": "v1", "kind": "Pod"}],
+      "properties": {
+        "apiVersion": {"type": "string"},
+        "kind": {"type": "string"}
+      }
+    },
+    "io.k8s.api.apps.v1.Deployment": {
+      "type": "object",
+      "x-kubernetes-group-version-kind": [{"group": "apps", "version": "v1", "kind": "Deployment"}],
+      "properties": {
+        "apiVersion": {"type": "string"},
+        "kind": {"type": "string"}
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(specPath, []byte(openAPI), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runConvert([]string{"--openapi", specPath, "--output-dir", outputDir, "--kind", "pod"}); err != nil {
+		t.Fatalf("runConvert --openapi error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "core", "pod_v1.json")); err != nil {
+		t.Fatal("expected Pod schema to match --kind filter")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "apps", "deployment_v1.json")); !os.IsNotExist(err) {
+		t.Fatal("expected Deployment schema to be filtered out")
+	}
+}
+
 func TestRunConvert_ValidatesOutputDir(t *testing.T) {
 	dir := t.TempDir()
 	inputFile := filepath.Join(dir, "crd.yaml")

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/sholdee/crd-schema-publisher/jsonschema"
 )
@@ -351,6 +352,9 @@ func isOptionalProperty(propertyName string, requiredSet map[string]struct{}) bo
 }
 
 func allowNullForOptionalField(data map[string]interface{}) {
+	if wrapRefWithNullAnyOf(data) {
+		return
+	}
 	_, hasOneOf := data["oneOf"]
 	if hasOneOf && appendNullOneOf(data) {
 		addNullToType(data)
@@ -358,6 +362,40 @@ func allowNullForOptionalField(data map[string]interface{}) {
 	} else if !hasOneOf {
 		addNullToType(data)
 	}
+}
+
+func wrapRefWithNullAnyOf(data map[string]interface{}) bool {
+	ref, ok := data["$ref"].(string)
+	if !ok || ref == "" {
+		return false
+	}
+	if !hasOnlyRefAndAnnotationSiblings(data) {
+		return false
+	}
+	delete(data, "$ref")
+	data["anyOf"] = []interface{}{
+		map[string]interface{}{"$ref": ref},
+		map[string]interface{}{"type": "null"},
+	}
+	return true
+}
+
+func hasOnlyRefAndAnnotationSiblings(data map[string]interface{}) bool {
+	for key := range data {
+		if key == "$ref" || isRefAnnotationKeyword(key) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isRefAnnotationKeyword(key string) bool {
+	switch key {
+	case "description", "title", "default", "examples", "externalDocs":
+		return true
+	}
+	return strings.HasPrefix(key, "x-")
 }
 
 func childRequiredSet(data map[string]interface{}) map[string]struct{} {

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -37,6 +37,34 @@ func assertOneOfHasType(t *testing.T, schema map[string]interface{}, expected st
 	t.Fatalf("expected oneOf to contain %q branch, got %v", expected, oneOf)
 }
 
+func assertAnyOfHasRefAndNull(t *testing.T, schema map[string]interface{}, ref string) {
+	t.Helper()
+	if _, hasRef := schema["$ref"]; hasRef {
+		t.Fatalf("nullable ref wrapper must not keep sibling $ref, got %v", schema)
+	}
+	anyOf, ok := schema["anyOf"].([]interface{})
+	if !ok {
+		t.Fatalf("expected anyOf array, got %T", schema["anyOf"])
+	}
+	hasRef := false
+	hasNull := false
+	for _, item := range anyOf {
+		branch, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected anyOf branch to be map, got %T", item)
+		}
+		if branch["$ref"] == ref {
+			hasRef = true
+		}
+		if branch["type"] == "null" {
+			hasNull = true
+		}
+	}
+	if !hasRef || !hasNull {
+		t.Fatalf("expected anyOf to contain %q and null, got %v", ref, anyOf)
+	}
+}
+
 func assertAllOfOneOfAllowsNullBypass(t *testing.T, schema map[string]interface{}) {
 	t.Helper()
 	allOf, ok := schema["allOf"].([]interface{})
@@ -1190,6 +1218,94 @@ func TestAllowNullOptionalFields_SkipsRequiredFields(t *testing.T) {
 	name := propField(t, result, "name")
 	if name["type"] != "string" {
 		t.Fatal("required field type should remain a string, not array")
+	}
+}
+
+func TestAllowNullOptionalFieldsWrapsOptionalRefsWithNull(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"creationTimestamp": map[string]interface{}{
+				"$ref":        "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+				"description": "Populated by the system. Null for lists.",
+			},
+		},
+		"definitions": map[string]interface{}{
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Time": map[string]interface{}{
+				"type":   "string",
+				"format": "date-time",
+			},
+		},
+	}
+
+	result := AllowNullOptionalFields(schema, "", nil)
+	creationTimestamp := propField(t, result, "creationTimestamp")
+	assertAnyOfHasRefAndNull(t, creationTimestamp, "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time")
+	if creationTimestamp["description"] != "Populated by the system. Null for lists." {
+		t.Fatalf("expected description to be preserved, got %v", creationTimestamp["description"])
+	}
+	defs, ok := result["definitions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected definitions to be map, got %T", result["definitions"])
+	}
+	timeDef, ok := defs["io.k8s.apimachinery.pkg.apis.meta.v1.Time"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Time definition to be map, got %T", defs["io.k8s.apimachinery.pkg.apis.meta.v1.Time"])
+	}
+	if !reflect.DeepEqual(timeDef["type"], "string") {
+		t.Fatalf("referenced definition itself should remain string, got %v", timeDef["type"])
+	}
+}
+
+func TestAllowNullOptionalFieldsLeavesRequiredRefsDirect(t *testing.T) {
+	schema := map[string]interface{}{
+		"type":     "object",
+		"required": []interface{}{"uid"},
+		"properties": map[string]interface{}{
+			"uid": map[string]interface{}{
+				"$ref": "#/definitions/io.k8s.apimachinery.pkg.types.UID",
+			},
+		},
+		"definitions": map[string]interface{}{
+			"io.k8s.apimachinery.pkg.types.UID": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	result := AllowNullOptionalFields(schema, "", nil)
+	uid := propField(t, result, "uid")
+	if uid["$ref"] != "#/definitions/io.k8s.apimachinery.pkg.types.UID" {
+		t.Fatalf("required ref should remain direct, got %v", uid)
+	}
+	if _, hasAnyOf := uid["anyOf"]; hasAnyOf {
+		t.Fatalf("required ref must not receive nullable anyOf, got %v", uid)
+	}
+}
+
+func TestAllowNullOptionalFieldsLeavesRefsWithValidationSiblingsDirect(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"name": map[string]interface{}{
+				"$ref":      "#/definitions/Name",
+				"minLength": float64(1),
+			},
+		},
+		"definitions": map[string]interface{}{
+			"Name": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	result := AllowNullOptionalFields(schema, "", nil)
+	name := propField(t, result, "name")
+	if name["$ref"] != "#/definitions/Name" {
+		t.Fatalf("ref with validation sibling should stay direct, got %v", name)
+	}
+	if _, hasAnyOf := name["anyOf"]; hasAnyOf {
+		t.Fatalf("ref with validation sibling must not be wrapped, got %v", name)
 	}
 }
 

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -132,6 +132,12 @@ func writeSchemaFiles(props *apiextensionsv1.JSONSchemaProps, kind, group, versi
 		return "", fmt.Errorf("unmarshaling schema for %s/%s: %w", group, kind, err)
 	}
 
+	return writeSchemaMap(schema, kind, group, versionName, outputDir)
+}
+
+// writeSchemaMap runs the converter over an already-decoded schema and writes
+// the grouped and master-standalone files. Shared by CRD and OpenAPI inputs.
+func writeSchemaMap(schema map[string]interface{}, kind, group, versionName, outputDir string) (string, error) {
 	schema = converter.Convert(schema)
 
 	jsonBytes, err := json.MarshalIndent(schema, "", "  ")
@@ -159,15 +165,28 @@ func writeSchemaFiles(props *apiextensionsv1.JSONSchemaProps, kind, group, versi
 	return filename, nil
 }
 
+// writeKindsManifest merges kinds into any existing manifest, so CRD and OpenAPI
+// passes into the same directory share one index.
 func writeKindsManifest(outputDir string, kinds map[string]string) error {
 	metaDir := filepath.Join(outputDir, metadataDirName)
 	if err := os.MkdirAll(metaDir, 0o755); err != nil {
 		return err
 	}
 
+	manifestPath := filepath.Join(metaDir, kindsManifestName)
+	if existing, err := os.ReadFile(manifestPath); err == nil {
+		var prev map[string]string
+		if err := json.Unmarshal(existing, &prev); err == nil {
+			for path, kind := range kinds {
+				prev[path] = kind
+			}
+			kinds = prev
+		}
+	}
+
 	data, err := json.MarshalIndent(kinds, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling kinds manifest: %w", err)
 	}
-	return os.WriteFile(filepath.Join(metaDir, kindsManifestName), data, 0o644)
+	return os.WriteFile(manifestPath, data, 0o644)
 }

--- a/extractor/openapi.go
+++ b/extractor/openapi.go
@@ -30,25 +30,36 @@ type groupVersionKind struct {
 // schema embeds the transitive closure of its referenced definitions locally,
 // keeping files self-contained like CRD schemas (and recursion representable).
 func WriteOpenAPISchemas(openapiPath, outputDir string, filter SchemaFilter) (int, error) {
+	defs, err := readOpenAPIDefinitions(openapiPath)
+	if err != nil {
+		return 0, err
+	}
+	return writeOpenAPIDefinitions(defs, outputDir, filter)
+}
+
+func readOpenAPIDefinitions(openapiPath string) (map[string]map[string]interface{}, error) {
 	raw, err := os.ReadFile(openapiPath)
 	if err != nil {
-		return 0, fmt.Errorf("reading openapi spec: %w", err)
+		return nil, fmt.Errorf("reading openapi spec: %w", err)
 	}
 
 	var doc openAPIDoc
 	if err := json.Unmarshal(raw, &doc); err != nil {
-		return 0, fmt.Errorf("parsing openapi spec: %w", err)
+		return nil, fmt.Errorf("parsing openapi spec: %w", err)
 	}
 
 	defs := make(map[string]map[string]interface{}, len(doc.Definitions))
 	for name, rawDef := range doc.Definitions {
 		var def map[string]interface{}
 		if err := json.Unmarshal(rawDef, &def); err != nil {
-			return 0, fmt.Errorf("parsing definition %s: %w", name, err)
+			return nil, fmt.Errorf("parsing definition %s: %w", name, err)
 		}
 		defs[name] = def
 	}
+	return defs, nil
+}
 
+func writeOpenAPIDefinitions(defs map[string]map[string]interface{}, outputDir string, filter SchemaFilter) (int, error) {
 	var (
 		mu       sync.Mutex
 		wg       sync.WaitGroup

--- a/extractor/openapi.go
+++ b/extractor/openapi.go
@@ -1,0 +1,208 @@
+package extractor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// draft04 is the JSON Schema dialect Kubernetes OpenAPI v2 definitions use.
+const draft04 = "http://json-schema.org/draft-04/schema#"
+
+// openAPIDoc is the subset of a Kubernetes OpenAPI v2 (swagger) document we need:
+// the flat map of named type definitions.
+type openAPIDoc struct {
+	Definitions map[string]json.RawMessage `json:"definitions"`
+}
+
+type groupVersionKind struct {
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+}
+
+// WriteOpenAPISchemas reads a Kubernetes OpenAPI v2 (swagger) document and writes
+// one JSON schema per built-in (group, version, kind), matching WriteSchemas'
+// layout. OpenAPI definitions cross-reference via "#/definitions/...", so each
+// schema embeds the transitive closure of its referenced definitions locally,
+// keeping files self-contained like CRD schemas (and recursion representable).
+func WriteOpenAPISchemas(openapiPath, outputDir string) (int, error) {
+	raw, err := os.ReadFile(openapiPath)
+	if err != nil {
+		return 0, fmt.Errorf("reading openapi spec: %w", err)
+	}
+
+	var doc openAPIDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return 0, fmt.Errorf("parsing openapi spec: %w", err)
+	}
+
+	defs := make(map[string]map[string]interface{}, len(doc.Definitions))
+	for name, rawDef := range doc.Definitions {
+		var def map[string]interface{}
+		if err := json.Unmarshal(rawDef, &def); err != nil {
+			return 0, fmt.Errorf("parsing definition %s: %w", name, err)
+		}
+		defs[name] = def
+	}
+
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		sem      = make(chan struct{}, 10)
+		count    int
+		firstErr error
+		kinds    = make(map[string]string)
+	)
+
+	for name, def := range defs {
+		// Authorable kinds declare a GVK and apiVersion/kind properties; this
+		// skips internal types like WatchEvent.
+		gvks := groupVersionKinds(def)
+		if len(gvks) == 0 || !hasManifestProperties(def) {
+			continue
+		}
+
+		closure := definitionClosure(name, defs)
+		for _, gvk := range gvks {
+			group := gvk.Group
+			if group == "" {
+				group = "core"
+			}
+			schema := standaloneSchema(def, defs, closure)
+
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(schema map[string]interface{}, kind, group, version, originalKind string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				filename, err := writeSchemaMap(schema, kind, group, version, outputDir)
+				if err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+					return
+				}
+
+				mu.Lock()
+				kinds[filepath.ToSlash(filepath.Join(group, filename))] = originalKind
+				count++
+				mu.Unlock()
+			}(schema, strings.ToLower(gvk.Kind), group, gvk.Version, gvk.Kind)
+		}
+	}
+
+	wg.Wait()
+	if firstErr != nil {
+		return count, firstErr
+	}
+	if len(kinds) > 0 {
+		if err := writeKindsManifest(outputDir, kinds); err != nil {
+			return count, err
+		}
+	}
+	return count, nil
+}
+
+// groupVersionKinds reads the x-kubernetes-group-version-kind extension. A type
+// may register several (e.g. Event in core and events.k8s.io).
+func groupVersionKinds(def map[string]interface{}) []groupVersionKind {
+	raw, ok := def["x-kubernetes-group-version-kind"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var gvks []groupVersionKind
+	for _, entry := range raw {
+		m, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		group, _ := m["group"].(string)
+		version, _ := m["version"].(string)
+		kind, _ := m["kind"].(string)
+		if version != "" && kind != "" {
+			gvks = append(gvks, groupVersionKind{Group: group, Version: version, Kind: kind})
+		}
+	}
+	return gvks
+}
+
+func hasManifestProperties(def map[string]interface{}) bool {
+	props, ok := def["properties"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	_, hasAPIVersion := props["apiVersion"]
+	_, hasKind := props["kind"]
+	return hasAPIVersion && hasKind
+}
+
+// definitionClosure returns every definition transitively reachable from root
+// via "#/definitions/..." references.
+func definitionClosure(root string, defs map[string]map[string]interface{}) map[string]bool {
+	closure := make(map[string]bool)
+	queue := collectRefs(defs[root])
+	for len(queue) > 0 {
+		name := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if closure[name] {
+			continue
+		}
+		closure[name] = true
+		queue = append(queue, collectRefs(defs[name])...)
+	}
+	return closure
+}
+
+// collectRefs walks a decoded schema and returns the names of every
+// "#/definitions/<name>" reference it contains.
+func collectRefs(node interface{}) []string {
+	var refs []string
+	switch n := node.(type) {
+	case map[string]interface{}:
+		for key, value := range n {
+			if key == "$ref" {
+				if ref, ok := value.(string); ok {
+					if name, found := strings.CutPrefix(ref, "#/definitions/"); found {
+						refs = append(refs, name)
+					}
+				}
+				continue
+			}
+			refs = append(refs, collectRefs(value)...)
+		}
+	case []interface{}:
+		for _, value := range n {
+			refs = append(refs, collectRefs(value)...)
+		}
+	}
+	return refs
+}
+
+// standaloneSchema returns a self-contained draft-04 copy of def with its
+// referenced definitions embedded, so internal $refs resolve within the file.
+func standaloneSchema(def map[string]interface{}, defs map[string]map[string]interface{}, closure map[string]bool) map[string]interface{} {
+	schema := deepCopy(def)
+	if len(closure) > 0 {
+		bundle := make(map[string]interface{}, len(closure))
+		for name := range closure {
+			bundle[name] = deepCopy(defs[name])
+		}
+		schema["definitions"] = bundle
+	}
+	schema["$schema"] = draft04
+	return schema
+}
+
+func deepCopy(m map[string]interface{}) map[string]interface{} {
+	raw, _ := json.Marshal(m)
+	var out map[string]interface{}
+	_ = json.Unmarshal(raw, &out)
+	return out
+}

--- a/extractor/openapi.go
+++ b/extractor/openapi.go
@@ -29,7 +29,7 @@ type groupVersionKind struct {
 // layout. OpenAPI definitions cross-reference via "#/definitions/...", so each
 // schema embeds the transitive closure of its referenced definitions locally,
 // keeping files self-contained like CRD schemas (and recursion representable).
-func WriteOpenAPISchemas(openapiPath, outputDir string) (int, error) {
+func WriteOpenAPISchemas(openapiPath, outputDir string, filter SchemaFilter) (int, error) {
 	raw, err := os.ReadFile(openapiPath)
 	if err != nil {
 		return 0, fmt.Errorf("reading openapi spec: %w", err)
@@ -71,6 +71,9 @@ func WriteOpenAPISchemas(openapiPath, outputDir string) (int, error) {
 			group := gvk.Group
 			if group == "" {
 				group = "core"
+			}
+			if !filter.Matches(gvk.Kind, group, gvk.Version) {
+				continue
 			}
 			schema := standaloneSchema(def, defs, closure)
 

--- a/extractor/openapi_test.go
+++ b/extractor/openapi_test.go
@@ -1,0 +1,109 @@
+package extractor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleOpenAPI = `{
+  "definitions": {
+    "io.k8s.api.apps.v1.Deployment": {
+      "type": "object",
+      "x-kubernetes-group-version-kind": [{"group": "apps", "version": "v1", "kind": "Deployment"}],
+      "properties": {
+        "apiVersion": {"type": "string"},
+        "kind": {"type": "string"},
+        "metadata": {"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"}
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+      "type": "object",
+      "properties": {"name": {"type": "string"}}
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+      "type": "object",
+      "x-kubernetes-group-version-kind": [{"group": "", "version": "v1", "kind": "WatchEvent"}],
+      "properties": {"type": {"type": "string"}}
+    }
+  }
+}`
+
+func TestWriteOpenAPISchemas(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "swagger.json")
+	if err := os.WriteFile(specPath, []byte(sampleOpenAPI), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "out")
+
+	count, err := WriteOpenAPISchemas(specPath, out)
+	if err != nil {
+		t.Fatalf("WriteOpenAPISchemas: %v", err)
+	}
+	// Deployment emitted; WatchEvent skipped (GVK but no apiVersion/kind props).
+	if count != 1 {
+		t.Fatalf("expected 1 schema, got %d", count)
+	}
+
+	data, err := os.ReadFile(filepath.Join(out, "apps", "deployment_v1.json"))
+	if err != nil {
+		t.Fatalf("reading deployment schema: %v", err)
+	}
+	var schema map[string]interface{}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatal(err)
+	}
+
+	// Self-contained: the referenced ObjectMeta is bundled under definitions,
+	// and the $ref stays internal to the file.
+	defs, ok := schema["definitions"].(map[string]interface{})
+	if !ok || defs["io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"] == nil {
+		t.Fatalf("expected ObjectMeta bundled under definitions, got %v", schema["definitions"])
+	}
+	meta := schema["properties"].(map[string]interface{})["metadata"].(map[string]interface{})
+	if ref := meta["$ref"]; ref != "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta" {
+		t.Fatalf("expected internal $ref, got %v", ref)
+	}
+
+	// WatchEvent must not be written.
+	if _, err := os.Stat(filepath.Join(out, "core", "watchevent_v1.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected WatchEvent to be skipped")
+	}
+
+	// kinds manifest maps the file to its kind so the index/search picks it up.
+	manifest, err := os.ReadFile(filepath.Join(out, "_meta", "kinds.json"))
+	if err != nil {
+		t.Fatalf("reading kinds manifest: %v", err)
+	}
+	var kinds map[string]string
+	if err := json.Unmarshal(manifest, &kinds); err != nil {
+		t.Fatal(err)
+	}
+	if kinds["apps/deployment_v1.json"] != "Deployment" {
+		t.Fatalf("expected kinds manifest entry for Deployment, got %v", kinds)
+	}
+}
+
+func TestWriteKindsManifestMerges(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeKindsManifest(dir, map[string]string{"apps/deployment_v1.json": "Deployment"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeKindsManifest(dir, map[string]string{"cert-manager.io/certificate_v1.json": "Certificate"}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "_meta", "kinds.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kinds map[string]string
+	if err := json.Unmarshal(data, &kinds); err != nil {
+		t.Fatal(err)
+	}
+	if kinds["apps/deployment_v1.json"] != "Deployment" || kinds["cert-manager.io/certificate_v1.json"] != "Certificate" {
+		t.Fatalf("expected both passes merged, got %v", kinds)
+	}
+}

--- a/extractor/openapi_test.go
+++ b/extractor/openapi_test.go
@@ -38,7 +38,7 @@ func TestWriteOpenAPISchemas(t *testing.T) {
 	}
 	out := filepath.Join(dir, "out")
 
-	count, err := WriteOpenAPISchemas(specPath, out)
+	count, err := WriteOpenAPISchemas(specPath, out, SchemaFilter{})
 	if err != nil {
 		t.Fatalf("WriteOpenAPISchemas: %v", err)
 	}

--- a/extractor/openapi_test.go
+++ b/extractor/openapi_test.go
@@ -20,7 +20,22 @@ const sampleOpenAPI = `{
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
       "type": "object",
-      "properties": {"name": {"type": "string"}}
+      "required": ["uid"],
+      "properties": {
+        "name": {"type": "string"},
+        "creationTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Populated by the system. Null for lists."
+        },
+        "uid": {"$ref": "#/definitions/io.k8s.apimachinery.pkg.types.UID"}
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "io.k8s.apimachinery.pkg.types.UID": {
+      "type": "string"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
       "type": "object",
@@ -56,22 +71,68 @@ func TestWriteOpenAPISchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertOpenAPISchemaBundlesNullableRefs(t, schema)
+	assertOpenAPIWatchEventSkipped(t, out)
+	assertOpenAPIKindsManifest(t, out)
+}
+
+func assertOpenAPISchemaBundlesNullableRefs(t *testing.T, schema map[string]interface{}) {
+	t.Helper()
+
 	// Self-contained: the referenced ObjectMeta is bundled under definitions,
 	// and the $ref stays internal to the file.
 	defs, ok := schema["definitions"].(map[string]interface{})
 	if !ok || defs["io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"] == nil {
 		t.Fatalf("expected ObjectMeta bundled under definitions, got %v", schema["definitions"])
 	}
-	meta := schema["properties"].(map[string]interface{})["metadata"].(map[string]interface{})
-	if ref := meta["$ref"]; ref != "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta" {
-		t.Fatalf("expected internal $ref, got %v", ref)
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected schema properties, got %v", schema["properties"])
 	}
+	meta, ok := props["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected metadata property, got %v", props["metadata"])
+	}
+	assertAnyOfHasRefAndNull(t, meta, "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta")
 
+	objectMeta, ok := defs["io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected ObjectMeta definition to be a map, got %T", defs["io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"])
+	}
+	objectMetaProps, ok := objectMeta["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected ObjectMeta properties to be a map, got %T", objectMeta["properties"])
+	}
+	creationTimestamp, ok := objectMetaProps["creationTimestamp"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected creationTimestamp to be a map, got %T", objectMetaProps["creationTimestamp"])
+	}
+	assertAnyOfHasRefAndNull(t, creationTimestamp, "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time")
+	uid, ok := objectMetaProps["uid"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected uid to be a map, got %T", objectMetaProps["uid"])
+	}
+	if uid["$ref"] != "#/definitions/io.k8s.apimachinery.pkg.types.UID" {
+		t.Fatalf("required ref field should stay direct, got %v", uid)
+	}
+	if defs["io.k8s.apimachinery.pkg.apis.meta.v1.Time"] == nil {
+		t.Fatalf("expected Time definition to be bundled")
+	}
+	if defs["io.k8s.apimachinery.pkg.types.UID"] == nil {
+		t.Fatalf("expected UID definition to be bundled")
+	}
+}
+
+func assertOpenAPIWatchEventSkipped(t *testing.T, out string) {
+	t.Helper()
 	// WatchEvent must not be written.
 	if _, err := os.Stat(filepath.Join(out, "core", "watchevent_v1.json")); !os.IsNotExist(err) {
 		t.Fatalf("expected WatchEvent to be skipped")
 	}
+}
 
+func assertOpenAPIKindsManifest(t *testing.T, out string) {
+	t.Helper()
 	// kinds manifest maps the file to its kind so the index/search picks it up.
 	manifest, err := os.ReadFile(filepath.Join(out, "_meta", "kinds.json"))
 	if err != nil {
@@ -83,6 +144,34 @@ func TestWriteOpenAPISchemas(t *testing.T) {
 	}
 	if kinds["apps/deployment_v1.json"] != "Deployment" {
 		t.Fatalf("expected kinds manifest entry for Deployment, got %v", kinds)
+	}
+}
+
+func assertAnyOfHasRefAndNull(t *testing.T, schema map[string]interface{}, ref string) {
+	t.Helper()
+	if _, hasRef := schema["$ref"]; hasRef {
+		t.Fatalf("nullable ref wrapper must not keep sibling $ref, got %v", schema)
+	}
+	anyOf, ok := schema["anyOf"].([]interface{})
+	if !ok {
+		t.Fatalf("expected anyOf array, got %T", schema["anyOf"])
+	}
+	hasRef := false
+	hasNull := false
+	for _, item := range anyOf {
+		branch, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected anyOf branch to be map, got %T", item)
+		}
+		if branch["$ref"] == ref {
+			hasRef = true
+		}
+		if branch["type"] == "null" {
+			hasNull = true
+		}
+	}
+	if !hasRef || !hasNull {
+		t.Fatalf("expected anyOf to contain %q and null, got %v", ref, anyOf)
 	}
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -25,10 +25,12 @@ const (
 // SchemaNode represents a JSON Schema node for rendering.
 type SchemaNode struct {
 	Type                 interface{}            `json:"type,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
 	Description          string                 `json:"description,omitempty"`
 	Properties           map[string]*SchemaNode `json:"properties,omitempty"`
 	Items                *SchemaNode            `json:"items,omitempty"`
 	Required             []string               `json:"required,omitempty"`
+	Definitions          map[string]*SchemaNode `json:"definitions,omitempty"`
 	Enum                 []interface{}          `json:"enum,omitempty"`
 	OneOf                []*SchemaNode          `json:"oneOf,omitempty"`
 	AnyOf                []*SchemaNode          `json:"anyOf,omitempty"`
@@ -128,6 +130,224 @@ type RenderConstraint struct {
 	Text    string
 	Preview string
 	Long    bool
+}
+
+type schemaResolver struct {
+	definitions map[string]*SchemaNode
+}
+
+func newSchemaResolver(root *SchemaNode) schemaResolver {
+	if root == nil {
+		return schemaResolver{}
+	}
+	return schemaResolver{definitions: root.Definitions}
+}
+
+func (r schemaResolver) resolve(node *SchemaNode, seen map[string]struct{}) (*SchemaNode, map[string]struct{}) {
+	if node == nil {
+		return nil, seen
+	}
+
+	resolved, nextSeen := r.resolveLocalRef(node, seen)
+	resolved, nextSeen = r.resolveNullableComposition(resolved, nextSeen)
+	return r.resolveArrayItems(resolved, nextSeen)
+}
+
+func (r schemaResolver) resolveLocalRef(node *SchemaNode, seen map[string]struct{}) (*SchemaNode, map[string]struct{}) {
+	refName, ok := localDefinitionRef(node.Ref)
+	if !ok {
+		return node, seen
+	}
+
+	target := r.definitions[refName]
+	if target == nil {
+		return node, seen
+	}
+
+	if _, repeated := seen[refName]; repeated {
+		return mergeSchemaNode(leafSchemaNode(target), node), seen
+	}
+
+	nextSeen := copySeenWith(seen, refName)
+	resolved, targetSeen := r.resolve(target, nextSeen)
+	return mergeSchemaNode(resolved, node), targetSeen
+}
+
+func (r schemaResolver) resolveArrayItems(node *SchemaNode, seen map[string]struct{}) (*SchemaNode, map[string]struct{}) {
+	if node == nil || node.Items == nil {
+		return node, seen
+	}
+
+	items, itemSeen := r.resolve(node.Items, seen)
+	if items == node.Items {
+		return node, itemSeen
+	}
+
+	cloned := cloneSchemaNode(node)
+	cloned.Items = items
+	return cloned, itemSeen
+}
+
+func (r schemaResolver) resolveNullableComposition(node *SchemaNode, seen map[string]struct{}) (*SchemaNode, map[string]struct{}) {
+	if node == nil {
+		return node, seen
+	}
+	if branch := singleNonNullCompositionBranch(node.AnyOf); branch != nil {
+		resolved, branchSeen := r.resolve(branch, seen)
+		return mergeSchemaNode(resolved, node), branchSeen
+	}
+	if branch := singleNonNullCompositionBranch(node.OneOf); branch != nil {
+		resolved, branchSeen := r.resolve(branch, seen)
+		return mergeSchemaNode(resolved, node), branchSeen
+	}
+	return node, seen
+}
+
+func singleNonNullCompositionBranch(branches []*SchemaNode) *SchemaNode {
+	if len(branches) == 0 {
+		return nil
+	}
+
+	var nonNull *SchemaNode
+	hasNull := false
+	for _, branch := range branches {
+		if branch == nil {
+			continue
+		}
+		if branch.resolveType() == "null" {
+			hasNull = true
+			continue
+		}
+		if nonNull != nil {
+			return nil
+		}
+		nonNull = branch
+	}
+	if !hasNull {
+		return nil
+	}
+	return nonNull
+}
+
+func localDefinitionRef(ref string) (string, bool) {
+	name, found := strings.CutPrefix(ref, "#/definitions/")
+	if !found || name == "" {
+		return "", false
+	}
+	name = strings.ReplaceAll(name, "~1", "/")
+	name = strings.ReplaceAll(name, "~0", "~")
+	return name, true
+}
+
+func copySeen(seen map[string]struct{}) map[string]struct{} {
+	copied := make(map[string]struct{}, len(seen))
+	for name := range seen {
+		copied[name] = struct{}{}
+	}
+	return copied
+}
+
+func copySeenWith(seen map[string]struct{}, name string) map[string]struct{} {
+	copied := copySeen(seen)
+	copied[name] = struct{}{}
+	return copied
+}
+
+func cloneSchemaNode(node *SchemaNode) *SchemaNode {
+	if node == nil {
+		return nil
+	}
+	cloned := *node
+	return &cloned
+}
+
+func leafSchemaNode(node *SchemaNode) *SchemaNode {
+	leaf := cloneSchemaNode(node)
+	leaf.Properties = nil
+	leaf.Items = nil
+	return leaf
+}
+
+func mergeSchemaNode(base, overlay *SchemaNode) *SchemaNode {
+	merged := cloneSchemaNode(base)
+	if merged == nil {
+		merged = &SchemaNode{}
+	}
+
+	mergeSchemaShape(merged, overlay)
+	mergeSchemaComposition(merged, overlay)
+	mergeSchemaValidation(merged, overlay)
+	merged.Ref = ""
+	return merged
+}
+
+func mergeSchemaShape(merged, overlay *SchemaNode) {
+	if overlay.Type != nil {
+		merged.Type = overlay.Type
+	}
+	if overlay.Description != "" {
+		merged.Description = overlay.Description
+	}
+	if len(overlay.Properties) > 0 {
+		merged.Properties = overlay.Properties
+	}
+	if overlay.Items != nil {
+		merged.Items = overlay.Items
+	}
+	if len(overlay.Required) > 0 {
+		merged.Required = overlay.Required
+	}
+	if len(overlay.Definitions) > 0 {
+		merged.Definitions = overlay.Definitions
+	}
+}
+
+func mergeSchemaComposition(merged, overlay *SchemaNode) {
+	if len(overlay.Enum) > 0 {
+		merged.Enum = overlay.Enum
+	}
+	if len(overlay.OneOf) > 0 {
+		merged.OneOf = overlay.OneOf
+	}
+	if len(overlay.AnyOf) > 0 {
+		merged.AnyOf = overlay.AnyOf
+	}
+	if len(overlay.AllOf) > 0 {
+		merged.AllOf = overlay.AllOf
+	}
+	if overlay.Format != "" {
+		merged.Format = overlay.Format
+	}
+	if overlay.Pattern != "" {
+		merged.Pattern = overlay.Pattern
+	}
+}
+
+func mergeSchemaValidation(merged, overlay *SchemaNode) {
+	if overlay.Minimum != nil {
+		merged.Minimum = overlay.Minimum
+	}
+	if overlay.Maximum != nil {
+		merged.Maximum = overlay.Maximum
+	}
+	if overlay.MinLength != nil {
+		merged.MinLength = overlay.MinLength
+	}
+	if overlay.MaxLength != nil {
+		merged.MaxLength = overlay.MaxLength
+	}
+	if overlay.MinItems != nil {
+		merged.MinItems = overlay.MinItems
+	}
+	if overlay.MaxItems != nil {
+		merged.MaxItems = overlay.MaxItems
+	}
+	if overlay.Default != nil {
+		merged.Default = overlay.Default
+	}
+	if overlay.AdditionalProperties != nil {
+		merged.AdditionalProperties = overlay.AdditionalProperties
+	}
 }
 
 // Expandable returns true when the property renders as an expandable details row.
@@ -336,12 +556,29 @@ func renderSchemaFileWithKinds(tmpl *template.Template, jsonPath, group, filenam
 }
 
 func buildRenderProperties(node *SchemaNode, parentPath, parentRowPath, arraySuffix string) []RenderProperty {
+	return buildRenderPropertiesWithResolver(newSchemaResolver(node), node, parentPath, parentRowPath, arraySuffix, map[string]struct{}{})
+}
+
+func buildRenderPropertiesWithResolver(
+	resolver schemaResolver,
+	node *SchemaNode,
+	parentPath,
+	parentRowPath,
+	arraySuffix string,
+	seen map[string]struct{},
+) []RenderProperty {
+	node, parentSeen := resolver.resolve(node, seen)
+	if node == nil {
+		return nil
+	}
+
 	entries := node.SortedProperties()
 	props := make([]RenderProperty, 0, len(entries))
 	for _, entry := range entries {
 		path := joinPropertyPath(parentPath, entry.Name, arraySuffix)
+		childNode, childSeen := resolver.resolve(entry.Node, copySeen(parentSeen))
 		childArraySuffix := ""
-		if entry.Node.resolveType() == "array" {
+		if childNode.resolveType() == "array" {
 			childArraySuffix = "[]"
 		}
 
@@ -350,16 +587,16 @@ func buildRenderProperties(node *SchemaNode, parentPath, parentRowPath, arraySuf
 			Path:       path,
 			PathKey:    buildPathSearchKey(path),
 			ParentPath: parentRowPath,
-			SearchText: buildSearchText(entry.Node),
+			SearchText: buildSearchText(childNode),
 			Required:   node.IsRequired(entry.Name),
-			Node:       entry.Node,
+			Node:       childNode,
 		}
-		if entry.Node.HasChildren() {
-			childNode := entry.Node
-			if entry.Node.Items != nil && len(entry.Node.Items.Properties) > 0 {
-				childNode = entry.Node.Items
+		if childNode.HasChildren() {
+			nestedNode := childNode
+			if childNode.Items != nil && len(childNode.Items.Properties) > 0 {
+				nestedNode = childNode.Items
 			}
-			prop.Children = buildRenderProperties(childNode, path+childArraySuffix, path, "")
+			prop.Children = buildRenderPropertiesWithResolver(resolver, nestedNode, path+childArraySuffix, path, "", childSeen)
 		}
 		props = append(props, prop)
 	}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -270,6 +270,7 @@ type schemaPageData struct {
 	Kind           string
 	Group          string
 	Version        string
+	APIVersion     string
 	JSONPath       string
 	BasePath       string
 	Schema         *SchemaNode
@@ -313,6 +314,7 @@ func renderSchemaFileWithKinds(tmpl *template.Template, jsonPath, group, filenam
 		Kind:           kind,
 		Group:          group,
 		Version:        version,
+		APIVersion:     renderAPIVersion(group, version),
 		JSONPath:       basePath + "/" + group + "/" + filename,
 		BasePath:       basePath,
 		Schema:         &schema,
@@ -489,6 +491,16 @@ func lookupManifestKind(kinds map[string]string, group, filename string) string 
 		return ""
 	}
 	return strings.TrimSpace(kinds[filepath.ToSlash(filepath.Join(group, filename))])
+}
+
+func renderAPIVersion(group, version string) string {
+	if group == "" || group == "core" {
+		return version
+	}
+	if version == "" {
+		return group
+	}
+	return group + "/" + version
 }
 
 type renderJob struct {
@@ -746,7 +758,7 @@ var schemaTemplate = `<!DOCTYPE html>
   <h1 class="schema-title">{{.Kind}}</h1>
   <p class="schema-title-group">{{.Group}} / {{.Version}}</p>
 </header>
-<div class="yaml-block">apiVersion: {{.Group}}/{{.Version}}
+<div class="yaml-block">apiVersion: {{.APIVersion}}
 kind: {{.Kind}}
 metadata:
   name: example</div>

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -269,6 +269,299 @@ func TestSortedProperties(t *testing.T) {
 	}
 }
 
+func TestBuildRenderPropertiesResolvesLocalDefinitionRefs(t *testing.T) {
+	props := refBackedSpecProperties(t)
+	assertRefBackedSpecProperty(t, props[0], "firstSpec", "First spec description", "pattern: ^[a-z]+$")
+	assertRefBackedSpecProperty(t, props[1], "secondSpec", "Second spec description", "")
+}
+
+func TestBuildRenderPropertiesResolvesNullableAnyOfLocalDefinitionRefs(t *testing.T) {
+	root := &SchemaNode{
+		Type: "object",
+		Properties: map[string]*SchemaNode{
+			"spec": {
+				AnyOf: []*SchemaNode{
+					{Ref: "#/definitions/io.k8s.example.Spec"},
+					{Type: "null"},
+				},
+				Description: "Spec defines desired state",
+			},
+		},
+		Definitions: map[string]*SchemaNode{
+			"io.k8s.example.Spec": {
+				Type:     "object",
+				Required: []string{"containers"},
+				Properties: map[string]*SchemaNode{
+					"containers": {
+						Type: "array",
+						Items: &SchemaNode{
+							Ref: "#/definitions/io.k8s.example.Container",
+						},
+					},
+				},
+			},
+			"io.k8s.example.Container": {
+				Type: "object",
+				Properties: map[string]*SchemaNode{
+					"name": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	props := buildRenderProperties(root, "", "", "")
+	if len(props) != 1 {
+		t.Fatalf("got %d top-level properties, want 1", len(props))
+	}
+	spec := props[0]
+	if spec.Name != "spec" {
+		t.Fatalf("property = %q, want spec", spec.Name)
+	}
+	if !spec.Expandable() {
+		t.Fatalf("nullable ref-backed spec should expand, got %#v", spec)
+	}
+	if got := spec.Node.Description; got != "Spec defines desired state" {
+		t.Fatalf("spec description = %q, want wrapper description", got)
+	}
+	if got := spec.Node.DisplayType(); got != "object" {
+		t.Fatalf("spec type = %q, want object", got)
+	}
+	if len(spec.Children) != 1 || spec.Children[0].Path != "spec.containers" {
+		t.Fatalf("spec children = %#v, want spec.containers", spec.Children)
+	}
+	if !spec.Children[0].Required {
+		t.Fatal("required fields from the referenced definition should be preserved")
+	}
+	if len(spec.Children[0].Children) != 1 || spec.Children[0].Children[0].Path != "spec.containers[].name" {
+		t.Fatalf("container children = %#v, want spec.containers[].name", spec.Children[0].Children)
+	}
+}
+
+func TestBuildRenderPropertiesResolvesNullableOneOfLocalDefinitionRefs(t *testing.T) {
+	root := &SchemaNode{
+		Type: "object",
+		Properties: map[string]*SchemaNode{
+			"status": {
+				OneOf: []*SchemaNode{
+					{Ref: "#/definitions/io.k8s.example.Status"},
+					{Type: "null"},
+				},
+				Description: "Status records observed state",
+			},
+		},
+		Definitions: map[string]*SchemaNode{
+			"io.k8s.example.Status": {
+				Type: "object",
+				Properties: map[string]*SchemaNode{
+					"phase": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	props := buildRenderProperties(root, "", "", "")
+	if len(props) != 1 {
+		t.Fatalf("got %d top-level properties, want 1", len(props))
+	}
+	status := props[0]
+	if !status.Expandable() {
+		t.Fatalf("nullable oneOf ref-backed status should expand, got %#v", status)
+	}
+	if got := status.Node.Description; got != "Status records observed state" {
+		t.Fatalf("status description = %q, want wrapper description", got)
+	}
+	if len(status.Children) != 1 || status.Children[0].Path != "status.phase" {
+		t.Fatalf("status children = %#v, want status.phase", status.Children)
+	}
+}
+
+func TestBuildRenderPropertiesDoesNotCollapseSingleBranchAnyOfWithoutNull(t *testing.T) {
+	root := &SchemaNode{
+		Type: "object",
+		Properties: map[string]*SchemaNode{
+			"spec": {
+				AnyOf: []*SchemaNode{
+					{Ref: "#/definitions/io.k8s.example.Spec"},
+				},
+			},
+		},
+		Definitions: map[string]*SchemaNode{
+			"io.k8s.example.Spec": {
+				Type: "object",
+				Properties: map[string]*SchemaNode{
+					"replicas": {Type: "integer"},
+				},
+			},
+		},
+	}
+
+	props := buildRenderProperties(root, "", "", "")
+	if len(props) != 1 {
+		t.Fatalf("got %d top-level properties, want 1", len(props))
+	}
+	if props[0].Expandable() {
+		t.Fatalf("single-branch anyOf without null should not expand, got %#v", props[0])
+	}
+}
+
+func TestBuildRenderPropertiesDoesNotCollapseMultiBranchAnyOf(t *testing.T) {
+	root := &SchemaNode{
+		Type: "object",
+		Properties: map[string]*SchemaNode{
+			"value": {
+				AnyOf: []*SchemaNode{
+					{Ref: "#/definitions/io.k8s.example.Spec"},
+					{Type: "string"},
+					{Type: "null"},
+				},
+			},
+		},
+		Definitions: map[string]*SchemaNode{
+			"io.k8s.example.Spec": {
+				Type: "object",
+				Properties: map[string]*SchemaNode{
+					"replicas": {Type: "integer"},
+				},
+			},
+		},
+	}
+
+	props := buildRenderProperties(root, "", "", "")
+	if len(props) != 1 {
+		t.Fatalf("got %d top-level properties, want 1", len(props))
+	}
+	if props[0].Expandable() {
+		t.Fatalf("multi-branch union should not expand into the ref branch, got %#v", props[0])
+	}
+	if got := props[0].Node.DisplayType(); got != "object" {
+		t.Fatalf("current anyOf display type should remain stable, got %q", got)
+	}
+}
+
+func refBackedSpecProperties(t *testing.T) []RenderProperty {
+	t.Helper()
+
+	root := &SchemaNode{
+		Type: "object",
+		Properties: map[string]*SchemaNode{
+			"firstSpec": {
+				Ref:         "#/definitions/io.k8s.example.Spec",
+				Description: "First spec description",
+				Pattern:     "^[a-z]+$",
+			},
+			"secondSpec": {
+				Ref:         "#/definitions/io.k8s.example.Spec",
+				Description: "Second spec description",
+			},
+		},
+		Definitions: map[string]*SchemaNode{
+			"io.k8s.example.Spec": {
+				Type:        "object",
+				Description: "Shared spec description",
+				Required:    []string{"replicas"},
+				Properties: map[string]*SchemaNode{
+					"replicas": {
+						Type:        "integer",
+						Description: "Replica count",
+					},
+				},
+			},
+		},
+	}
+
+	props := buildRenderProperties(root, "", "", "")
+	if len(props) != 2 {
+		t.Fatalf("got %d top-level properties, want 2", len(props))
+	}
+	return props
+}
+
+func assertRefBackedSpecProperty(t *testing.T, prop RenderProperty, name, description, constraint string) {
+	t.Helper()
+
+	if prop.Name != name {
+		t.Fatalf("property = %q, want %s", prop.Name, name)
+	}
+	if !prop.Expandable() {
+		t.Fatalf("%s should expand; seen refs must be path-local, not shared across siblings", name)
+	}
+	if got := prop.Node.Description; got != description {
+		t.Fatalf("%s description = %q, want %q", name, got, description)
+	}
+	constraints := prop.Node.RenderConstraints()
+	if constraint == "" && len(constraints) != 0 {
+		t.Fatalf("%s constraints = %#v, want no leaked constraints", name, constraints)
+	}
+	if constraint != "" && (len(constraints) != 1 || constraints[0].Text != constraint) {
+		t.Fatalf("%s constraints = %#v, want %q", name, constraints, constraint)
+	}
+	if constraint != "" && !strings.Contains(prop.SearchText, constraint) {
+		t.Fatalf("%s search text = %q, want %q", name, prop.SearchText, constraint)
+	}
+	if len(prop.Children) != 1 || prop.Children[0].Path != name+".replicas" {
+		t.Fatalf("%s children = %#v, want %s.replicas", name, prop.Children, name)
+	}
+	if !prop.Children[0].Required {
+		t.Fatal("required fields from the referenced definition should be preserved")
+	}
+	if got := prop.Children[0].Node.DisplayType(); got != "integer" {
+		t.Fatalf("replicas type = %q, want integer", got)
+	}
+}
+
+func TestBuildRenderPropertiesResolvesArrayItemRefsWithoutRecursingForever(t *testing.T) {
+	root := &SchemaNode{
+		Type: "object",
+		Properties: map[string]*SchemaNode{
+			"items": {
+				Type: "array",
+				Items: &SchemaNode{
+					Ref: "#/definitions/io.k8s.example.Item",
+				},
+			},
+		},
+		Definitions: map[string]*SchemaNode{
+			"io.k8s.example.Item": {
+				Type: "object",
+				Properties: map[string]*SchemaNode{
+					"name": {Type: "string"},
+					"children": {
+						Type: "array",
+						Items: &SchemaNode{
+							Ref: "#/definitions/io.k8s.example.Item",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	props := buildRenderProperties(root, "", "", "")
+	if len(props) != 1 {
+		t.Fatalf("got %d top-level properties, want 1", len(props))
+	}
+	items := props[0]
+	if !items.Expandable() {
+		t.Fatal("array property should expand when items ref an object definition")
+	}
+	if len(items.Children) != 2 {
+		t.Fatalf("array item children = %d, want 2", len(items.Children))
+	}
+	children := items.Children[0]
+	if children.Path != "items[].children" {
+		t.Fatalf("first child path = %q, want items[].children", children.Path)
+	}
+	if children.Expandable() {
+		t.Fatal("recursive array ref should stop at the repeated definition")
+	}
+	if got := children.Node.DisplayType(); got != "[]object" {
+		t.Fatalf("recursive array type = %q, want []object", got)
+	}
+	if items.Children[1].Path != "items[].name" {
+		t.Fatalf("second child path = %q, want items[].name", items.Children[1].Path)
+	}
+}
+
 func TestConstraints(t *testing.T) {
 	minLen := int64(1)
 	maxLen := int64(255)
@@ -873,12 +1166,66 @@ func TestRenderSchema_CoreGroupUsesVersionOnlyAPIVersion(t *testing.T) {
 		t.Fatalf("renderSchemaFile error: %v", err)
 	}
 
-	html := string(readFile(t, filepath.Join(tmpDir, "core", "pod_v1.html")))
+	html := readFile(t, filepath.Join(tmpDir, "core", "pod_v1.html"))
 	if !strings.Contains(html, "apiVersion: v1\nkind: Pod") {
 		t.Fatal("expected core resources to render apiVersion without synthetic core group")
 	}
 	if strings.Contains(html, "apiVersion: core/v1") {
 		t.Fatal("core resources must not render synthetic core group in apiVersion")
+	}
+}
+
+func TestRenderSchemaResolvesLocalDefinitionRefsInHTML(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"spec": {
+				"anyOf": [
+					{"$ref": "#/definitions/io.k8s.example.Spec"},
+					{"type": "null"}
+				],
+				"description": "Spec defines desired state"
+			}
+		},
+		"definitions": {
+			"io.k8s.example.Spec": {
+				"type": "object",
+				"required": ["containers"],
+				"properties": {
+					"containers": {
+						"type": "array",
+						"items": {"$ref": "#/definitions/io.k8s.example.Container"}
+					}
+				}
+			},
+			"io.k8s.example.Container": {
+				"type": "object",
+				"properties": {
+					"name": {"type": "string"}
+				}
+			}
+		}
+	}`
+
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "core"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "core", "pod_v1.json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "core", "pod_v1.json"), "core", "pod_v1.json", "")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	html := readFile(t, filepath.Join(tmpDir, "core", "pod_v1.html"))
+	for _, needle := range []string{
+		`data-path="spec"`,
+		`Spec defines desired state`,
+		`data-path="spec.containers"`,
+		`data-path="spec.containers[].name"`,
+	} {
+		if !strings.Contains(html, needle) {
+			t.Fatalf("rendered HTML missing %q", needle)
+		}
 	}
 }
 

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -853,6 +853,35 @@ func TestRenderSchema_PreservesOriginalKindFromManifest(t *testing.T) {
 	}
 }
 
+func TestRenderSchema_CoreGroupUsesVersionOnlyAPIVersion(t *testing.T) {
+	schema := `{"type":"object"}`
+
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "core"), 0o755)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "_meta"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "core", "pod_v1.json"), []byte(schema), 0o644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "_meta", "kinds.json"), []byte(`{"core/pod_v1.json":"Pod"}`), 0o644)
+
+	err := renderSchemaFile(
+		testTemplate(t),
+		filepath.Join(tmpDir, "core", "pod_v1.json"),
+		"core",
+		"pod_v1.json",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	html := string(readFile(t, filepath.Join(tmpDir, "core", "pod_v1.html")))
+	if !strings.Contains(html, "apiVersion: v1\nkind: Pod") {
+		t.Fatal("expected core resources to render apiVersion without synthetic core group")
+	}
+	if strings.Contains(html, "apiVersion: core/v1") {
+		t.Fatal("core resources must not render synthetic core group in apiVersion")
+	}
+}
+
 func TestRenderAll_CreatesHTMLFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(tmpDir, "cert-manager.io"), 0o755)


### PR DESCRIPTION
Adds an OpenAPI v2 (swagger) input to `convert`, so Kubernetes's built-in types (Pod, Deployment, …) can be published through the same naming, render, and index path as CRDs. Combinable with `--file`/`--dir` to put CRDs and built-ins in one searchable site.

OpenAPI definitions cross-reference via `#/definitions/...`, whereas CRD schemas are self-contained, so each emitted schema bundles the transitive closure of its referenced definitions inline. Reuses `converter.Convert` and the existing writer; the kinds manifest merges across the CRD and OpenAPI passes.

```sh
kubectl get --raw /openapi/v2 > swagger.json
crd-schema-publisher convert -d ./crds --openapi swagger.json -o ./schemas --render
```

Tested: a combined CRD + OpenAPI run writes both into one site and one kinds manifest; full existing suite plus new tests pass; `gofmt`/`go vet` clean.