### PR TITLE
feat(kustomize): publish component schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes cluster, converts Kubernetes built-in schemas from OpenAPI v2, publishes kustomize's client-side Kustomization schema, and builds a browsable static site. It can publish directly to Cloudflare Pages or run in extract-only mode for sidecar consumers such as local web servers, git sync, or object-storage sync. Runs as a long-lived Deployment (watch mode) or CronJob on Kubernetes. Deployed in a nonroot distroless container.
+A statically-compiled Go binary that extracts CRD JSON schemas from a Kubernetes cluster, converts Kubernetes built-in schemas from OpenAPI v2, publishes kustomize's client-side config schemas, and builds a browsable static site. It can publish directly to Cloudflare Pages or run in extract-only mode for sidecar consumers such as local web servers, git sync, or object-storage sync. Runs as a long-lived Deployment (watch mode) or CronJob on Kubernetes. Deployed in a nonroot distroless container.
 
 ## Repository Layout
 
@@ -57,11 +57,11 @@ sha256sum crd-schema-publisher-* > checksums-sha256.txt
 # Local extract (requires kubeconfig)
 KUBECTL_CONTEXT=my-context OUTPUT_DIR=./output go run ./cmd/ extract
 
-# Convert Kubernetes built-ins and kustomize schema offline
+# Convert Kubernetes built-ins and kustomize schemas offline
 kubectl get --raw /openapi/v2 > swagger.json
 go run ./cmd/ convert --openapi swagger.json --kustomize -o ./schemas --render
 
-# Extract CRDs plus optional API-server built-ins and kustomize schema
+# Extract CRDs plus optional API-server built-ins and kustomize schemas
 OUTPUT_DIR=./output go run ./cmd/ extract --include-builtins --include-kustomize
 
 # Preview index UI locally (no cluster needed)
@@ -78,7 +78,7 @@ go run ./cmd/main.go --help
 
 - `run` (default) — extract + optional upload. Degrades gracefully: skips upload when Cloudflare credentials are missing, prints guidance when no kubeconfig is available. Accepts `--output-dir`/`-o`, `--kind`, `--group`, `--version`, `--include-builtins`, and `--include-kustomize`; the output root must already exist.
 - `extract` — extract CRDs and build a new site generation, exposed at `OUTPUT_DIR/current`. Requires an explicit output directory via `--output-dir`/`-o` or `OUTPUT_DIR`; it does not fall back to `/output`. Supports `--kind`, `--group`, `--version`, `--include-builtins`, and `--include-kustomize` plus CLI flags (`--output-dir`/`-o`, `--context`, `--base-path`, `--skip-render`) that override env vars.
-- `convert` — convert CRD YAML files and Kubernetes OpenAPI v2 built-ins to JSON Schema without a cluster connection, and optionally emit kustomize's Kustomization schema. Requires `--output-dir`/`-o`. Reads CRDs from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`; reads built-ins from `--openapi <swagger.json>`; emits Kustomization with `--kustomize`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. `--kind`, `--group`, and `--version` filter CRD YAML and OpenAPI inputs; `--kustomize` is explicit and unfiltered.
+- `convert` — convert CRD YAML files and Kubernetes OpenAPI v2 built-ins to JSON Schema without a cluster connection, and optionally emit kustomize's config schemas. Requires `--output-dir`/`-o`. Reads CRDs from `--file`/`-f` (comma-separated, `-` for stdin) and/or `--dir`/`-d`; reads built-ins from `--openapi <swagger.json>`; emits Kustomization and Component with `--kustomize`. Writes flat output (no generation lifecycle). Optional `--render` for HTML docs. `--kind`, `--group`, and `--version` filter CRD YAML and OpenAPI inputs; `--kustomize` is explicit and unfiltered.
 - `upload` — upload the active site from `OUTPUT_DIR/current` to Cloudflare Pages. Accepts `--output-dir`/`-o`; the output root must already exist.
 - `watch` — long-lived process: informer watches CRDs, debounces events, and runs extract plus optional upload cycles. Leader election for multi-replica safety. Accepts `--output-dir`/`-o`, `--kind`, `--group`, `--version`, `--include-builtins`, and `--include-kustomize`; the output root must already exist. Filters are applied to generated output, not to the informer watch scope.
 - `preview` — generate sample data by default, or with explicit `--output-dir`/`-o` copy the active site into an isolated temp generation and serve it on localhost. Ambient `OUTPUT_DIR` is ignored. No cluster or credentials needed. Handles signal cleanup of temp directories.
@@ -106,7 +106,7 @@ go run ./cmd/main.go --help
 | `UPLOAD_CONCURRENCY` | No | `3` | Concurrent CF upload buckets |
 | `BASE_PATH` | No | — | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages) |
 | `SCHEMA_INCLUDE_BUILTINS` | No | — | Set to `true` to include Kubernetes built-ins from API server OpenAPI v2 (`run`, `extract`, `watch`) |
-| `SCHEMA_INCLUDE_KUSTOMIZE` | No | — | Set to `true` to include kustomize's client-side Kustomization schema (`run`, `extract`, `watch`) |
+| `SCHEMA_INCLUDE_KUSTOMIZE` | No | — | Set to `true` to include kustomize's client-side config schemas (`run`, `extract`, `watch`) |
 | `SCHEMA_FILTER_KIND` | No | — | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
 | `SCHEMA_FILTER_GROUP` | No | — | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
 | `SCHEMA_FILTER_VERSION` | No | — | Restrict generated schemas to matching API versions, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
