### PR TITLE
feat(convert): add --kustomize for the Kustomization schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes cluster, converts Kubernetes built-in schemas from OpenAPI v2, and builds a browsable static site. It can publish directly to Cloudflare Pages or run in extract-only mode for sidecar consumers such as local web servers, git sync, or object-storage sync. Runs as a long-lived Deployment (watch mode) or CronJob on Kubernetes. Deployed in a nonroot distroless container.
+A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes cluster, converts Kubernetes built-in schemas from OpenAPI v2, publishes kustomize's client-side Kustomization schema, and builds a browsable static site. It can publish directly to Cloudflare Pages or run in extract-only mode for sidecar consumers such as local web servers, git sync, or object-storage sync. Runs as a long-lived Deployment (watch mode) or CronJob on Kubernetes. Deployed in a nonroot distroless container.
 
 ## Repository Layout
 
@@ -59,7 +59,7 @@ KUBECTL_CONTEXT=my-context OUTPUT_DIR=./output go run ./cmd/ extract
 
 # Convert Kubernetes built-ins from a cluster OpenAPI document
 kubectl get --raw /openapi/v2 > swagger.json
-go run ./cmd/ convert --openapi swagger.json -o ./schemas --render
+go run ./cmd/ convert --openapi swagger.json --kustomize -o ./schemas --render
 
 # Preview index UI locally (no cluster needed)
 go run ./cmd/ preview
@@ -75,7 +75,7 @@ go run ./cmd/main.go --help
 
 - `run` (default) — extract + optional upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`/`-o`, `--kind`, `--group`, and `--version`; the output root must already exist.
 - `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir`/`-o` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version` filters and CLI flags (`--output-dir`/`-o`, `--context`, `--base-path`, `--skip-render`) that override env vars.
-- `convert` — convert CRD YAML files and Kubernetes OpenAPI v2 built-ins to JSON Schema without a cluster connection. Requires `--output-dir`/`-o`. Reads CRDs from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`; reads built-ins from `--openapi <swagger.json>`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. Supports the same `--kind`, `--group`, `--version` filters.
+- `convert` — convert CRD YAML files and Kubernetes OpenAPI v2 built-ins to JSON Schema without a cluster connection, and optionally emit kustomize's Kustomization schema. Requires `--output-dir`/`-o`. Reads CRDs from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`; reads built-ins from `--openapi <swagger.json>`; emits Kustomization with `--kustomize`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. `--kind`, `--group`, and `--version` filter CRD YAML and OpenAPI inputs; `--kustomize` is explicit and unfiltered.
 - `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`/`-o`; the output root must already exist.
 - `watch` — long-lived process: informer watches CRDs, debounces events, and runs extract plus optional upload cycles. Leader election for multi-replica safety. Accepts `--output-dir`/`-o`, `--kind`, `--group`, and `--version`; the output root must already exist. Filters are applied to generated output, not to the informer watch scope.
 - `preview` — generate sample data by default, or with explicit `--output-dir`/`-o` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
@@ -120,10 +120,11 @@ go run ./cmd/main.go --help
 | `--file`, `-f` | convert | — | CRD YAML file(s), comma-separated. `-` for stdin |
 | `--dir`, `-d` | convert | — | Directory of CRD YAML files (non-recursive) |
 | `--openapi` | convert | — | Kubernetes OpenAPI v2 (swagger) file for built-in resource schemas |
+| `--kustomize` | convert | `false` | Emit kustomize's Kustomization schema. Explicit opt-in; not filtered. |
 | `--render` | convert | `false` | Render HTML docs |
-| `--kind` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_KIND`; `convert`: — | Filter by kind (comma-separated, case-insensitive) |
-| `--group` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_GROUP`; `convert`: — | Filter by group (comma-separated, case-insensitive) |
-| `--version` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_VERSION`; `convert`: — | Filter by version (comma-separated, case-insensitive) |
+| `--kind` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_KIND`; `convert`: — | Filter by kind (comma-separated, case-insensitive). For `convert`, applies to CRD YAML and OpenAPI inputs. |
+| `--group` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_GROUP`; `convert`: — | Filter by group (comma-separated, case-insensitive). For `convert`, applies to CRD YAML and OpenAPI inputs. |
+| `--version` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_VERSION`; `convert`: — | Filter by version (comma-separated, case-insensitive). For `convert`, applies to CRD YAML and OpenAPI inputs. |
 
 ### Key Design Decisions
 