@@ -125,9 +125,9 @@ go run ./cmd/main.go --help
 | `--file`, `-f` | convert | — | CRD YAML file(s), comma-separated. `-` for stdin |
 | `--dir`, `-d` | convert | — | Directory of CRD YAML files (non-recursive) |
 | `--openapi` | convert | — | Kubernetes OpenAPI v2 (swagger) file for built-in resource schemas |
-| `--kustomize` | convert | `false` | Emit kustomize's Kustomization schema. Explicit opt-in; not filtered. |
+| `--kustomize` | convert | `false` | Emit kustomize's Kustomization and Component schemas. Explicit opt-in; not filtered. |
 | `--include-builtins` | run, extract, watch | `$SCHEMA_INCLUDE_BUILTINS` | Include Kubernetes built-ins from API server OpenAPI v2 |
-| `--include-kustomize` | run, extract, watch | `$SCHEMA_INCLUDE_KUSTOMIZE` | Include kustomize's client-side Kustomization schema. Explicit opt-in; not filtered. |
+| `--include-kustomize` | run, extract, watch | `$SCHEMA_INCLUDE_KUSTOMIZE` | Include kustomize's client-side config schemas. Explicit opt-in; not filtered. |
 | `--render` | convert | `false` | Render HTML docs |
 | `--kind` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_KIND`; `convert`: — | Filter by kind (comma-separated, case-insensitive). For `convert`, applies to CRD YAML and OpenAPI inputs. |
 | `--group` | run, extract, convert, watch | `run`/`extract`/`watch`: `$SCHEMA_FILTER_GROUP`; `convert`: — | Filter by group (comma-separated, case-insensitive). For `convert`, applies to CRD YAML and OpenAPI inputs. |
@@ -140,7 +140,7 @@ go run ./cmd/main.go --help
 - **BLAKE3 file hashing** exactly matches wrangler's `hashFile`: `hex(blake3(base64(content) + extension))[0:32]`. Do not change this algorithm without verifying against wrangler source.
 - **OpenAPI v3 to JSON Schema conversion** applies three transforms in order: additionalProperties, replaceIntOrString, allowNullOptionalFields. Shared JSON Schema semantics that are used by both converter and renderer live in `jsonschema/`; keep traversal keyword sets, non-null type resolution, required-property lookup, and oneOf branch display de-duplication there instead of duplicating them in call sites. Current behavior is intentionally tuned for kubeconform/IDE validation correctness: (1) `additionalProperties` uses schema-aware traversal, closing structural child object schemas while skipping same-instance validation overlays (`oneOf`/`anyOf`/`allOf`/`not`/dependencies/conditionals) and literal data-valued keywords such as `default` and `enum`; it also recurses into each property sub-schema individually so CRD fields named `properties` or other JSON Schema keywords do not corrupt the output; (2) nullable applies only to fields *not* in the required list, including optional pure `$ref` fields as `anyOf` ref-or-null wrappers; (3) `replaceIntOrString` preserves safe metadata but removes/replaces conflicting parent type and distributes type-specific assertions into the string or integer oneOf branch for Kubernetes int-or-string markers; (4) root object and array items are not made nullable. Golden E2E tests (`extractor/testdata/golden_certificate_v1.json`, `golden_edgecase_v1.json`) freeze the converter output and catch regressions.
 - **Kubernetes OpenAPI v2 built-ins** are opt-in. Runtime modes use `--include-builtins`/`SCHEMA_INCLUDE_BUILTINS` to fetch `/openapi/v2` from the API server; `convert --openapi` remains the offline file path. Definitions with authorable group/version/kind metadata and `apiVersion`/`kind` properties become per-kind schemas. The empty API group is normalized to `core`, referenced definitions are bundled into each schema, and CRD YAML inputs can be combined with OpenAPI inputs into one site. When OpenAPI also contains known CRD-backed definitions, CRD schemas and source metadata win; matching OpenAPI definitions and their conventional List types are skipped.
-- **Kustomize Kustomization schema** is opt-in at `kustomize.config.k8s.io/kustomization_v1beta1.json`. Runtime modes use `--include-kustomize`/`SCHEMA_INCLUDE_KUSTOMIZE`; `convert` uses `--kustomize`. It is reflected from the pinned `sigs.k8s.io/kustomize/api` Go type because Kustomization is client-side and not served by the Kubernetes API. Filters apply to CRD and OpenAPI inputs; Kustomize is explicit and unfiltered.
+- **Kustomize config schemas** are opt-in at `kustomize.config.k8s.io/kustomization_v1beta1.json` and `kustomize.config.k8s.io/component_v1alpha1.json`. Runtime modes use `--include-kustomize`/`SCHEMA_INCLUDE_KUSTOMIZE`; `convert` uses `--kustomize`. They are reflected from the pinned `sigs.k8s.io/kustomize/api` Go types because these config kinds are client-side and not served by the Kubernetes API. Filters apply to CRD and OpenAPI inputs; Kustomize is explicit and unfiltered.
 - **Schema renderer** generates interactive HTML documentation pages (collapsible `<details>`/`<summary>` property trees, type/required badges, YAML boilerplate). It resolves local `#/definitions/...` refs, array item refs, and nullable `anyOf`/`oneOf` wrappers with exactly one non-null branch so built-in fields such as `Pod.spec.containers` expand in HTML while the JSON stays validator-friendly. Uses `html/template` with recursive `{{define "properties"}}` for nested schemas. Schema-page path search behavior lives in the extracted `theme/schema_search.js` asset, which `RenderAll` emits into the output root as `schema-search.js` and the page bootstrap loads at runtime. Enabled by default; disable with `SKIP_RENDER=true`.
 - **Index grouping** remains API-group-only when generated output has one schema source, preserving the original CRD-only page shape. When more than one source is present, the index adds top-level source sections ordered Custom Resources, Kubernetes Built-ins, Kustomize, Unknown.
 - **Theme package** (`theme/`) holds shared CSS, HTML fragments, small JS helpers used by both index and renderer templates, and emitted static assets such as `schema-search.js`. CSS custom properties are the union of both pages' needs. The deepspace theme (starfield, flare, light/dark toggle) is defined once here.
@@ -167,7 +167,7 @@ go run ./cmd/main.go --help
 | `k8s.io/apiextensions-apiserver` | CRD typed client and API types |
 | `k8s.io/apimachinery` | Shared Kubernetes API machinery used by clients and watchers |
 | `k8s.io/client-go` | Kubernetes API access, informer/watch plumbing, leader election |
-| `sigs.k8s.io/kustomize/api` | Source Go type for kustomize's Kustomization schema |
+| `sigs.k8s.io/kustomize/api` | Source Go type for kustomize config schemas |
 | `sigs.k8s.io/yaml` | YAML-to-Kubernetes-struct decoding for CRD conversion |
 
 Everything else in `go.mod` is transitive. The project still leans heavily on the standard library for HTTP, JSON, HTML templates, MIME types, and the preview server.
@@ -207,7 +207,7 @@ Pushes to main run `test` and `helm-lint` only (no Docker build, no release). PR
 | `test` | After `release-meta` passes | Calls `test.yml` — re-runs all linting and Go tests as a safety net before building |
 | `helm-lint` | After `release-meta` passes | Calls `helm-lint.yml` — re-runs all Helm validation before packaging |
 | `build` | After `test` and `release-meta` pass | Multi-arch Docker build (amd64 + arm64), pushes `vYYYY.MDD.HMMSS` + `latest` to GHCR. Verifies distroless base image digest with cosign before building. This creates the unsigned candidate image used by release-smoke. |
-| `release-smoke` | After `build` and `helm-lint` pass | Starts a temporary kind cluster, applies a unique marker CRD, installs the chart in controller/watch mode using the candidate image digest and dedicated Cloudflare CI credentials, then fetches the published Pages deployment to verify the marker CRD, built-in Pod schema, Kustomization schema, and core site assets. Blocks all promotional artifacts if it fails. |
+| `release-smoke` | After `build` and `helm-lint` pass | Starts a temporary kind cluster, applies a unique marker CRD, installs the chart in controller/watch mode using the candidate image digest and dedicated Cloudflare CI credentials, then fetches the published Pages deployment to verify the marker CRD, built-in Pod schema, Kustomize config schemas, and core site assets. Blocks all promotional artifacts if it fails. |
 | `sign` | After `build` and `release-smoke` pass | Cosign keyless signing via GitHub OIDC |
 | `helm-package` | After `helm-lint`, `release-smoke`, and `sign` pass | Package chart with CalVer SemVer matching the image tag. Push OCI to GHCR, cosign sign. Image and chart always share the same version — no desync possible. |
 | `binaries` | After `test` and `release-meta` pass | Cross-compiles static binaries for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, generates `checksums-sha256.txt`, signs the checksum manifest with cosign keyless blob signing, uploads `dist/` as short-lived artifacts for the `release` job, and publishes GitHub/Sigstore build provenance for the binaries via the attestations service. |

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Controller mode still watches all CRDs, then applies the filter to each generate
 
 #### Runtime built-ins and Kustomize
 
-Runtime modes publish CRDs only by default. Enable built-ins and Kustomize explicitly when you want one site for CRDs, Kubernetes built-in types, and kustomize's client-side `Kustomization` schema.
+Runtime modes publish CRDs only by default. Enable built-ins and Kustomize explicitly when you want one site for CRDs, Kubernetes built-in types, and kustomize's client-side `Kustomization` and `Component` schemas.
 
 ```bash
 helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
@@ -367,14 +367,14 @@ Deployment/runtime configuration is primarily via environment variables. For loc
 | `UPLOAD_CONCURRENCY`       | No          | `3`                    | Concurrent Cloudflare upload buckets. Lower values reduce peak upload memory at the cost of slower cache-miss uploads |
 | `BASE_PATH`                | No          | —                      | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`)                      |
 | `SCHEMA_INCLUDE_BUILTINS`  | No          | —                      | Set to `true` to include Kubernetes built-ins from API server OpenAPI v2 (`run`, `extract`, `watch`)                  |