@@ -132,6 +133,7 @@ go run ./cmd/main.go --help
 - **BLAKE3 file hashing** exactly matches wrangler's `hashFile`: `hex(blake3(base64(content) + extension))[0:32]`. Do not change this algorithm without verifying against wrangler source.
 - **OpenAPI v3 to JSON Schema conversion** applies three transforms in order: additionalProperties, replaceIntOrString, allowNullOptionalFields. Shared JSON Schema semantics that are used by both converter and renderer live in `jsonschema/`; keep traversal keyword sets, non-null type resolution, required-property lookup, and oneOf branch display de-duplication there instead of duplicating them in call sites. Current behavior is intentionally tuned for kubeconform/IDE validation correctness: (1) `additionalProperties` uses schema-aware traversal, closing structural child object schemas while skipping same-instance validation overlays (`oneOf`/`anyOf`/`allOf`/`not`/dependencies/conditionals) and literal data-valued keywords such as `default` and `enum`; it also recurses into each property sub-schema individually so CRD fields named `properties` or other JSON Schema keywords do not corrupt the output; (2) nullable applies only to fields *not* in the required list, including optional pure `$ref` fields as `anyOf` ref-or-null wrappers; (3) `replaceIntOrString` preserves safe metadata but removes/replaces conflicting parent type and distributes type-specific assertions into the string or integer oneOf branch for Kubernetes int-or-string markers; (4) root object and array items are not made nullable. Golden E2E tests (`extractor/testdata/golden_certificate_v1.json`, `golden_edgecase_v1.json`) freeze the converter output and catch regressions.
 - **Kubernetes OpenAPI v2 built-ins** are converted only by `convert --openapi`. Definitions with authorable group/version/kind metadata and `apiVersion`/`kind` properties become per-kind schemas. The empty API group is normalized to `core`, referenced definitions are bundled into each schema, and CRD YAML inputs can be combined with `--openapi` into one flat output site.
+- **Kustomize Kustomization schema** is emitted only by `convert --kustomize` at `kustomize.config.k8s.io/kustomization_v1beta1.json`. It is reflected from the pinned `sigs.k8s.io/kustomize/api` Go type because Kustomization is client-side and not served by the Kubernetes API. Convert filters apply to CRD YAML and OpenAPI inputs; `--kustomize` is a single explicit opt-in and is not filtered.
 - **Schema renderer** generates interactive HTML documentation pages (collapsible `<details>`/`<summary>` property trees, type/required badges, YAML boilerplate). It resolves local `#/definitions/...` refs, array item refs, and nullable `anyOf`/`oneOf` wrappers with exactly one non-null branch so built-in fields such as `Pod.spec.containers` expand in HTML while the JSON stays validator-friendly. Uses `html/template` with recursive `{{define "properties"}}` for nested schemas. Schema-page path search behavior lives in the extracted `theme/schema_search.js` asset, which `RenderAll` emits into the output root as `schema-search.js` and the page bootstrap loads at runtime. Enabled by default; disable with `SKIP_RENDER=true`.
 - **Theme package** (`theme/`) holds shared CSS, HTML fragments, small JS helpers used by both index and renderer templates, and emitted static assets such as `schema-search.js`. CSS custom properties are the union of both pages' needs. The deepspace theme (starfield, flare, light/dark toggle) is defined once here.
 - **Output format** builds immutable site generations under `OUTPUT_DIR/.generations/<generation>/` and atomically switches `OUTPUT_DIR/current` to the active generation. Each generation contains both directory formats: `<group>/<kind>_<version>.json` (primary) and `master-standalone/<group>-<kind>-stable-<version>.json` (kubeval compatibility), plus rendered `.html` documentation pages, `index.html`, static assets, and an internal `_meta/kinds.json` manifest used to preserve exact Kind casing for re-render/preview paths. Direct-volume consumers should read from `OUTPUT_DIR/current`, not the flat root. First-party Cloudflare, git, S3, and Caddy examples exclude `_meta/` from public output.
@@ -151,11 +153,13 @@ go run ./cmd/main.go --help
 
 | Dependency | Purpose |
 | --------- | ------- |
+| `github.com/invopop/jsonschema` | Reflect kustomize Go types into JSON Schema |
 | `github.com/zeebo/blake3` | BLAKE3 hashing (pure Go) |
 | `gopkg.in/yaml.v3` | Streaming YAML document decoding for file/stdin conversion |
 | `k8s.io/apiextensions-apiserver` | CRD typed client and API types |
 | `k8s.io/apimachinery` | Shared Kubernetes API machinery used by clients and watchers |
 | `k8s.io/client-go` | Kubernetes API access, informer/watch plumbing, leader election |
+| `sigs.k8s.io/kustomize/api` | Source Go type for kustomize's Kustomization schema |
 | `sigs.k8s.io/yaml` | YAML-to-Kubernetes-struct decoding for CRD conversion |
 
 Everything else in `go.mod` is transitive. The project still leans heavily on the standard library for HTTP, JSON, HTML templates, MIME types, and the preview server.

--- a/README.md
+++ b/README.md
@@ -248,11 +248,11 @@ helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publis
   -f examples/<example>/values.yaml
 ```
 
-| Example | Backend | Description |
-| ------- | ------- | ----------- |
-| [`caddy-sidecar`](examples/caddy-sidecar/values.yaml) | Local HTTP | Caddy serves schemas directly from the cluster with directory browsing and a Gateway API HTTPRoute. Adaptable to nginx or any web server. |
-| [`rclone-s3`](examples/rclone-s3/values.yaml) | S3-compatible storage | rclone syncs schemas to any S3-compatible provider (AWS S3, Backblaze B2, MinIO, Cloudflare R2, GCS) on a 60-second interval. Provider-specific configuration documented in the file header. |
-| [`git-push`](examples/git-push/values.yaml) | Git repository | Commits and pushes schema changes to a GitHub repository for GitHub Pages hosting. Works with any git host (GitLab, Gitea, Bitbucket) by adjusting the remote URL. |
+| Example                                               | Backend               | Description                                                                                                                                                                                  |
+| ----------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`caddy-sidecar`](examples/caddy-sidecar/values.yaml) | Local HTTP            | Caddy serves schemas directly from the cluster with directory browsing and a Gateway API HTTPRoute. Adaptable to nginx or any web server.                                                    |
+| [`rclone-s3`](examples/rclone-s3/values.yaml)         | S3-compatible storage | rclone syncs schemas to any S3-compatible provider (AWS S3, Backblaze B2, MinIO, Cloudflare R2, GCS) on a 60-second interval. Provider-specific configuration documented in the file header. |
+| [`git-push`](examples/git-push/values.yaml)           | Git repository        | Commits and pushes schema changes to a GitHub repository for GitHub Pages hosting. Works with any git host (GitLab, Gitea, Bitbucket) by adjusting the remote URL.                           |
 
 Each example is a self-contained values file — copy it, fill in your credentials, and install. See the comments in each file for what to customize.
 
@@ -331,31 +331,31 @@ cosign verify ghcr.io/sholdee/crd-schema-publisher:latest \
 
 ### Environment Variables
 
-Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`/`-o`. Variables marked *(watch)* apply only to watch mode deployment.
+Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`/`-o`. Variables marked _(watch)_ apply only to watch mode deployment.
 
-| Variable | Required | Default | Description |
-| -------- | -------- | ------- | ----------- |
-| `CLOUDFLARE_API_TOKEN` | Upload only | — | Cloudflare API token with Pages permissions |
-| `CLOUDFLARE_ACCOUNT_ID` | Upload only | — | Cloudflare account ID |
-| `CF_PAGES_PROJECT` | No | `kubernetes-schemas` | Cloudflare Pages project name |
-| `OUTPUT_DIR` | No | `/output` | Site output root. The active snapshot is exposed at `OUTPUT_DIR/current` |
-| `KUBECTL_CONTEXT` | No | — | Kubernetes context name (local development only) |
-| `DEBOUNCE_SECONDS` | No | `15` | Seconds to wait after last CRD event before publishing (watch mode) |
-| `POD_NAME` | Yes (watch) | — | Pod identity for leader election (set via downward API) |
-| `POD_NAMESPACE` | Yes (watch) | — | Namespace for leader lease (set via downward API) |
-| `LEASE_NAME` | No | `crd-schema-publisher` | Name of the Lease resource (watch mode) |
-| `HEALTH_PORT` | No | `8080` | Port for liveness/readiness probes (watch mode) |
-| `SERVE_SITE` | No | — | Set to `true` to serve `OUTPUT_DIR/current` from watch mode |
-| `SITE_PORT` | No | `8081` | Non-privileged static site server port when `SERVE_SITE=true` |
-| `SERVE_ACCESS_LOG` | No | — | Set to `true` to log each request served by the built-in static site server |
-| `PREVIEW_ADDR` | No | `127.0.0.1:8989` | Listen address for preview server (preview mode) |
-| `SKIP_RENDER` | No | — | Set to `true` to skip HTML schema page rendering |
-| `UPLOAD_BUCKET_SIZE_BYTES` | No | `41943040` | Cloudflare upload bucket size in bytes. Lower values reduce peak upload memory at the cost of more requests |
-| `UPLOAD_CONCURRENCY` | No | `3` | Concurrent Cloudflare upload buckets. Lower values reduce peak upload memory at the cost of slower cache-miss uploads |
-| `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`) |
-| `SCHEMA_FILTER_KIND` | No | — | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
-| `SCHEMA_FILTER_GROUP` | No | — | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
-| `SCHEMA_FILTER_VERSION` | No | — | Restrict generated schemas to matching API versions, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
+| Variable                   | Required    | Default                | Description                                                                                                           |
+| -------------------------- | ----------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`     | Upload only | —                      | Cloudflare API token with Pages permissions                                                                           |
+| `CLOUDFLARE_ACCOUNT_ID`    | Upload only | —                      | Cloudflare account ID                                                                                                 |
+| `CF_PAGES_PROJECT`         | No          | `kubernetes-schemas`   | Cloudflare Pages project name                                                                                         |
+| `OUTPUT_DIR`               | No          | `/output`              | Site output root. The active snapshot is exposed at `OUTPUT_DIR/current`                                              |
+| `KUBECTL_CONTEXT`          | No          | —                      | Kubernetes context name (local development only)                                                                      |
+| `DEBOUNCE_SECONDS`         | No          | `15`                   | Seconds to wait after last CRD event before publishing (watch mode)                                                   |
+| `POD_NAME`                 | Yes (watch) | —                      | Pod identity for leader election (set via downward API)                                                               |
+| `POD_NAMESPACE`            | Yes (watch) | —                      | Namespace for leader lease (set via downward API)                                                                     |
+| `LEASE_NAME`               | No          | `crd-schema-publisher` | Name of the Lease resource (watch mode)                                                                               |
+| `HEALTH_PORT`              | No          | `8080`                 | Port for liveness/readiness probes (watch mode)                                                                       |
+| `SERVE_SITE`               | No          | —                      | Set to `true` to serve `OUTPUT_DIR/current` from watch mode                                                           |
+| `SITE_PORT`                | No          | `8081`                 | Non-privileged static site server port when `SERVE_SITE=true`                                                         |
+| `SERVE_ACCESS_LOG`         | No          | —                      | Set to `true` to log each request served by the built-in static site server                                           |
+| `PREVIEW_ADDR`             | No          | `127.0.0.1:8989`       | Listen address for preview server (preview mode)                                                                      |
+| `SKIP_RENDER`              | No          | —                      | Set to `true` to skip HTML schema page rendering                                                                      |
+| `UPLOAD_BUCKET_SIZE_BYTES` | No          | `41943040`             | Cloudflare upload bucket size in bytes. Lower values reduce peak upload memory at the cost of more requests           |
+| `UPLOAD_CONCURRENCY`       | No          | `3`                    | Concurrent Cloudflare upload buckets. Lower values reduce peak upload memory at the cost of slower cache-miss uploads |
+| `BASE_PATH`                | No          | —                      | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`)                      |
+| `SCHEMA_FILTER_KIND`       | No          | —                      | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`)    |
+| `SCHEMA_FILTER_GROUP`      | No          | —                      | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`)   |
+| `SCHEMA_FILTER_VERSION`    | No          | —                      | Restrict generated schemas to matching API versions, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
 
 Schema filters limit generated output only. In watch mode, the controller still watches all cluster CRDs and applies the filters during each publish cycle. If active filters match no CRDs, runtime builds publish an empty catalog instead of leaving stale schemas in place.
 
@@ -373,20 +373,21 @@ Commands:
   preview   Serve a local preview of the documentation site
 ```
 