-| `SCHEMA_INCLUDE_KUSTOMIZE` | No          | —                      | Set to `true` to include kustomize's client-side `Kustomization` schema (`run`, `extract`, `watch`)                   |
+| `SCHEMA_INCLUDE_KUSTOMIZE` | No          | —                      | Set to `true` to include kustomize's client-side config schemas (`run`, `extract`, `watch`)                           |
 | `SCHEMA_FILTER_KIND`       | No          | —                      | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`)    |
 | `SCHEMA_FILTER_GROUP`      | No          | —                      | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`)   |
 | `SCHEMA_FILTER_VERSION`    | No          | —                      | Restrict generated schemas to matching API versions, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
 
 Schema filters limit generated output only. In watch mode, the controller still watches all cluster CRDs and applies the filters during each publish cycle. If active filters match no CRDs or built-ins and Kustomize is not enabled, runtime builds publish an empty catalog instead of leaving stale schemas in place.
 
-Runtime modes stay CRD-only unless opt-ins are enabled. `--include-builtins` reads `/openapi/v2` from the API server and publishes built-ins into the same generation. `--include-kustomize` adds kustomize's client-side `Kustomization` schema. Filters apply to CRDs and built-ins; Kustomize is explicit and unfiltered.
+Runtime modes stay CRD-only unless opt-ins are enabled. `--include-builtins` reads `/openapi/v2` from the API server and publishes built-ins into the same generation. `--include-kustomize` adds kustomize's client-side config schemas. Filters apply to CRDs and built-ins; Kustomize is explicit and unfiltered.
 
 ### Command Behavior
 
@@ -401,12 +401,12 @@ Commands:
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`.        |
 | `run`, `extract`, `watch` | Support `--include-builtins`/`SCHEMA_INCLUDE_BUILTINS` to include built-ins from the API server OpenAPI v2 document.                                                                                 |
-| `run`, `extract`, `watch` | Support `--include-kustomize`/`SCHEMA_INCLUDE_KUSTOMIZE` to include kustomize's client-side `Kustomization` schema.                                                                                  |
+| `run`, `extract`, `watch` | Support `--include-kustomize`/`SCHEMA_INCLUDE_KUSTOMIZE` to include kustomize's client-side config schemas.                                                                                          |
 | `extract`                 | Supports `--context`, `--base-path`, and `--skip-render`.                                                                                                                                            |
 | `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters for CRD YAML and OpenAPI inputs.                                                                             |
 | `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
 | `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
-| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` schema, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                                              |
+| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` and `Component` schemas, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                             |
 
 ## 📋 Using Your Schemas
 
@@ -587,7 +587,7 @@ For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
 
 The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
 
-Runtime modes can include optional schemas in generated snapshots. `--include-builtins` fetches `/openapi/v2` from the API server and writes authorable built-in types into the same generation as CRDs. When OpenAPI also contains CRD-backed definitions, CRD schemas take precedence and those OpenAPI duplicates are skipped. `--include-kustomize` writes kustomize's client-side `Kustomization` schema. When more than one schema source is present, the index separates CRDs, built-ins, and Kustomize schemas; CRD-only output keeps the original API-group-only index. In the Helm chart, `config.includeBuiltins=true` adds `/openapi/v2` RBAC when `rbac.create=true`; `config.includeKustomize=true` does not require additional Kubernetes permissions.
+Runtime modes can include optional schemas in generated snapshots. `--include-builtins` fetches `/openapi/v2` from the API server and writes authorable built-in types into the same generation as CRDs. When OpenAPI also contains CRD-backed definitions, CRD schemas take precedence and those OpenAPI duplicates are skipped. `--include-kustomize` writes kustomize's client-side config schemas. When more than one schema source is present, the index separates CRDs, built-ins, and Kustomize schemas; CRD-only output keeps the original API-group-only index. In the Helm chart, `config.includeBuiltins=true` adds `/openapi/v2` RBAC when `rbac.create=true`; `config.includeKustomize=true` does not require additional Kubernetes permissions.
 
 `--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (for example `kubectl get --raw /openapi/v2`). Each authorable type that declares a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`; the empty API group is written under `core/`. Referenced definitions are bundled into each schema so validation and rendered child fields work without external references. When combined with CRD inputs, matching OpenAPI CRD definitions and their List types are skipped.
 
@@ -598,9 +598,9 @@ crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 
 Combine `--openapi` with `--file` or `--dir` when you want one local site containing both built-ins and CRDs.
 
-`--kustomize` publishes a schema for kustomize's `Kustomization` at `kustomize.config.k8s.io/kustomization_v1beta1.json`. It's a client-side type with no usable upstream schema, so it's reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module — bumping that dependency updates the schema. Combine it with the other inputs in a single run:
+`--kustomize` publishes schemas for kustomize's `Kustomization` and `Component` at `kustomize.config.k8s.io/kustomization_v1beta1.json` and `kustomize.config.k8s.io/component_v1alpha1.json`. These are client-side types with no usable upstream schemas, so they are reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module. Bumping that dependency updates the schemas. Combine them with the other inputs in a single run:
 