-| Command(s) | Output directory behavior |
-| --- | --- |
-| `extract` | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; does not fall back to `/output`. |
-| `convert` | Requires `--output-dir`/`-o`; does not read `OUTPUT_DIR`. |
-| `run`, `watch`, `upload` | Accept `--output-dir`/`-o`; output root must already exist. |
-| `preview` | Uses sample data by default; reads real extracted output only when `--output-dir`/`-o` is passed explicitly. |
+| Command(s)               | Output directory behavior                                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `extract`                | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; does not fall back to `/output`.                      |
+| `convert`                | Requires `--output-dir`/`-o`; does not read `OUTPUT_DIR`.                                                    |
+| `run`, `watch`, `upload` | Accept `--output-dir`/`-o`; output root must already exist.                                                  |
+| `preview`                | Uses sample data by default; reads real extracted output only when `--output-dir`/`-o` is passed explicitly. |
 
-| Command(s) | Filters and command-specific flags |
-| --- | --- |
-| `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`. |
-| `extract` | Supports `--context`, `--base-path`, and `--skip-render`. |
-| `convert` | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. |
-| `convert` | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links. |
-| `convert` | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
+| Command(s)                | Filters and command-specific flags                                                                                                                                                                   |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`.        |
+| `extract`                 | Supports `--context`, `--base-path`, and `--skip-render`.                                                                                                                                            |
+| `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters.                                                                                                             |
+| `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
+| `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
+| `convert`                 | `--kustomize` publishes a schema for kustomize's `Kustomization`, reflected from the pinned `sigs.k8s.io/kustomize/api` types. Combinable with the inputs above.                                     |
 
 ## 📋 Using Your Schemas
 
@@ -410,8 +411,8 @@ Or configure schemas globally in VS Code:
 // .vscode/settings.json
 {
   "yaml.schemas": {
-    "https://kube-schemas.example.com/cert-manager.io/certificate_v1.json": ["**/certificates/*.yaml"]
-  }
+    "https://kube-schemas.example.com/cert-manager.io/certificate_v1.json": ["**/certificates/*.yaml"],
+  },
 }
 ```
 
@@ -440,16 +441,16 @@ This validates Kubernetes built-ins and CRDs against the same published schema s
 
 In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` (default 8080) in Prometheus text format.
 
-| Metric | Type | Description |
-| ------ | ---- | ----------- |
-| `crdpublisher_publish_cycle_duration_seconds` | gauge | Duration of the most recent publish cycle |
-| `crdpublisher_publish_cycle_total` | counter | Publish cycles by result (`success`, `error`) |
-| `crdpublisher_crds_discovered` | gauge | CRDs found in the most recent cycle |
-| `crdpublisher_schemas_written` | gauge | Schemas written in the most recent cycle |
-| `crdpublisher_last_successful_publish_timestamp` | gauge | Unix epoch of the last successful publish |
-| `crdpublisher_watchdog_timestamp` | gauge | Unix epoch of the last debounce loop tick |
-| `crdpublisher_publish_skipped_total` | counter | Debounce skips (publish already in progress) |
-| `crdpublisher_leader` | gauge | Whether this pod is the current leader |
+| Metric                                           | Type    | Description                                   |
+| ------------------------------------------------ | ------- | --------------------------------------------- |
+| `crdpublisher_publish_cycle_duration_seconds`    | gauge   | Duration of the most recent publish cycle     |
+| `crdpublisher_publish_cycle_total`               | counter | Publish cycles by result (`success`, `error`) |
+| `crdpublisher_crds_discovered`                   | gauge   | CRDs found in the most recent cycle           |
+| `crdpublisher_schemas_written`                   | gauge   | Schemas written in the most recent cycle      |
+| `crdpublisher_last_successful_publish_timestamp` | gauge   | Unix epoch of the last successful publish     |
+| `crdpublisher_watchdog_timestamp`                | gauge   | Unix epoch of the last debounce loop tick     |
+| `crdpublisher_publish_skipped_total`             | counter | Debounce skips (publish already in progress)  |
+| `crdpublisher_leader`                            | gauge   | Whether this pod is the current leader        |
 
 The watchdog timestamp enables dead man's switch alerting — it updates on every debounce loop tick (regardless of whether a publish occurs), so `time() - crdpublisher_watchdog_timestamp` staying fresh proves the watcher is alive. The publish timestamp separately tracks when content was last pushed.
 