-`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs; `--kustomize` is a single explicit opt-in and always emits Kustomization when set.
+`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs; `--kustomize` is a single explicit opt-in and always emits the Kustomize config schemas when set.
 
 ```sh
 crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render

--- a/charts/crd-schema-publisher/values.schema.json
+++ b/charts/crd-schema-publisher/values.schema.json
@@ -124,7 +124,7 @@
         },
         "includeKustomize": {
           "type": "boolean",
-          "description": "Include kustomize's client-side Kustomization schema"
+          "description": "Include kustomize's client-side config schemas"
         },
         "filter": {
           "type": "object",

--- a/charts/crd-schema-publisher/values.yaml
+++ b/charts/crd-schema-publisher/values.yaml
@@ -48,7 +48,7 @@ config:
   basePath: ""
   # -- Include Kubernetes built-in schemas from the API server OpenAPI v2 document
   includeBuiltins: false
-  # -- Include kustomize's client-side Kustomization schema
+  # -- Include kustomize's client-side config schemas
   includeKustomize: false
   # -- Optional schema filters. Values are comma-separated and case-insensitive.
   filter:

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -232,7 +232,7 @@ func shouldSkipConvertAfterFiltering(crds []apiextensionsv1.CustomResourceDefini
 func writeKustomizeInput(outputDir string) (int, error) {
 	n, err := extractor.WriteKustomizeSchemas(outputDir)
 	if err != nil {
-		return 0, fmt.Errorf("writing kustomize schema: %w", err)
+		return 0, fmt.Errorf("writing kustomize schemas: %w", err)
 	}
 	return n, nil
 }
@@ -244,7 +244,7 @@ func runConvert(args []string) error {
 	var dirFlag string
 	stringFlagWithAlias(fs, &dirFlag, "dir", "d", "", "directory containing CRD YAML files")
 	openapiFlag := fs.String("openapi", "", "Kubernetes OpenAPI v2 (swagger) file; converts built-in types (combinable with --file/--dir)")
-	kustomizeFlag := fs.Bool("kustomize", false, "also publish the kustomize Kustomization schema (combinable with --file/--dir/--openapi)")
+	kustomizeFlag := fs.Bool("kustomize", false, "also publish kustomize config schemas (combinable with --file/--dir/--openapi)")
 	var outputDir string
 	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", "", "output directory for JSON schemas (required)")
 	basePath := fs.String("base-path", os.Getenv("BASE_PATH"), "URL path prefix for subpath deployments")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1474,6 +1474,12 @@ func TestRunConvert_KustomizeExplicitOptInIgnoresFilters(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(outputDir, "master-standalone", "kustomize.config.k8s.io-kustomization-stable-v1beta1.json")); err != nil {
 		t.Fatal("expected standalone Kustomization schema")
 	}
+	if _, err := os.Stat(filepath.Join(outputDir, "kustomize.config.k8s.io", "component_v1alpha1.json")); err != nil {
+		t.Fatal("expected Component schema because --kustomize is an explicit opt-in")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "master-standalone", "kustomize.config.k8s.io-component-stable-v1alpha1.json")); err != nil {
+		t.Fatal("expected standalone Component schema")
+	}
 }
 
 func TestRunConvert_ValidatesOutputDir(t *testing.T) {

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -293,6 +293,7 @@ func scaffoldSampleData(dir string) error {
 		},
 		"kustomize.config.k8s.io": {
 			{file: "kustomization_v1beta1.json", kind: "Kustomization", source: schemametadata.SchemaSourceKustomize},
+			{file: "component_v1alpha1.json", kind: "Component", source: schemametadata.SchemaSourceKustomize},
 		},
 	}
 	kinds := make(map[string]string)

--- a/cmd/run_flow_test.go
+++ b/cmd/run_flow_test.go
@@ -708,6 +708,7 @@ func assertSamplePreviewSchemaMetadata(t *testing.T, serveDir string) {
 		"monitoring.coreos.com/servicemonitor_v1.json": schemametadata.SchemaSourceCRD,
 		"core/pod_v1.json": schemametadata.SchemaSourceBuiltin,
 		"kustomize.config.k8s.io/kustomization_v1beta1.json": schemametadata.SchemaSourceKustomize,
+		"kustomize.config.k8s.io/component_v1alpha1.json":    schemametadata.SchemaSourceKustomize,
 	} {
 		if got := metadata[path].Source; got != wantSource {
 			t.Fatalf("expected sample metadata %s source %q, got %q", path, wantSource, got)

--- a/cmd/runtime_config.go
+++ b/cmd/runtime_config.go
@@ -56,7 +56,7 @@ func parseRuntimeConfig(cmd string, args []string, fallbackOutputDir string, env
 	group := fs.String("group", envDefault(env, schemaFilterGroupEnv, ""), "filter by group (comma-separated, case-insensitive)")
 	version := fs.String("version", envDefault(env, schemaFilterVersionEnv, ""), "filter by version (comma-separated, case-insensitive)")
 	includeBuiltins := fs.Bool("include-builtins", envDefault(env, schemaIncludeBuiltinsEnv, "") == "true", "include Kubernetes built-in schemas from the API server")
-	includeKustomize := fs.Bool("include-kustomize", envDefault(env, schemaIncludeKustomizeEnv, "") == "true", "include kustomize's Kustomization schema")
+	includeKustomize := fs.Bool("include-kustomize", envDefault(env, schemaIncludeKustomizeEnv, "") == "true", "include kustomize config schemas")
 	if err := fs.Parse(args); err != nil {
 		return runtimeConfig{}, err
 	}
@@ -82,7 +82,7 @@ func parseExtractConfig(args []string, env envGetter) (extractConfig, error) {
 	group := fs.String("group", envDefault(env, schemaFilterGroupEnv, ""), "filter by group (comma-separated, case-insensitive)")
 	version := fs.String("version", envDefault(env, schemaFilterVersionEnv, ""), "filter by version (comma-separated, case-insensitive)")
 	includeBuiltins := fs.Bool("include-builtins", envDefault(env, schemaIncludeBuiltinsEnv, "") == "true", "include Kubernetes built-in schemas from the API server")
-	includeKustomize := fs.Bool("include-kustomize", envDefault(env, schemaIncludeKustomizeEnv, "") == "true", "include kustomize's Kustomization schema")
+	includeKustomize := fs.Bool("include-kustomize", envDefault(env, schemaIncludeKustomizeEnv, "") == "true", "include kustomize config schemas")
 	if err := fs.Parse(args); err != nil {
 		return extractConfig{}, err
 	}

--- a/extractor/build.go
+++ b/extractor/build.go
@@ -157,7 +157,7 @@ func writeOptionalSchemas(ctx context.Context, opts SiteBuildOptions, generation
 	if opts.IncludeKustomize {
 		n, err := WriteKustomizeSchemas(generationDir)
 		if err != nil {
-			return 0, fmt.Errorf("writing kustomize schema: %w", err)
+			return 0, fmt.Errorf("writing kustomize schemas: %w", err)
 		}
 		count += n
 		snapshot(opts.Profiler, "build.after-write-kustomize", "schema_count", count, "generation", generationName)

--- a/extractor/build_test.go
+++ b/extractor/build_test.go
@@ -330,11 +330,14 @@ func TestBuildSite_IncludeKustomizeWithZeroCRDsBuildsGeneration(t *testing.T) {
 	if result.Status != BuildResultBuilt {
 		t.Fatalf("expected BuildResultBuilt, got %q", result.Status)
 	}
-	if result.CRDCount != 0 || result.SchemaCount != 1 {
-		t.Fatalf("expected CRDCount=0 SchemaCount=1, got CRDCount=%d SchemaCount=%d", result.CRDCount, result.SchemaCount)
+	if result.CRDCount != 0 || result.SchemaCount != 2 {
+		t.Fatalf("expected CRDCount=0 SchemaCount=2, got CRDCount=%d SchemaCount=%d", result.CRDCount, result.SchemaCount)
 	}
 	if _, err := os.Stat(filepath.Join(outputDir, "current", "kustomize.config.k8s.io", "kustomization_v1beta1.json")); err != nil {
 		t.Fatalf("expected Kustomization schema: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "current", "kustomize.config.k8s.io", "component_v1alpha1.json")); err != nil {
+		t.Fatalf("expected Component schema: %v", err)
 	}
 }
 
@@ -351,8 +354,8 @@ func TestBuildSite_MergesCRDsBuiltinsAndKustomizeKindsManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSite error: %v", err)
 	}
-	if result.CRDCount != 1 || result.SchemaCount != 4 {
-		t.Fatalf("expected CRDCount=1 SchemaCount=4, got CRDCount=%d SchemaCount=%d", result.CRDCount, result.SchemaCount)
+	if result.CRDCount != 1 || result.SchemaCount != 5 {
+		t.Fatalf("expected CRDCount=1 SchemaCount=5, got CRDCount=%d SchemaCount=%d", result.CRDCount, result.SchemaCount)
 	}
 
 	data, err := os.ReadFile(filepath.Join(outputDir, "current", "_meta", "kinds.json"))
@@ -367,6 +370,7 @@ func TestBuildSite_MergesCRDsBuiltinsAndKustomizeKindsManifest(t *testing.T) {
 		"example.io/test_v1.json":                            "Test",
 		"core/pod_v1.json":                                   "Pod",
 		"kustomize.config.k8s.io/kustomization_v1beta1.json": "Kustomization",
+		"kustomize.config.k8s.io/component_v1alpha1.json":    "Component",
 		"apps/deployment_v1.json":                            "Deployment",
 	} {
 		if kinds[path] != kind {

--- a/extractor/kustomize.go
+++ b/extractor/kustomize.go
@@ -11,40 +11,85 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 )
 
-// WriteKustomizeSchemas reflects kustomize's Kustomization Go type into a
-// self-contained JSON schema and writes it like any other kind. Kustomization
-// is a client-side type — not a CRD or API-server type — and its published
-// OpenAPI is near-empty, so the Go struct kustomize itself uses is the only
-// complete, version-pinned source.
+// WriteKustomizeSchemas reflects kustomize's Kustomization Go type into
+// self-contained JSON schemas for kustomize's top-level config kinds.
+// Kustomization and Component are client-side types, not CRDs or API-server
+// types, and kustomize's published OpenAPI is near-empty. The Go struct
+// kustomize itself uses is the complete, version-pinned source.
 func WriteKustomizeSchemas(outputDir string) (int, error) {
+	specs := []struct {
+		filenameKind string
+		kind         string
+		version      string
+		apiVersion   string
+	}{
+		{
+			filenameKind: "kustomization",
+			kind:         types.KustomizationKind,
+			version:      "v1beta1",
+			apiVersion:   types.KustomizationVersion,
+		},
+		{
+			filenameKind: "component",
+			kind:         types.ComponentKind,
+			version:      "v1alpha1",
+			apiVersion:   types.ComponentVersion,
+		},
+	}
+
+	const group = "kustomize.config.k8s.io"
+	kinds := make(map[string]string, len(specs))
+	metadata := make(map[string]schemametadata.SchemaMetadataEntry, len(specs))
+	for _, spec := range specs {
+		schema, err := reflectedKustomizeSchema(spec.kind, spec.apiVersion)
+		if err != nil {
+			return len(kinds), err
+		}
+
+		filename, err := writeSchemaMap(schema, spec.filenameKind, group, spec.version, outputDir)
+		if err != nil {
+			return len(kinds), err
+		}
+
+		relPath := filepath.ToSlash(filepath.Join(group, filename))
+		kinds[relPath] = spec.kind
+		metadata[relPath] = schemametadata.SchemaMetadataEntry{
+			Kind:   spec.kind,
+			Source: schemametadata.SchemaSourceKustomize,
+		}
+	}
+
+	if err := writeKindsManifest(outputDir, kinds); err != nil {
+		return len(kinds), err
+	}
+	if err := writeSchemaMetadataManifest(outputDir, metadata); err != nil {
+		return len(kinds), err
+	}
+	return len(kinds), nil
+}
+
+func reflectedKustomizeSchema(kind, apiVersion string) (map[string]interface{}, error) {
 	reflector := &jsonschema.Reflector{ExpandedStruct: true, DoNotReference: true}
 	raw, err := json.Marshal(reflector.Reflect(&types.Kustomization{}))
 	if err != nil {
-		return 0, fmt.Errorf("reflecting kustomization schema: %w", err)
+		return nil, fmt.Errorf("reflecting kustomize schema: %w", err)
 	}
 
 	var schema map[string]interface{}
 	if err := json.Unmarshal(raw, &schema); err != nil {
-		return 0, fmt.Errorf("decoding kustomization schema: %w", err)
+		return nil, fmt.Errorf("decoding kustomize schema: %w", err)
 	}
 	delete(schema, "$id") // reflector emits a Go-package $id that is meaningless when served
+	constrainKustomizeTypeMeta(schema, kind, apiVersion)
+	return schema, nil
+}
 
-	const group, version = "kustomize.config.k8s.io", "v1beta1"
-	filename, err := writeSchemaMap(schema, "kustomization", group, version, outputDir)
-	if err != nil {
-		return 0, err
+func constrainKustomizeTypeMeta(schema map[string]interface{}, kind, apiVersion string) {
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		props = make(map[string]interface{}, 2)
+		schema["properties"] = props
 	}
-
-	relPath := filepath.ToSlash(filepath.Join(group, filename))
-	kinds := map[string]string{relPath: "Kustomization"}
-	if err := writeKindsManifest(outputDir, kinds); err != nil {
-		return 1, err
-	}
-	metadata := map[string]schemametadata.SchemaMetadataEntry{
-		relPath: {Kind: "Kustomization", Source: schemametadata.SchemaSourceKustomize},
-	}
-	if err := writeSchemaMetadataManifest(outputDir, metadata); err != nil {
-		return 1, err
-	}
-	return 1, nil
+	props["apiVersion"] = map[string]interface{}{"const": apiVersion, "type": "string"}
+	props["kind"] = map[string]interface{}{"const": kind, "type": "string"}
 }

--- a/extractor/kustomize_test.go
+++ b/extractor/kustomize_test.go
@@ -16,24 +16,12 @@ func TestWriteKustomizeSchemas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteKustomizeSchemas: %v", err)
 	}
-	if count != 1 {
-		t.Fatalf("expected 1 schema, got %d", count)
+	if count != 2 {
+		t.Fatalf("expected 2 schemas, got %d", count)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "kustomize.config.k8s.io", "kustomization_v1beta1.json"))
-	if err != nil {
-		t.Fatalf("reading kustomization schema: %v", err)
-	}
-	var schema map[string]interface{}
-	if err := json.Unmarshal(data, &schema); err != nil {
-		t.Fatal(err)
-	}
-	props, _ := schema["properties"].(map[string]interface{})
-	for _, want := range []string{"resources", "patches", "namespace"} {
-		if _, ok := props[want]; !ok {
-			t.Fatalf("reflected schema missing %q (got %d properties)", want, len(props))
-		}
-	}
+	assertKustomizeSchema(t, dir, "kustomization", "v1beta1", "Kustomization", "kustomize.config.k8s.io/v1beta1")
+	assertKustomizeSchema(t, dir, "component", "v1alpha1", "Component", "kustomize.config.k8s.io/v1alpha1")
 
 	manifest, err := os.ReadFile(filepath.Join(dir, "_meta", "kinds.json"))
 	if err != nil {
@@ -44,11 +32,48 @@ func TestWriteKustomizeSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	if kinds["kustomize.config.k8s.io/kustomization_v1beta1.json"] != "Kustomization" {
-		t.Fatalf("expected kinds manifest entry, got %v", kinds)
+		t.Fatalf("expected Kustomization kinds manifest entry, got %v", kinds)
+	}
+	if kinds["kustomize.config.k8s.io/component_v1alpha1.json"] != "Component" {
+		t.Fatalf("expected Component kinds manifest entry, got %v", kinds)
 	}
 	metadata := readSchemaMetadata(t, dir)
-	entry := metadata["kustomize.config.k8s.io/kustomization_v1beta1.json"]
-	if entry.Kind != "Kustomization" || entry.Source != schemametadata.SchemaSourceKustomize {
-		t.Fatalf("expected Kustomize schema metadata, got %#v", entry)
+	for path, kind := range map[string]string{
+		"kustomize.config.k8s.io/kustomization_v1beta1.json": "Kustomization",
+		"kustomize.config.k8s.io/component_v1alpha1.json":    "Component",
+	} {
+		entry := metadata[path]
+		if entry.Kind != kind || entry.Source != schemametadata.SchemaSourceKustomize {
+			t.Fatalf("expected %s schema metadata, got %#v", kind, entry)
+		}
+	}
+}
+
+func assertKustomizeSchema(t *testing.T, dir, filenameKind, version, kind, apiVersion string) {
+	t.Helper()
+	file := filenameKind + "_" + version + ".json"
+	data, err := os.ReadFile(filepath.Join(dir, "kustomize.config.k8s.io", file))
+	if err != nil {
+		t.Fatalf("reading %s schema: %v", kind, err)
+	}
+	var schema map[string]interface{}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatal(err)
+	}
+	props, _ := schema["properties"].(map[string]interface{})
+	for _, want := range []string{"resources", "patches", "namespace"} {
+		if _, ok := props[want]; !ok {
+			t.Fatalf("reflected %s schema missing %q (got %d properties)", kind, want, len(props))
+		}
+	}
+	for field, want := range map[string]string{"apiVersion": apiVersion, "kind": kind} {
+		prop, _ := props[field].(map[string]interface{})
+		if prop["const"] != want {
+			t.Fatalf("expected %s.%s const %q, got %#v", kind, field, want, prop)
+		}
+	}
+	standalone := filepath.Join(dir, "master-standalone", "kustomize.config.k8s.io-"+filenameKind+"-stable-"+version+".json")
+	if _, err := os.Stat(standalone); err != nil {
+		t.Fatalf("expected standalone %s schema: %v", kind, err)
 	}
 }

--- a/extractor/openapi_test.go
+++ b/extractor/openapi_test.go
@@ -277,8 +277,8 @@ func TestSchemaMetadataManifestMergesAcrossWriters(t *testing.T) {
 	}
 	if count, err := WriteKustomizeSchemas(dir); err != nil {
 		t.Fatalf("WriteKustomizeSchemas: %v", err)
-	} else if count != 1 {
-		t.Fatalf("expected 1 Kustomize schema, got %d", count)
+	} else if count != 2 {
+		t.Fatalf("expected 2 Kustomize schemas, got %d", count)
 	}
 
 	metadata := readSchemaMetadata(t, dir)
@@ -286,6 +286,7 @@ func TestSchemaMetadataManifestMergesAcrossWriters(t *testing.T) {
 		"example.io/test_v1.json":                            {Kind: "Test", Source: schemametadata.SchemaSourceCRD},
 		"apps/deployment_v1.json":                            {Kind: "Deployment", Source: schemametadata.SchemaSourceBuiltin},
 		"kustomize.config.k8s.io/kustomization_v1beta1.json": {Kind: "Kustomization", Source: schemametadata.SchemaSourceKustomize},
+		"kustomize.config.k8s.io/component_v1alpha1.json":    {Kind: "Component", Source: schemametadata.SchemaSourceKustomize},
 	}
 	if len(metadata) != len(wantMetadata) {
 		t.Fatalf("expected metadata for primary schema files only, got %v", metadata)
@@ -308,6 +309,7 @@ func TestSchemaMetadataManifestMergesAcrossWriters(t *testing.T) {
 		"example.io/test_v1.json":                            "Test",
 		"apps/deployment_v1.json":                            "Deployment",
 		"kustomize.config.k8s.io/kustomization_v1beta1.json": "Kustomization",
+		"kustomize.config.k8s.io/component_v1alpha1.json":    "Component",
 	} {
 		if kinds[path] != want {
 			t.Fatalf("expected kinds[%q]=%q, got %q in %v", path, want, kinds[path], kinds)

--- a/hack/release-smoke/validate.sh
+++ b/hack/release-smoke/validate.sh
@@ -198,6 +198,8 @@ validate_site_at() {
   assert_url_reachable "${base}/core/pod_v1.html" || return 1
   assert_url_reachable "${base}/kustomize.config.k8s.io/kustomization_v1beta1.json" || return 1
   assert_url_reachable "${base}/kustomize.config.k8s.io/kustomization_v1beta1.html" || return 1
+  assert_url_reachable "${base}/kustomize.config.k8s.io/component_v1alpha1.json" || return 1
+  assert_url_reachable "${base}/kustomize.config.k8s.io/component_v1alpha1.html" || return 1
   assert_url_reachable "${base}/schema-search.js" || return 1
   assert_url_reachable "${base}/favicon.svg" || return 1
 }


### PR DESCRIPTION
## Summary
- publish kustomize Component alongside Kustomization when --kustomize / --include-kustomize is enabled
- keep the source limited to sigs.k8s.io/kustomize/api/types; deprecated builtin plugin types are not included
- update tests, preview sample data, release smoke checks, CLI/help docs, README, AGENTS, and Helm descriptions

## Validation
- go test ./...
- go vet ./...
- golangci-lint run
- go run ./hack/chartassert
- npx --yes markdownlint-cli2@0.22.1 README.md AGENTS.md
- git diff --check
- go mod verify
- go mod tidy -diff
- live extract with default kube context: go run ./cmd extract --output-dir /private/tmp/crdsp-component-live --include-builtins --include-kustomize
- preview verified Component JSON/HTML at http://127.0.0.1:8992