@@ -557,6 +558,7 @@ For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
    - Allows null for optional fields (per-field precision, including optional `$ref` fields as ref-or-null `anyOf` wrappers)
 
    These transforms handle nullable fields, int-or-string types, root objects, and keyword-colliding property names. A frozen golden test locks converter output to prevent regressions.
+
 4. Writes schemas to both primary and kubeval-compatible directory formats inside a new generation snapshot
 5. Renders an interactive HTML documentation page for each schema with collapsible property trees, local `$ref` expansion, path-aware search, and autocomplete powered by a shared emitted `schema-search.js` asset
 6. Generates an HTML index grouped by API group with client-side search, schema statistics, and yaml-language-server usage examples
@@ -573,6 +575,10 @@ crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 ```
 
 Combine `--openapi` with `--file` or `--dir` when you want one local site containing both built-ins and CRDs.
+
+`--kustomize` publishes a schema for kustomize's `Kustomization` at `kustomize.config.k8s.io/kustomization_v1beta1.json`. It's a client-side type with no usable upstream schema, so it's reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module — bumping that dependency updates the schema. Combine it with the other inputs in a single run:
+
+crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render
 
 ## 🔧 Development
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Commands:
 | `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters for CRD YAML and OpenAPI inputs.                                                                             |
 | `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
 | `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
-| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` schema, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                                               |
+| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` schema, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                                              |
 
 ## 📋 Using Your Schemas
 

--- a/README.md
+++ b/README.md
@@ -384,10 +384,10 @@ Commands:
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`.        |
 | `extract`                 | Supports `--context`, `--base-path`, and `--skip-render`.                                                                                                                                            |
-| `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters.                                                                                                             |
+| `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters for CRD YAML and OpenAPI inputs.                                                                             |
 | `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
 | `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
-| `convert`                 | `--kustomize` publishes a schema for kustomize's `Kustomization`, reflected from the pinned `sigs.k8s.io/kustomize/api` types. Combinable with the inputs above.                                     |
+| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` schema, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                                               |
 
 ## 📋 Using Your Schemas
 
@@ -578,7 +578,11 @@ Combine `--openapi` with `--file` or `--dir` when you want one local site contai
 
 `--kustomize` publishes a schema for kustomize's `Kustomization` at `kustomize.config.k8s.io/kustomization_v1beta1.json`. It's a client-side type with no usable upstream schema, so it's reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module — bumping that dependency updates the schema. Combine it with the other inputs in a single run:
 
+`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs; `--kustomize` is a single explicit opt-in and always emits Kustomization when set.
+
+```sh
 crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render
+```
 
 ## 🔧 Development
 

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -231,6 +231,7 @@ func runConvert(args []string) error {
 	var dirFlag string
 	stringFlagWithAlias(fs, &dirFlag, "dir", "d", "", "directory containing CRD YAML files")
 	openapiFlag := fs.String("openapi", "", "Kubernetes OpenAPI v2 (swagger) file; converts built-in types (combinable with --file/--dir)")
+	kustomizeFlag := fs.Bool("kustomize", false, "also publish the kustomize Kustomization schema (combinable with --file/--dir/--openapi)")
 	var outputDir string
 	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", "", "output directory for JSON schemas (required)")
 	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")
@@ -249,8 +250,8 @@ func runConvert(args []string) error {
 	if err := extractor.ValidateOutputDir(outputDir); err != nil {
 		return err
 	}
-	if fileFlag == "" && dirFlag == "" && *openapiFlag == "" {
-		return fmt.Errorf("one of --file, --dir, or --openapi is required")
+	if fileFlag == "" && dirFlag == "" && *openapiFlag == "" && !*kustomizeFlag {
+		return fmt.Errorf("one of --file, --dir, --openapi, or --kustomize is required")
 	}
 
 	filter := extractor.ParseFilter(*kind, *group, *version)
@@ -263,7 +264,7 @@ func runConvert(args []string) error {
 		return fmt.Errorf("preparing output directory: %w", err)
 	}
 
-	if len(crds) == 0 && *openapiFlag == "" {
+	if len(crds) == 0 && *openapiFlag == "" && !*kustomizeFlag {
 		slog.Info("no CRDs matched filters")
 		return nil
 	}
@@ -273,6 +274,13 @@ func runConvert(args []string) error {
 	count, err := writeConvertInputs(crds, *openapiFlag, outputDir, filter)
 	if err != nil {
 		return err
+	}
+	if *kustomizeFlag {
+		n, err := extractor.WriteKustomizeSchemas(outputDir)
+		if err != nil {
+			return fmt.Errorf("writing kustomize schema: %w", err)
+		}
+		count += n
 	}
 
 	if *render {

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -224,6 +224,25 @@ func renderConvertOutput(outputDir, basePath string) error {
 	return nil
 }
 
+func validateConvertInputs(fileFlag, dirFlag, openapiPath string, kustomize bool) error {
+	if fileFlag == "" && dirFlag == "" && openapiPath == "" && !kustomize {
+		return fmt.Errorf("one of --file, --dir, --openapi, or --kustomize is required")
+	}
+	return nil
+}
+
+func shouldSkipConvertAfterFiltering(crds []apiextensionsv1.CustomResourceDefinition, openapiPath string, kustomize bool) bool {
+	return len(crds) == 0 && openapiPath == "" && !kustomize
+}
+
+func writeKustomizeInput(outputDir string) (int, error) {
+	n, err := extractor.WriteKustomizeSchemas(outputDir)
+	if err != nil {
+		return 0, fmt.Errorf("writing kustomize schema: %w", err)
+	}
+	return n, nil
+}
+
 func runConvert(args []string) error {
 	fs := newCommandFlagSet("convert")
 	var fileFlag string
@@ -250,8 +269,8 @@ func runConvert(args []string) error {
 	if err := extractor.ValidateOutputDir(outputDir); err != nil {
 		return err
 	}
-	if fileFlag == "" && dirFlag == "" && *openapiFlag == "" && !*kustomizeFlag {
-		return fmt.Errorf("one of --file, --dir, --openapi, or --kustomize is required")
+	if err := validateConvertInputs(fileFlag, dirFlag, *openapiFlag, *kustomizeFlag); err != nil {
+		return err
 	}
 
 	filter := extractor.ParseFilter(*kind, *group, *version)
@@ -264,7 +283,7 @@ func runConvert(args []string) error {
 		return fmt.Errorf("preparing output directory: %w", err)
 	}
 
-	if len(crds) == 0 && *openapiFlag == "" && !*kustomizeFlag {
+	if shouldSkipConvertAfterFiltering(crds, *openapiFlag, *kustomizeFlag) {
 		slog.Info("no CRDs matched filters")
 		return nil
 	}
@@ -276,9 +295,9 @@ func runConvert(args []string) error {
 		return err
 	}
 	if *kustomizeFlag {
-		n, err := extractor.WriteKustomizeSchemas(outputDir)
+		n, err := writeKustomizeInput(outputDir)
 		if err != nil {
-			return fmt.Errorf("writing kustomize schema: %w", err)
+			return err
 		}
 		count += n
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1204,6 +1204,22 @@ func TestRunConvert_OpenAPIHonorsFilters(t *testing.T) {
 	}
 }
 
+func TestRunConvert_KustomizeExplicitOptInIgnoresFilters(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+
+	if err := runConvert([]string{"--kustomize", "--output-dir", outputDir, "--kind", "pod"}); err != nil {
+		t.Fatalf("runConvert --kustomize error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "kustomize.config.k8s.io", "kustomization_v1beta1.json")); err != nil {
+		t.Fatal("expected Kustomization schema because --kustomize is an explicit opt-in")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "master-standalone", "kustomize.config.k8s.io-kustomization-stable-v1beta1.json")); err != nil {
+		t.Fatal("expected standalone Kustomization schema")
+	}
+}
+
 func TestRunConvert_ValidatesOutputDir(t *testing.T) {
 	dir := t.TempDir()
 	inputFile := filepath.Join(dir, "crd.yaml")

--- a/extractor/kustomize.go
+++ b/extractor/kustomize.go
@@ -1,0 +1,41 @@
+package extractor
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/invopop/jsonschema"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+// WriteKustomizeSchemas reflects kustomize's Kustomization Go type into a
+// self-contained JSON schema and writes it like any other kind. Kustomization
+// is a client-side type — not a CRD or API-server type — and its published
+// OpenAPI is near-empty, so the Go struct kustomize itself uses is the only
+// complete, version-pinned source.
+func WriteKustomizeSchemas(outputDir string) (int, error) {
+	reflector := &jsonschema.Reflector{ExpandedStruct: true, DoNotReference: true}
+	raw, err := json.Marshal(reflector.Reflect(&types.Kustomization{}))
+	if err != nil {
+		return 0, fmt.Errorf("reflecting kustomization schema: %w", err)
+	}
+
+	var schema map[string]interface{}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return 0, fmt.Errorf("decoding kustomization schema: %w", err)
+	}
+	delete(schema, "$id") // reflector emits a Go-package $id that is meaningless when served
+
+	const group, version = "kustomize.config.k8s.io", "v1beta1"
+	filename, err := writeSchemaMap(schema, "kustomization", group, version, outputDir)
+	if err != nil {
+		return 0, err
+	}
+
+	kinds := map[string]string{filepath.ToSlash(filepath.Join(group, filename)): "Kustomization"}
+	if err := writeKindsManifest(outputDir, kinds); err != nil {
+		return 1, err
+	}
+	return 1, nil
+}

--- a/extractor/kustomize_test.go
+++ b/extractor/kustomize_test.go
@@ -1,0 +1,47 @@
+package extractor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteKustomizeSchemas(t *testing.T) {
+	dir := t.TempDir()
+
+	count, err := WriteKustomizeSchemas(dir)
+	if err != nil {
+		t.Fatalf("WriteKustomizeSchemas: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 schema, got %d", count)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "kustomize.config.k8s.io", "kustomization_v1beta1.json"))
+	if err != nil {
+		t.Fatalf("reading kustomization schema: %v", err)
+	}
+	var schema map[string]interface{}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatal(err)
+	}
+	props, _ := schema["properties"].(map[string]interface{})
+	for _, want := range []string{"resources", "patches", "namespace"} {
+		if _, ok := props[want]; !ok {
+			t.Fatalf("reflected schema missing %q (got %d properties)", want, len(props))
+		}
+	}
+
+	manifest, err := os.ReadFile(filepath.Join(dir, "_meta", "kinds.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kinds map[string]string
+	if err := json.Unmarshal(manifest, &kinds); err != nil {
+		t.Fatal(err)
+	}
+	if kinds["kustomize.config.k8s.io/kustomization_v1beta1.json"] != "Kustomization" {
+		t.Fatalf("expected kinds manifest entry, got %v", kinds)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,23 @@ module github.com/sholdee/crd-schema-publisher
 go 1.26.3
 
 require (
+	github.com/invopop/jsonschema v0.14.0
 	github.com/zeebo/blake3 v0.2.4
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
+	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -28,11 +33,13 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
@@ -47,6 +54,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -7,6 +11,8 @@ github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bF
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
@@ -24,6 +30,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -47,6 +55,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -79,6 +89,8 @@ go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
@@ -119,6 +131,10 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
+sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=
+sigs.k8s.io/kustomize/api v0.21.1/go.mod h1:f3wkKByTrgpgltLgySCntrYoq5d3q7aaxveSagwTlwI=
+sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7fI=
+sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80uLmm0wJkk8=


### PR DESCRIPTION
Stacked on #138 — please review/merge that first; the diff here includes its commit until then (the kustomize change is the second commit, `ecaf935`).

Adds `convert --kustomize`, publishing a schema for kustomize's `Kustomization` at `kustomize.config.k8s.io/kustomization_v1beta1.json`.

`Kustomization` is a client-side type: it has no CRD, isn't served by the API server, and kustomize's own published OpenAPI is near-empty (2 fields). So this reflects it from the `sigs.k8s.io/kustomize/api` Go types pinned in `go.mod` — the same structs `kustomize build` uses — yielding a complete, self-contained schema (34 fields) that updates when the module is bumped. More accurate and current than the hand-maintained SchemaStore schema.

It flows through the existing converter / naming / render / index path (reuses `writeSchemaMap` and the merged kinds manifest from #138), and combines with the other inputs:

```sh
crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render
```

Note the tradeoff: this pulls `sigs.k8s.io/kustomize/api` + `invopop/jsonschema` into the build. Verified a combined run produces 253 kinds (CRDs + built-ins + Kustomization) in one site/index; full suite + new test pass; gofmt/vet clean.