### PR TITLE
docs: add Hugo documentation site

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  HUGO_VERSION: "0.162.1"
 
 jobs:
   detect:
@@ -21,6 +22,7 @@ jobs:
     outputs:
       app: ${{ steps.paths.outputs.app }}
       chart: ${{ steps.paths.outputs.chart }}
+      docs-site: ${{ steps.paths.outputs.docs-site }}
       renovate: ${{ steps.paths.outputs.renovate }}
     steps:
       - name: Checkout
@@ -39,6 +41,13 @@ jobs:
             chart:
               - 'charts/**'
               - '.github/workflows/helm-lint.yml'
+            docs-site:
+              - 'README.md'
+              - 'docs/assets/**'
+              - 'docs/screenshots/**'
+              - 'docs-site/**'
+              - '.github/workflows/pages.yml'
+              - '.github/workflows/ci.yaml'
             renovate:
               - '.github/renovate.json5'
               - '.github/workflows/ci.yaml'
@@ -109,10 +118,33 @@ jobs:
     if: needs.detect.outputs.chart == 'true'
     uses: ./.github/workflows/helm-lint.yml
 
+  docs-site:
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.docs-site == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Hugo
+        run: |
+          set -euo pipefail
+          curl -sL -o /tmp/hugo.tar.gz "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+          mkdir "${HOME}/hugo"
+          tar -C "${HOME}/hugo" -xf /tmp/hugo.tar.gz
+          echo "${HOME}/hugo" >> "${GITHUB_PATH}"
+
+      - name: Build documentation site
+        run: hugo --source docs-site --destination /tmp/crd-schema-publisher-docs-site --cleanDestinationDir --minify
+
   gate:
     runs-on: ubuntu-latest
     if: always()
-    needs: [detect, test, build, renovate, helm-lint]
+    needs: [detect, test, build, renovate, helm-lint, docs-site]
     permissions: {}
     steps:
       - name: Evaluate results
@@ -122,10 +154,11 @@ jobs:
           BUILD: ${{ needs.build.result }}
           RENOVATE: ${{ needs.renovate.result }}
           HELM_LINT: ${{ needs.helm-lint.result }}
+          DOCS_SITE: ${{ needs.docs-site.result }}
         run: |
-          echo "detect=${DETECT} test=${TEST} build=${BUILD} renovate=${RENOVATE} helm-lint=${HELM_LINT}"
+          echo "detect=${DETECT} test=${TEST} build=${BUILD} renovate=${RENOVATE} helm-lint=${HELM_LINT} docs-site=${DOCS_SITE}"
 
-          for result in "${DETECT}" "${TEST}" "${BUILD}" "${RENOVATE}" "${HELM_LINT}"; do
+          for result in "${DETECT}" "${TEST}" "${BUILD}" "${RENOVATE}" "${HELM_LINT}" "${DOCS_SITE}"; do
             if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
               echo "CI failed: job returned ${result}"
               exit 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/pages.yml"
+      - "README.md"
+      - "docs/assets/**"
+      - "docs/screenshots/**"
+      - "docs-site/**"
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  HUGO_VERSION: "0.162.1"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Hugo
+        run: |
+          set -euo pipefail
+          curl -sL -o /tmp/hugo.tar.gz "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+          mkdir "${HOME}/hugo"
+          tar -C "${HOME}/hugo" -xf /tmp/hugo.tar.gz
+          echo "${HOME}/hugo" >> "${GITHUB_PATH}"
+
+      - name: Build documentation site
+        run: hugo --source docs-site --destination public --minify
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: docs-site/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ coverage.txt
 
 # Output
 /output/
+
+# Hugo docs site output
+/docs-site/public/
+/docs-site/resources/
+/docs-site/.hugo_build.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,16 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 git config core.hooksPath .githooks
 ```
 
+## Documentation Site
+
+The public docs site lives under `docs-site/` and is built with Hugo.
+
+```bash
+${HUGO_BIN:-hugo} --source docs-site --destination /tmp/crd-schema-publisher-docs-site --cleanDestinationDir --minify
+```
+
+Run that command before opening a PR that changes `docs-site/`, `README.md`, or docs assets.
+
 ## Guidelines
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

--- a/README.md
+++ b/README.md
@@ -23,36 +23,23 @@ Extracts CRD schemas from Kubernetes or YAML, converts Kubernetes built-in resou
 </p>
 
 <p align="center">
-  <a href="https://kube-schemas.shold.io">Live demo</a>
+  <a href="https://sholdee.github.io/crd-schema-publisher/">Documentation</a> ·
+  <a href="https://kube-schemas.shold.io">Live demo</a> ·
+  <a href="https://artifacthub.io/packages/helm/crd-schema-publisher/crd-schema-publisher">Helm chart</a>
 </p>
 
-Run it as:
+## Why
 
-- a Kubernetes-native controller for real-time CRD watching
-- a CronJob for scheduled extraction
-- a local CLI for extracting from a live cluster, converting CRD YAML, or rendering built-in schemas from Kubernetes OpenAPI
+Static CRD catalogs go stale, miss internal CRDs, and depend on external infrastructure. `crd-schema-publisher` publishes schemas from your cluster and can serve or sync them wherever you host static files.
 
-Exports schemas for IDE validation with yaml-language-server and CI linting with kubeconform. Cloudflare Pages and local serving are built in; S3, git repos, and custom web servers are supported via sidecar.
+- Always accurate for installed CRDs, internal CRDs, and optional Kubernetes built-ins.
+- Self-hosted output for Cloudflare Pages, local serving, S3-compatible storage, git, or any static web server.
+- Single static binary in a distroless nonroot container.
+- Controller-grade watch mode with informers, leader election, debounced refreshes, health probes, and metrics.
 
-> **Upgrading direct-volume deployments:** the active site now lives at `OUTPUT_DIR/current`. Existing sidecars or scripts that read the shared output volume directly must be updated. Cloudflare Pages users do not need to change anything.
+## Quickstart
 
-## 💡 Why
-
-Most CRD schema solutions rely on static catalogs — community-maintained repositories that scrape schemas from popular Helm charts. Schemas go stale, internal CRDs are missing, and your validation pipeline depends on third-party infrastructure.
-
-- **Always accurate** — CRD schemas reflect what's installed in your cluster, including custom and internal CRDs, and built-in schemas can be pulled from the same cluster's OpenAPI document
-- **Self-hosted** — run in extract-only mode and serve schemas however you like, or publish directly to Cloudflare Pages
-- **Single static binary** — no runtime dependencies, no interpreters, no package managers. One binary in a distroless nonroot container with no shell
-- **Controller-grade runtime** — watch mode uses informers, leader election, debounced refresh cycles, and health probes. It's a proper workload, not a script on a timer
-- **No glue pipelines** — replaces multi-tool chains (CI runners, shell scripts, kubectl, CLI wrappers) with a single in-cluster binary. No external CI dependency, no cluster-admin runner pods, no scheduled workflow orchestration
-
-The JSON Schema conversion is built for kubeconform and yaml-language-server compatibility — see [How It Works](#%EF%B8%8F-how-it-works) for details.
-
-## ⚡ Quickstart
-
-### Deploy to a Cluster
-
-Install the Helm chart in controller mode for real-time CRD watching. Provide Cloudflare credentials to publish directly to Cloudflare Pages, or omit credentials to run extract-only and serve `OUTPUT_DIR/current` yourself.
+Install the Helm chart in controller mode:
 
 ```bash
 helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
@@ -60,10 +47,6 @@ helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publis
   --create-namespace \
   --set existingSecret.name=crd-schema-publisher-cloudflare
 ```
-
-See [Deploying](#-deploying) for credentials, raw manifests, CronJob mode, alternative backends, and chart verification.
-
-### Install and Run the CLI
 
 Install the standalone CLI:
 
@@ -71,28 +54,28 @@ Install the standalone CLI:
 curl -fsSL https://crdsp.shold.io | bash
 ```
 
-Extract schemas from a kubeconfig context, convert CRD YAML, or render Kubernetes built-ins from the cluster OpenAPI document:
+Extract schemas from a kubeconfig context:
 
 ```bash
-# Extract from the current kubeconfig context
 crd-schema-publisher extract -o ./schemas
+```
 
-# Extract from a specific context
-crd-schema-publisher extract --context my-cluster -o ./schemas
+Convert CRD YAML without a cluster:
 
-# Convert CRD YAML without a cluster
+```bash
 crd-schema-publisher convert -f crd.yaml -o ./schemas
+```
 
-# Convert Kubernetes built-in resources from the current cluster
+Render Kubernetes built-ins from OpenAPI:
+
+```bash
 kubectl get --raw /openapi/v2 > swagger.json
 crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 ```
 
-For source builds, use `go run ./cmd/` in place of `crd-schema-publisher`. See [Standalone Binary](#standalone-binary) for installer options and manual downloads, and [Configuration and CLI Reference](#configuration-and-cli-reference) for flags and command behavior.
+## Use Published Schemas
 
-### Use Published Schemas
-
-Once published, schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`, for example `cert-manager.io/certificate_v1.json` or `core/pod_v1.json`.
+Published schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`, for example `cert-manager.io/certificate_v1.json` or `core/pod_v1.json`.
 
 ```yaml
 # yaml-language-server: $schema=https://kube-schemas.example.com/cert-manager.io/certificate_v1.json
@@ -102,614 +85,18 @@ metadata:
   name: example
 ```
 
-See [Using Your Schemas](#-using-your-schemas) for IDE and kubeconform examples.
-
-## 📦 Installation
-
-### Standalone Binary
-
-The quick installer is the recommended path for local CLI use. Static binaries for Linux and macOS (amd64 + arm64) are also attached to each [GitHub Release](https://github.com/sholdee/crd-schema-publisher/releases).
-
-Quick install/update:
-
-```bash
-curl -fsSL https://crdsp.shold.io | bash
-```
-
-Non-interactive install:
-
-```bash
-curl -fsSL https://crdsp.shold.io | bash -s -- --yes
-```
-
-Install a specific release:
-
-```bash
-curl -fsSL https://crdsp.shold.io | bash -s -- --version vYYYY.MDD.HMMSS
-```
-
-The installer detects Linux/macOS and amd64/arm64, verifies the selected binary against the release checksum manifest, optionally verifies the checksum Sigstore bundle when `cosign` is available, and installs to an existing `crd-schema-publisher` path or `/usr/local/bin/crd-schema-publisher`.
-
-```bash
-# Download the latest release (example: Linux amd64)
-curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/crd-schema-publisher-linux-amd64
-chmod +x crd-schema-publisher-linux-amd64
-```
-
-If you manage project CLIs with [mise](https://mise.jdx.dev/), install through the aqua backend:
-
-```bash
-mise use aqua:sholdee/crd-schema-publisher@latest
-```
-
-Or pin a release in `mise.toml`:
-
-```toml
-[tools]
-"aqua:sholdee/crd-schema-publisher" = "2026.519.317"
-```
-
-### Verify Release Artifacts
-
-```bash
-# Verify the signed checksum manifest
-curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/checksums-sha256.txt
-curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/checksums-sha256.txt.sigstore.json
-cosign verify-blob checksums-sha256.txt \
-  --bundle checksums-sha256.txt.sigstore.json \
-  --certificate-identity 'https://github.com/sholdee/crd-schema-publisher/.github/workflows/release.yaml@refs/heads/main' \
-  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
-
-# Verify the binary against the trusted checksum manifest
-sha256sum -c --ignore-missing checksums-sha256.txt
-
-# Optional: verify build provenance for the binary
-gh attestation verify ./crd-schema-publisher-linux-amd64 \
-  --repo sholdee/crd-schema-publisher \
-  --signer-workflow sholdee/crd-schema-publisher/.github/workflows/release.yaml \
-  --source-ref refs/heads/main
-```
-
-## 🚀 Deploying
-
-### Helm Chart (recommended)
-
-The chart is distributed as an OCI artifact and signed with cosign:
-
-```bash
-helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --create-namespace \
-  --set existingSecret.name=crd-schema-publisher-cloudflare
-```
-
-This installs in **controller mode** by default (real-time watch with leader election). For scheduled runs, set `--set mode=cronjob`.
-
-#### Credentials
-
-Cloudflare credentials are **optional in both controller and CronJob modes**. Without them, the workload runs in extract-only mode — site generations are written under the output directory and the active snapshot is exposed at `OUTPUT_DIR/current`, but nothing is uploaded. This is useful when serving schemas locally (e.g., via a sidecar web server) instead of Cloudflare Pages.
-
-To publish to Cloudflare Pages, provide an API token with **Cloudflare Pages: Edit** permission and your account ID. Two secret management options are supported:
-
-- **`existingSecret`** — reference a pre-existing Secret containing `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
-- **`externalSecret`** — create an [ExternalSecret](https://external-secrets.io) CR that syncs credentials from an external provider (Vault, AWS Secrets Manager, 1Password, etc.)
-
-```bash
-# Using External Secrets Operator
-helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --create-namespace \
-  --set externalSecret.enabled=true \
-  --set externalSecret.secretStoreRef.name=my-store \
-  --set externalSecret.secretStoreRef.kind=ClusterSecretStore
-```
-
-The default remote ref points to a `crd-schema-publisher-cloudflare` key with `api-token` and `account-id` properties — override via `externalSecret.data` if your provider uses different paths.
-
-#### Schema filtering
-
-To publish only part of the cluster CRD catalog, set `config.filter.group`, `config.filter.kind`, and/or `config.filter.version`. Values are comma-separated and case-insensitive.
-
-```bash
-helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --create-namespace \
-  --set config.filter.group=cert-manager.io \
-  --set-string 'config.filter.kind=Certificate\,Issuer'
-```
-
-Controller mode still watches all CRDs, then applies the filter to each generated output snapshot. If active filters match no CRDs or built-ins and Kustomize is not enabled, the next runtime build publishes an empty catalog instead of preserving a previous broader snapshot.
-
-#### Runtime built-ins and Kustomize
-
-Runtime modes publish CRDs only by default. Enable built-ins and Kustomize explicitly when you want one site for CRDs, Kubernetes built-in types, and kustomize's client-side `Kustomization` and `Component` schemas.
-
-```bash
-helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --set config.includeBuiltins=true \
-  --set config.includeKustomize=true
-```
-
-`config.includeBuiltins=true` reads `/openapi/v2` from the API server. With chart RBAC enabled, it also adds the required ClusterRole permission; with `rbac.create=false`, provide that permission yourself. `config.includeKustomize=true` does not require extra Kubernetes permissions. Filters apply to CRDs and built-ins; Kustomize is an explicit unfiltered opt-in.
-
-#### Optional features
-
-Persistent output volume (`persistence`), built-in static serving (`serve`), Gateway API HTTPRoute (`serve.httpRoute`), extra volumes/volume mounts/containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard (sidecar ConfigMap or Grafana Operator `GrafanaDashboard`), NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects. See [`values.yaml`](charts/crd-schema-publisher/values.yaml) for all options.
-
-#### Built-in static serving
-
-For simple in-cluster deployments, the controller can serve the active generated site directly from `OUTPUT_DIR/current`:
-
-```bash
-helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --set serve.enabled=true
-```
-
-The site is exposed on the chart Service port named `site` and defaults to non-privileged port `8081`; health and metrics stay on the `health` port. Built-in serving is controller-only, requires `replicaCount=1`, and switches the Deployment strategy to `Recreate` so traffic is not routed to a new pod before it has published its first site.
-
-Use [`examples/built-in-server/values.yaml`](examples/built-in-server/values.yaml) for a complete values file with persistence and Gateway API `HTTPRoute` setup.
-
-#### Examples: Alternative backends via sidecar pattern
-
-The chart's `extraContainers` and `extraObjects` values let you wire up any backend without changes to the tool. Each example runs in extract-only mode (no Cloudflare credentials) — schemas are written to generation snapshots under the output directory and the active site is exposed at `OUTPUT_DIR/current` for the sidecar to serve or sync. Examples that push to external storage run stateless with an emptyDir; the caddy example uses a persistent volume since it serves directly from the cluster.
-
-```bash
-helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher --create-namespace \
-  -f examples/<example>/values.yaml
-```
-
-| Example                                               | Backend               | Description                                                                                                                                                                                  |
-| ----------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`caddy-sidecar`](examples/caddy-sidecar/values.yaml) | Local HTTP            | Caddy serves schemas directly from the cluster with directory browsing and a Gateway API HTTPRoute. Adaptable to nginx or any web server.                                                    |
-| [`rclone-s3`](examples/rclone-s3/values.yaml)         | S3-compatible storage | rclone syncs schemas to any S3-compatible provider (AWS S3, Backblaze B2, MinIO, Cloudflare R2, GCS) on a 60-second interval. Provider-specific configuration documented in the file header. |
-| [`git-push`](examples/git-push/values.yaml)           | Git repository        | Commits and pushes schema changes to a GitHub repository for GitHub Pages hosting. Works with any git host (GitLab, Gitea, Bitbucket) by adjusting the remote URL.                           |
-
-Each example is a self-contained values file — copy it, fill in your credentials, and install. See the comments in each file for what to customize.
-
-#### GitHub Pages subpath deployments
-
-When serving schemas from a GitHub Pages project path such as `https://user.github.io/iac/`, set the base path so generated HTML links include the subpath:
-
-```bash
-BASE_PATH=/iac
-```
-
-Or in the Helm chart:
-
-```yaml
-config:
-  basePath: "/iac"
-```
-
-If you already use the first-party `git-push` or `rclone-s3` examples, update them to read `/data/current`. Older example configs fail closed after upgrading to a new image: syncing stops, but existing remote content is not deleted or overwritten. Cloudflare Pages users do not need to change anything.
-
-#### Verification
-
-Verify the chart signature (substitute the version you installed — find it with `helm list`):
-
-```bash
-cosign verify ghcr.io/sholdee/charts/crd-schema-publisher:<VERSION> \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp github.com/sholdee/crd-schema-publisher
-```
-
-### Raw Manifests
-
-For users who prefer raw YAML without Helm, deploy manifests are available in [`deploy/`](deploy/).
-
-### Watch Mode (recommended)
-
-Reacts to CRD changes in real-time with debounced schema refreshes, uploading only when Cloudflare credentials are configured. Supports leader election for safe rolling updates. The container runs with `args: ["watch"]` — see [`deploy/deployment.yaml`](deploy/deployment.yaml).
-
-```bash
-kubectl apply -f deploy/common.yaml -f deploy/deployment.yaml
-```
-
-### CronJob Mode
-
-Runs scheduled schema extraction, uploading to Cloudflare Pages only when credentials are configured. Simpler, but schemas are only updated when the job runs. The example uses a daily schedule — adjust the `schedule` field as needed. Uses the default `run` command — see [`deploy/cronjob.yaml`](deploy/cronjob.yaml).
-
-Without Cloudflare credentials, CronJob mode is extract-only. With the default `emptyDir` output volume, extracted schemas are discarded when the Job pod exits. Configure Cloudflare credentials, `persistence.enabled`/`persistence.existingClaim`, or an extra container backend if you want scheduled output to be retained.
-
-```bash
-kubectl apply -f deploy/common.yaml -f deploy/cronjob.yaml
-```
-
-Both modes share [`deploy/common.yaml`](deploy/common.yaml) which provides namespace, ServiceAccount, RBAC (ClusterRole for CRD read access), and a hardened security context (nonroot, read-only rootfs, dropped capabilities).
-
-The deploy manifests include an empty placeholder Secret named `crd-schema-publisher-cloudflare`. Fill in the values in `common.yaml` directly, or replace the Secret with your own secrets management (e.g., ExternalSecret, Sealed Secret). If Cloudflare credentials are empty or omitted, workloads run in extract-only mode (site generations written under `OUTPUT_DIR/.generations` with the active snapshot exposed at `OUTPUT_DIR/current`, but not uploaded). In raw CronJob mode, the default `emptyDir` output is discarded when the Job pod exits unless you replace it with retained storage or a backend sync.
-
-### Container Image
-
-Pre-built multi-arch images (amd64 + arm64) are published to GHCR:
-
-```text
-ghcr.io/sholdee/crd-schema-publisher:latest
-```
-
-Releases are triggered manually via the release workflow, producing a date-based tag (`vYYYY.MDD.HMMSS` — e.g. `v2026.413.65435`) and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments. The workflow runs an internal smoke gate before release artifacts are promoted.
-
-Images use `gcr.io/distroless/static:nonroot` as the runtime base — no shell, no package manager, runs as UID 65534. Production images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing via GitHub Actions OIDC:
-
-```bash
-cosign verify ghcr.io/sholdee/crd-schema-publisher:latest \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp github.com/sholdee/crd-schema-publisher
-```
-
-## Configuration and CLI Reference
-
-### Environment Variables
-
-Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`/`-o`. Variables marked _(watch)_ apply only to watch mode deployment.
-
-| Variable                   | Required    | Default                | Description                                                                                                           |
-| -------------------------- | ----------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`     | Upload only | —                      | Cloudflare API token with Pages permissions                                                                           |
-| `CLOUDFLARE_ACCOUNT_ID`    | Upload only | —                      | Cloudflare account ID                                                                                                 |
-| `CF_PAGES_PROJECT`         | No          | `kubernetes-schemas`   | Cloudflare Pages project name                                                                                         |
-| `OUTPUT_DIR`               | No          | `/output`              | Site output root. The active snapshot is exposed at `OUTPUT_DIR/current`                                              |
-| `KUBECTL_CONTEXT`          | No          | —                      | Kubernetes context name (local development only)                                                                      |
-| `DEBOUNCE_SECONDS`         | No          | `15`                   | Seconds to wait after last CRD event before publishing (watch mode)                                                   |
-| `POD_NAME`                 | Yes (watch) | —                      | Pod identity for leader election (set via downward API)                                                               |
-| `POD_NAMESPACE`            | Yes (watch) | —                      | Namespace for leader lease (set via downward API)                                                                     |
-| `LEASE_NAME`               | No          | `crd-schema-publisher` | Name of the Lease resource (watch mode)                                                                               |
-| `HEALTH_PORT`              | No          | `8080`                 | Port for liveness/readiness probes (watch mode)                                                                       |
-| `SERVE_SITE`               | No          | —                      | Set to `true` to serve `OUTPUT_DIR/current` from watch mode                                                           |
-| `SITE_PORT`                | No          | `8081`                 | Non-privileged static site server port when `SERVE_SITE=true`                                                         |
-| `SERVE_ACCESS_LOG`         | No          | —                      | Set to `true` to log each request served by the built-in static site server                                           |
-| `PREVIEW_ADDR`             | No          | `127.0.0.1:8989`       | Listen address for preview server (preview mode)                                                                      |
-| `SKIP_RENDER`              | No          | —                      | Set to `true` to skip HTML schema page rendering                                                                      |
-| `UPLOAD_BUCKET_SIZE_BYTES` | No          | `41943040`             | Cloudflare upload bucket size in bytes. Lower values reduce peak upload memory at the cost of more requests           |
-| `UPLOAD_CONCURRENCY`       | No          | `3`                    | Concurrent Cloudflare upload buckets. Lower values reduce peak upload memory at the cost of slower cache-miss uploads |
-| `BASE_PATH`                | No          | —                      | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`)                      |
-| `SCHEMA_INCLUDE_BUILTINS`  | No          | —                      | Set to `true` to include Kubernetes built-ins from API server OpenAPI v2 (`run`, `extract`, `watch`)                  |
-| `SCHEMA_INCLUDE_KUSTOMIZE` | No          | —                      | Set to `true` to include kustomize's client-side config schemas (`run`, `extract`, `watch`)                           |
-| `SCHEMA_FILTER_KIND`       | No          | —                      | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`)    |
-| `SCHEMA_FILTER_GROUP`      | No          | —                      | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`)   |
-| `SCHEMA_FILTER_VERSION`    | No          | —                      | Restrict generated schemas to matching API versions, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
-
-Schema filters limit generated output only. In watch mode, the controller still watches all cluster CRDs and applies the filters during each publish cycle. If active filters match no CRDs or built-ins and Kustomize is not enabled, runtime builds publish an empty catalog instead of leaving stale schemas in place.
-
-Runtime modes stay CRD-only unless opt-ins are enabled. `--include-builtins` reads `/openapi/v2` from the API server and publishes built-ins into the same generation. `--include-kustomize` adds kustomize's client-side config schemas. Filters apply to CRDs and built-ins; Kustomize is explicit and unfiltered.
-
-### Command Behavior
-
-```text
-crd-schema-publisher [command]
-
-Commands:
-  run       Extract schemas and upload to Cloudflare Pages when credentials are configured (default)
-  extract   Extract schemas from a Kubernetes cluster
-  convert   Convert CRD YAML files and Kubernetes OpenAPI built-ins to JSON Schema
-  upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
-  watch     Watch for CRD changes and upload when credentials are configured
-  preview   Serve a local preview of the documentation site
-```
-
-| Command(s)               | Output directory behavior                                                                                    |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `extract`                | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; does not fall back to `/output`.                      |
-| `convert`                | Requires `--output-dir`/`-o`; does not read `OUTPUT_DIR`.                                                    |
-| `run`, `watch`, `upload` | Accept `--output-dir`/`-o`; output root must already exist.                                                  |
-| `preview`                | Uses sample data by default; reads real extracted output only when `--output-dir`/`-o` is passed explicitly. |
-
-| Command(s)                | Filters and command-specific flags                                                                                                                                                                   |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`.        |
-| `run`, `extract`, `watch` | Support `--include-builtins`/`SCHEMA_INCLUDE_BUILTINS` to include built-ins from the API server OpenAPI v2 document.                                                                                 |
-| `run`, `extract`, `watch` | Support `--include-kustomize`/`SCHEMA_INCLUDE_KUSTOMIZE` to include kustomize's client-side config schemas.                                                                                          |
-| `extract`                 | Supports `--context`, `--base-path`, and `--skip-render`.                                                                                                                                            |
-| `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters for CRD YAML and OpenAPI inputs.                                                                             |
-| `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
-| `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
-| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` and `Component` schemas, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                             |
-
-## 📋 Using Your Schemas
-
-Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`. Core built-ins use the `core` group path, such as `core/pod_v1.json`. The published site also includes a browsable index with search and interactive HTML documentation for each schema.
-
-### IDE Validation (yaml-language-server)
-
-Add a modeline to any YAML file. Works in VS Code, Neovim, Helix, and any editor with yaml-language-server:
-
-```yaml
-# yaml-language-server: $schema=https://kube-schemas.example.com/cert-manager.io/certificate_v1.json
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: example
-```
-
-Or configure schemas globally in VS Code:
-
-```jsonc
-// .vscode/settings.json
-{
-  "yaml.schemas": {
-    "https://kube-schemas.example.com/cert-manager.io/certificate_v1.json": ["**/certificates/*.yaml"],
-  },
-}
-```
-
-### CI Validation (kubeconform)
-
-If your registry includes built-ins from runtime `--include-builtins` or offline `convert --openapi`, point kubeconform at both the `core` path and the grouped path:
-
-```bash
-kubeconform \
-  -strict \
-  -ignore-missing-schemas \
-  -schema-location 'https://kube-schemas.example.com/core/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-  -schema-location 'https://kube-schemas.example.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-  manifests/*.yaml
-```
-
-This project validates its own Helm chart manifests against its published schema registry in CI — see the `helm-lint` job in [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) for a working example.
-
-This validates Kubernetes built-ins and CRDs against the same published schema snapshot. If you publish only CRDs, keep `-schema-location default` before your custom registry path so kubeconform still validates built-ins.
-
-> **Note:** Schema files are written as lowercase (e.g., `certificate_v1.json`) while `{{.ResourceKind}}` expands to the original case (e.g., `Certificate`). This works on Cloudflare Pages because it serves paths case-insensitively — the same convention used by [datreeio/CRDs-catalog](https://github.com/datreeio/CRDs-catalog). If serving schemas from a case-sensitive host, use lowercase kind names in your template paths.
-
-## Operations
-
-### Monitoring
-
-In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` (default 8080) in Prometheus text format.
-
-| Metric                                           | Type    | Description                                   |
-| ------------------------------------------------ | ------- | --------------------------------------------- |
-| `crdpublisher_publish_cycle_duration_seconds`    | gauge   | Duration of the most recent publish cycle     |
-| `crdpublisher_publish_cycle_total`               | counter | Publish cycles by result (`success`, `error`) |
-| `crdpublisher_crds_discovered`                   | gauge   | CRDs found in the most recent cycle           |
-| `crdpublisher_schemas_written`                   | gauge   | Schemas written in the most recent cycle      |
-| `crdpublisher_last_successful_publish_timestamp` | gauge   | Unix epoch of the last successful publish     |
-| `crdpublisher_watchdog_timestamp`                | gauge   | Unix epoch of the last debounce loop tick     |
-| `crdpublisher_publish_skipped_total`             | counter | Debounce skips (publish already in progress)  |
-| `crdpublisher_leader`                            | gauge   | Whether this pod is the current leader        |
-
-The watchdog timestamp enables dead man's switch alerting — it updates on every debounce loop tick (regardless of whether a publish occurs), so `time() - crdpublisher_watchdog_timestamp` staying fresh proves the watcher is alive. The publish timestamp separately tracks when content was last pushed.
-
-The Helm chart includes a PodMonitor — enable it with `--set metrics.podMonitor.enabled=true`. For raw manifests or vanilla Prometheus Operator, create a PodMonitor:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: crd-schema-publisher
-spec:
-  selector:
-    matchLabels:
-      app: crd-schema-publisher
-  podMetricsEndpoints:
-    - port: health
-      path: /metrics
-```
-
-For vanilla Prometheus, add `prometheus.io/*` annotations to the pod template or configure a static scrape target.
-
-#### Grafana dashboard
-
-The Helm chart can install the included Grafana dashboard in either sidecar-discovery mode or Grafana Operator mode.
-
-For Grafana sidecars that discover dashboard `ConfigMap` objects:
-
-```bash
-helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --set grafana.dashboard.enabled=true
-```
-
-For Grafana Operator:
-
-```bash
-helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
-  --namespace crd-schema-publisher \
-  --set grafana.dashboard.operator.enabled=true
-```
-
-Operator mode renders a `GrafanaDashboard` that references the embedded dashboard `ConfigMap`. It selects Grafana instances with `dashboards: grafana` by default. Custom `grafana.dashboard.operator.instanceSelector` values replace that fallback instead of being merged with it:
-
-```yaml
-grafana:
-  dashboard:
-    operator:
-      enabled: true
-      instanceSelector:
-        matchLabels:
-          grafana.internal/instance: home
-```
-
-To intentionally match all Grafana instances visible to the operator, set `grafana.dashboard.operator.defaultInstanceSelector.enabled=false`.
-
-Use `grafana.dashboard.operator.folder` for a Grafana folder title, `grafana.dashboard.operator.folderRef` for a `GrafanaFolder` resource reference, or `grafana.dashboard.operator.folderUID` for an existing Grafana folder UID. Set only one folder option.
-
-If your Grafana datasource name is not resolved automatically, map the bundled dashboard input with:
-
-```yaml
-grafana:
-  dashboard:
-    operator:
-      datasources:
-        - inputName: DS_PROMETHEUS
-          datasourceName: Prometheus
-```
-
-Grafana Operator and its CRDs must already be installed in the cluster.
-
-### Output Structure
-
-Cluster-backed site generation (`run`, `extract`, `watch`) and preview temp generations use this layout:
-
-```text
-<output-dir>/
-  .generations/
-    <generation>/
-      <apigroup>/
-        <kind>_<version>.json          # JSON schema
-        <kind>_<version>.html          # Interactive documentation page
-      _meta/
-        kinds.json                     # Internal Kind casing manifest
-        schema-metadata.json           # Internal index source manifest
-      master-standalone/
-        <apigroup>-<kind>-stable-<version>.json  # kubeval-compatible format
-      index.html                       # Browsable schema index
-      schema-search.js                 # Shared schema-page search/autocomplete module
-      favicon.svg                      # Constellation icon
-  current -> .generations/<generation> # Stable read path for sidecars and local servers
-```
-
-Direct-volume consumers should read or serve `OUTPUT_DIR/current`, not the flat root of `OUTPUT_DIR`. `_meta/` is internal tool state; first-party Cloudflare, git, S3, and Caddy examples exclude it from published or served output.
-
-`convert` writes schema files directly into `--output-dir` instead of creating `.generations/current`. It records generated files in `_meta/convert-manifest.json` so reruns can remove stale generated artifacts while preserving files that existed before `convert` ran.
-
-## ⚙️ How It Works
-
-For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
-
-1. Connects to the Kubernetes API (in-cluster or via kubeconfig)
-2. Lists all CRDs and extracts `.spec.versions[].schema.openAPIV3Schema`
-3. Applies three JSON Schema transforms:
-   - Adds `additionalProperties: false` to structural child objects with `properties` — recurses into schema-valued locations only, preserving validation overlays and literal `default`/`enum` data while fixing a bug in the original where CRD fields named `properties` or other JSON Schema keywords corrupt the output
-   - Replaces Kubernetes int-or-string markers with a non-conflicting `oneOf` union, preserving safe metadata and moving type-specific assertions into the matching string or integer branch
-   - Allows null for optional fields (per-field precision, including optional `$ref` fields as ref-or-null `anyOf` wrappers)
-
-   These transforms handle nullable fields, int-or-string types, root objects, and keyword-colliding property names. A frozen golden test locks converter output to prevent regressions.
-
-4. Writes schemas to both primary and kubeval-compatible directory formats inside a new generation snapshot
-5. Renders an interactive HTML documentation page for each schema with collapsible property trees, local `$ref` expansion, path-aware search, and autocomplete powered by a shared emitted `schema-search.js` asset
-6. Generates an HTML index grouped by schema source and API group with client-side search, schema statistics, and yaml-language-server usage examples
-7. Atomically switches `OUTPUT_DIR/current` to the completed generation so sidecars read a stable snapshot
-8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
-
-The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
-
-Runtime modes can include optional schemas in generated snapshots. `--include-builtins` fetches `/openapi/v2` from the API server and writes authorable built-in types into the same generation as CRDs. When OpenAPI also contains CRD-backed definitions, CRD schemas take precedence and those OpenAPI duplicates are skipped. `--include-kustomize` writes kustomize's client-side config schemas. When more than one schema source is present, the index separates CRDs, built-ins, and Kustomize schemas; CRD-only output keeps the original API-group-only index. In the Helm chart, `config.includeBuiltins=true` adds `/openapi/v2` RBAC when `rbac.create=true`; `config.includeKustomize=true` does not require additional Kubernetes permissions.
-
-`--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (for example `kubectl get --raw /openapi/v2`). Each authorable type that declares a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`; the empty API group is written under `core/`. Referenced definitions are bundled into each schema so validation and rendered child fields work without external references. When combined with CRD inputs, matching OpenAPI CRD definitions and their List types are skipped.
-
-```sh
-kubectl get --raw /openapi/v2 > swagger.json
-crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
-```
-
-Combine `--openapi` with `--file` or `--dir` when you want one local site containing both built-ins and CRDs.
-
-`--kustomize` publishes schemas for kustomize's `Kustomization` and `Component` at `kustomize.config.k8s.io/kustomization_v1beta1.json` and `kustomize.config.k8s.io/component_v1alpha1.json`. These are client-side types with no usable upstream schemas, so they are reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module. Bumping that dependency updates the schemas. Combine them with the other inputs in a single run:
-
-`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs; `--kustomize` is a single explicit opt-in and always emits the Kustomize config schemas when set.
-
-```sh
-crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render
-```
-
-## 🔧 Development
-
-### Run Locally
-
-Use the package path (`go run ./cmd/ <command>`) for local subcommands so Go compiles every file in `cmd/`. Single-file invocation (`go run ./cmd/main.go --help` or `--version`) is only kept for top-level smoke checks.
-
-```bash
-# Extract schemas from a local cluster (no upload)
-KUBECTL_CONTEXT=my-cluster OUTPUT_DIR=./output go run ./cmd/ extract
-# Writes the active snapshot under ./output/current
-
-# Full run with upload
-mkdir -p ./output
-KUBECTL_CONTEXT=my-cluster \
-  CLOUDFLARE_API_TOKEN=xxx \
-  CLOUDFLARE_ACCOUNT_ID=xxx \
-  go run ./cmd/ --output-dir ./output
-
-# Convert CRD YAML files to JSON Schema (no cluster needed)
-go run ./cmd/ convert -f crd.yaml -o ./schemas
-
-# Convert Kubernetes built-ins from a cluster OpenAPI document
-kubectl get --raw /openapi/v2 > swagger.json
-go run ./cmd/ convert --openapi swagger.json -o ./schemas --render
-
-# Convert all CRDs in a directory
-go run ./cmd/ convert -d ./crds/ -o ./schemas
-
-# Pipe from kubectl
-kubectl get crds -o yaml | go run ./cmd/ convert -f - -o ./schemas
-
-# Filter by kind and group
-go run ./cmd/ extract --output-dir ./schemas --kind certificate,issuer --group cert-manager.io
-
-# Filter a runtime extraction through env vars
-SCHEMA_FILTER_GROUP=cert-manager.io go run ./cmd/ --output-dir ./output
-```
-
-### Preview the Site Locally
-
-Preview is useful for UI development and local inspection. It needs no cluster or credentials when using sample data.
-
-```bash
-# Preview the index UI (no cluster or credentials needed)
-go run ./cmd/ preview
-# open http://127.0.0.1:8989
-
-# Preview with real extracted schemas
-go run ./cmd/ preview --output-dir ./output
-# Serves the active snapshot from ./output/current
-
-# Preview a subpath deployment locally
-BASE_PATH=/iac go run ./cmd/ preview
-# open http://127.0.0.1:8989/iac/
-```
-
-### Build
-
-```bash
-# Native build
-go build -o crd-schema-publisher ./cmd/
-
-# Example static cross-compile
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o crd-schema-publisher ./cmd/
-
-# Build all release binaries locally
-for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-  GOOS="${pair%/*}" GOARCH="${pair#*/}"
-  CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
-    go build -ldflags="-s -w" -o "crd-schema-publisher-${GOOS}-${GOARCH}" ./cmd/
-done
-
-# Docker (multi-arch)
-docker buildx build --platform linux/amd64,linux/arm64 -t crd-schema-publisher .
-```
-
-### Linting
-
-This project uses [golangci-lint](https://golangci-lint.run/) with strict linters enabled:
-
-```bash
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-golangci-lint run
-```
-
-Enable the pre-commit hook to enforce linting before each commit:
-
-```bash
-git config core.hooksPath .githooks
-```
-
-If you change the extracted schema search module or its tests, also run:
-
-```bash
-node --test theme/schema_search.test.js
-```
-
-### Renovate
-
-Dependencies are managed by [Renovate](https://docs.renovatebot.com/). Minor and patch updates for Go modules, GitHub Actions, Docker images, and CI tools are automerged after required status checks pass.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for full contributor setup and guidelines.
-
-## 👥 Community
+## Documentation
+
+- [Getting Started](https://sholdee.github.io/crd-schema-publisher/getting-started/)
+- [Installation](https://sholdee.github.io/crd-schema-publisher/installation/)
+- [Deploying with Helm](https://sholdee.github.io/crd-schema-publisher/deploying/helm/)
+- [Publishing Backends](https://sholdee.github.io/crd-schema-publisher/publishing-backends/)
+- [Using Schemas](https://sholdee.github.io/crd-schema-publisher/using-schemas/)
+- [Configuration Reference](https://sholdee.github.io/crd-schema-publisher/reference/configuration/)
+- [Operations](https://sholdee.github.io/crd-schema-publisher/operations/monitoring/)
+- [How It Works](https://sholdee.github.io/crd-schema-publisher/concepts/how-it-works/)
+
+## Community
 
 - [Home Operations Discord](https://discord.gg/home-operations)
 - [Contributing](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Extracts CRD schemas from Kubernetes or YAML, converts Kubernetes built-in resou
 
 ## Why
 
-Static CRD catalogs go stale, miss internal CRDs, and depend on external infrastructure. `crd-schema-publisher` publishes schemas from your cluster and can serve or sync them wherever you host static files.
+Static CRD catalogs go stale, miss internal CRDs, and depend on external infrastructure. `crd-schema-publisher` publishes schemas from your own cluster and can serve or sync them wherever you host static files.
 
 - Always accurate for installed CRDs, internal CRDs, and optional Kubernetes built-ins.
 - Self-hosted output for Cloudflare Pages, local serving, S3-compatible storage, git, or any static web server.
@@ -54,6 +54,12 @@ Install the standalone CLI:
 curl -fsSL https://crdsp.shold.io | bash
 ```
 
+Or install with mise through the aqua backend:
+
+```bash
+mise use aqua:sholdee/crd-schema-publisher@latest
+```
+
 Extract schemas from a kubeconfig context:
 
 ```bash
@@ -66,11 +72,10 @@ Convert CRD YAML without a cluster:
 crd-schema-publisher convert -f crd.yaml -o ./schemas
 ```
 
-Render Kubernetes built-ins from OpenAPI:
+Extract CRDs and Kubernetes built-ins directly from a cluster:
 
 ```bash
-kubectl get --raw /openapi/v2 > swagger.json
-crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
+crd-schema-publisher extract -o ./schemas --include-builtins
 ```
 
 ## Use Published Schemas

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -1,0 +1,593 @@
+:root {
+  --bg: #09090b;
+  --bg-surface: rgba(24, 24, 27, 0.68);
+  --bg-hover: rgba(24, 24, 27, 0.86);
+  --surface-background: linear-gradient(var(--bg-surface), var(--bg-surface)), var(--bg);
+  --surface-hover-background: linear-gradient(var(--bg-hover), var(--bg-hover)), var(--bg);
+  --fg: #fafafa;
+  --fg-muted: #b0b3bc;
+  --accent: #6bc1fe;
+  --accent-dim: rgba(107, 193, 254, 0.15);
+  --border: rgba(255, 255, 255, 0.1);
+  --border-active: #6bc1fe;
+  --code-bg: #050507;
+  --required-bg: rgba(251, 191, 36, 0.25);
+  --required-fg: #f59e0b;
+  --shadow: rgba(0, 0, 0, 0.35);
+  --content-width: 920px;
+  --sidebar-width: 245px;
+  --toc-width: 210px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--bg);
+  color: var(--fg);
+  scroll-padding-top: 5rem;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.55;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    radial-gradient(1.5px 1.5px at 31px 47px, rgba(255,255,255,1), transparent),
+    radial-gradient(1px 1px at 212px 23px, rgba(255,255,255,0.7), transparent),
+    radial-gradient(1.5px 1.5px at 68px 289px, rgba(255,255,255,0.84), transparent),
+    radial-gradient(1px 1px at 313px 151px, rgba(255,255,255,0.56), transparent),
+    radial-gradient(1px 1px at 157px 371px, rgba(255,255,255,0.6), transparent),
+    radial-gradient(2px 2px at 19px 83px, rgba(255,255,255,0.96), transparent),
+    radial-gradient(1px 1px at 301px 41px, rgba(255,255,255,0.6), transparent),
+    radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent);
+  background-size: 397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px, 509px 509px, 509px 509px, 509px 509px;
+  mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.visually-hidden,
+.skip-link {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link:focus {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 100;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 0.75rem;
+  clip: auto;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #09090b;
+  font-weight: 700;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  border-bottom: 1px solid var(--border);
+  background: rgba(9, 9, 11, 0.92);
+  backdrop-filter: blur(18px);
+}
+
+.header-nav {
+  display: grid;
+  grid-template-columns: minmax(210px, auto) minmax(0, 1fr) minmax(220px, 340px);
+  gap: 1rem;
+  align-items: center;
+  width: min(100%, 1380px);
+  margin: 0 auto;
+  padding: 0.8rem 1.25rem;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 0.6rem;
+  color: var(--fg);
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.brand-link img {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.brand-link span {
+  overflow-wrap: anywhere;
+}
+
+.header-links {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.header-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 6px;
+  color: var(--fg-muted);
+  padding: 0.35rem 0.5rem;
+  text-decoration: none;
+}
+
+.header-links a:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.github-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.site-search {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.site-search input {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-background);
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.92rem;
+  padding: 0.45rem 0.65rem;
+}
+
+.site-search input::placeholder {
+  color: var(--fg-muted);
+}
+
+.search-panel {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: 0;
+  z-index: 30;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #101014;
+  box-shadow: 0 16px 42px var(--shadow);
+}
+
+.search-panel ul {
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+}
+
+.search-panel li + li {
+  margin-top: 0.15rem;
+}
+
+.search-panel a {
+  display: block;
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 0.55rem 0.65rem;
+  text-decoration: none;
+}
+
+.search-panel li[aria-selected="true"] a,
+.search-panel a:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.search-panel .search-status span {
+  color: var(--fg-muted);
+  font-weight: 700;
+  padding: 0.55rem 0.65rem;
+}
+
+.search-panel span {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.search-panel small {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.search-match {
+  border-radius: 3px;
+  background: rgba(251, 191, 36, 0.25);
+  color: var(--required-fg);
+  padding: 0 0.08em;
+}
+
+.site-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) minmax(0, var(--content-width)) var(--toc-width);
+  gap: 2rem;
+  width: min(100%, 1380px);
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.site-shell.no-toc {
+  grid-template-columns: var(--sidebar-width) minmax(0, var(--content-width));
+}
+
+.site-sidebar,
+.site-toc {
+  position: sticky;
+  top: 5rem;
+  align-self: start;
+  max-height: calc(100vh - 6rem);
+  overflow: auto;
+}
+
+.docs-nav,
+.site-toc {
+  font-size: 0.875rem;
+}
+
+.nav-heading,
+.toc-heading,
+.nav-section-heading {
+  margin: 0 0 0.5rem;
+  color: var(--fg-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-section {
+  margin-bottom: 1.2rem;
+}
+
+.docs-nav ul,
+.site-toc ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.docs-nav li + li,
+.site-toc li + li {
+  margin-top: 0.2rem;
+}
+
+.docs-nav a,
+.site-toc a {
+  display: block;
+  border-radius: 6px;
+  color: var(--fg-muted);
+  padding: 0.25rem 0.45rem;
+  text-decoration: none;
+}
+
+.docs-nav a:hover,
+.docs-nav a.is-active,
+.site-toc a:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.site-main {
+  min-width: 0;
+}
+
+.doc-content {
+  min-width: 0;
+}
+
+.doc-header {
+  margin-bottom: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.doc-content h1 {
+  margin: 0;
+  color: var(--fg);
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.doc-content h2,
+.doc-content h3,
+.doc-content h4 {
+  margin: 2rem 0 0.75rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.doc-content h2 {
+  padding-top: 0.3rem;
+  border-top: 1px solid var(--border);
+  font-size: 1.45rem;
+}
+
+.doc-content h3 {
+  font-size: 1.15rem;
+}
+
+.lead {
+  max-width: 720px;
+  margin: 0.9rem 0 0;
+  color: var(--fg-muted);
+  font-size: 1.05rem;
+}
+
+.doc-content p,
+.doc-content ul,
+.doc-content ol,
+.doc-content table,
+.doc-content pre,
+.doc-content blockquote {
+  margin: 1rem 0;
+}
+
+.doc-content ul,
+.doc-content ol {
+  padding-left: 1.25rem;
+}
+
+.doc-content li + li {
+  margin-top: 0.3rem;
+}
+
+.doc-content code {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--code-bg);
+  color: var(--fg);
+  padding: 0.08rem 0.28rem;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 0.88em;
+}
+
+.doc-content pre {
+  position: relative;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--code-bg);
+  padding: 1rem;
+}
+
+.doc-content pre code {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font-size: 0.86rem;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #101014;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.45rem;
+}
+
+.copy-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.heading-permalink {
+  opacity: 0;
+  font-size: 0.85em;
+}
+
+h2:hover .heading-permalink,
+h3:hover .heading-permalink,
+.heading-permalink:focus {
+  opacity: 1;
+}
+
+.doc-content table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.doc-content th,
+.doc-content td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-content th {
+  color: var(--fg);
+  font-size: 0.86rem;
+}
+
+.doc-content td {
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+.page-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.page-list-item {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-background);
+  padding: 0.85rem 1rem;
+  text-decoration: none;
+}
+
+.page-list-item:hover {
+  border-color: var(--accent);
+  background: var(--surface-hover-background);
+}
+
+.page-list-item span {
+  display: block;
+  color: var(--fg);
+  font-weight: 750;
+}
+
+.page-list-item small {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--fg-muted);
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.home-grid a {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-background);
+  color: var(--fg);
+  padding: 0.9rem 1rem;
+  text-decoration: none;
+}
+
+.home-grid a:hover {
+  border-color: var(--accent);
+}
+
+.site-footer {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  padding: 1.5rem;
+}
+
+@media (max-width: 1120px) {
+  .header-nav {
+    grid-template-columns: minmax(210px, auto) minmax(220px, 1fr);
+  }
+
+  .header-links {
+    display: none;
+  }
+
+  .site-shell,
+  .site-shell.no-toc {
+    grid-template-columns: minmax(0, 1fr);
+    max-width: var(--content-width);
+  }
+
+  .site-sidebar,
+  .site-toc {
+    position: static;
+    max-height: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .header-nav {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .brand-link span {
+    font-size: 0.95rem;
+  }
+
+  .site-shell {
+    padding: 1.25rem 1rem 2rem;
+  }
+
+  .home-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -354,6 +354,12 @@ a:hover {
   letter-spacing: 0;
 }
 
+.home-content h1 {
+  margin-bottom: 0.75rem;
+  font-size: 2.15rem;
+  line-height: 1.15;
+}
+
 .doc-content h2,
 .doc-content h3,
 .doc-content h4 {
@@ -395,6 +401,12 @@ a:hover {
 
 .doc-content li + li {
   margin-top: 0.3rem;
+}
+
+.doc-content img {
+  display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 .doc-content code {
@@ -476,6 +488,22 @@ h3:hover .heading-permalink,
 .doc-content td {
   color: var(--fg-muted);
   font-size: 0.9rem;
+}
+
+.media-frame {
+  box-sizing: border-box;
+  overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: 0;
+  background: var(--code-bg);
+  box-shadow: 0 18px 60px var(--shadow);
+  margin: 1.25rem 0;
+}
+
+.media-frame img {
+  width: 100%;
 }
 
 .page-list {

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -11,6 +11,17 @@
   --border: rgba(255, 255, 255, 0.1);
   --border-active: #6bc1fe;
   --code-bg: #050507;
+  --syntax-text: #d4d4d4;
+  --syntax-comment: #6a9955;
+  --syntax-keyword: #569cd6;
+  --syntax-constant: #4fc1ff;
+  --syntax-function: #dcdcaa;
+  --syntax-string: #ce9178;
+  --syntax-number: #b5cea8;
+  --syntax-type: #4ec9b0;
+  --syntax-variable: #9cdcfe;
+  --syntax-operator: #d4d4d4;
+  --syntax-escape: #d7ba7d;
   --required-bg: rgba(251, 191, 36, 0.25);
   --required-fg: #f59e0b;
   --shadow: rgba(0, 0, 0, 0.35);
@@ -30,9 +41,12 @@ html {
 }
 
 body {
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
   min-width: 320px;
   margin: 0;
-  background: var(--bg);
+  background: transparent;
   color: var(--fg);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   line-height: 1.55;
@@ -52,8 +66,17 @@ body::before {
     radial-gradient(1px 1px at 157px 371px, rgba(255,255,255,0.6), transparent),
     radial-gradient(2px 2px at 19px 83px, rgba(255,255,255,0.96), transparent),
     radial-gradient(1px 1px at 301px 41px, rgba(255,255,255,0.6), transparent),
-    radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent);
-  background-size: 397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px, 509px 509px, 509px 509px, 509px 509px;
+    radial-gradient(1.5px 1.5px at 127px 409px, rgba(255,255,255,0.8), transparent),
+    radial-gradient(1px 1px at 443px 237px, rgba(255,255,255,0.5), transparent),
+    radial-gradient(1.5px 1.5px at 67px 491px, rgba(255,255,255,0.72), transparent),
+    radial-gradient(1px 1px at 11px 37px, rgba(255,255,255,0.72), transparent),
+    radial-gradient(1.5px 1.5px at 191px 213px, rgba(255,255,255,0.9), transparent),
+    radial-gradient(1px 1px at 53px 7px, rgba(255,255,255,0.5), transparent),
+    radial-gradient(1px 1px at 271px 103px, rgba(255,255,255,0.64), transparent);
+  background-size:
+    397px 397px, 397px 397px, 397px 397px, 397px 397px, 397px 397px,
+    509px 509px, 509px 509px, 509px 509px, 509px 509px, 509px 509px,
+    311px 311px, 311px 311px, 311px 311px, 311px 311px;
   mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
   -webkit-mask-image: linear-gradient(to bottom, black 0%, rgba(0,0,0,0.35) 45%, transparent 80%);
 }
@@ -111,7 +134,7 @@ a:hover {
 
 .header-nav {
   display: grid;
-  grid-template-columns: minmax(210px, auto) minmax(0, 1fr) minmax(220px, 340px);
+  grid-template-columns: minmax(210px, auto) minmax(0, 1fr) minmax(220px, 340px) auto;
   gap: 1rem;
   align-items: center;
   width: min(100%, 1380px);
@@ -162,9 +185,80 @@ a:hover {
   color: var(--accent);
 }
 
-.github-link svg {
-  width: 1rem;
-  height: 1rem;
+.github-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: 0.58rem;
+  row-gap: 0.12rem;
+  align-items: center;
+  justify-self: end;
+  min-width: 0;
+  max-width: 100%;
+  color: var(--fg);
+  line-height: 1;
+  padding: 0.08rem 0;
+  text-decoration: none;
+}
+
+.github-card:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.github-card:hover .github-card-repo {
+  color: var(--accent);
+}
+
+.github-card svg {
+  flex: 0 0 auto;
+  width: 0.84rem;
+  height: 0.84rem;
+  color: currentColor;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+}
+
+.github-card .github-card-mark {
+  grid-row: 1 / 3;
+  width: 1.55rem;
+  height: 1.55rem;
+  color: var(--fg);
+  stroke: none;
+}
+
+.github-card-repo {
+  grid-column: 2;
+  overflow: hidden;
+  max-width: 16rem;
+  color: var(--fg);
+  font-size: 0.9rem;
+  font-weight: 650;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-card-meta,
+.github-card-stat {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.github-card-meta {
+  grid-column: 2;
+  gap: 0.52rem;
+  color: var(--fg-muted);
+  font-size: 0.82rem;
+  font-weight: 560;
+  line-height: 1;
+}
+
+.github-card-stat {
+  gap: 0.22rem;
 }
 
 .site-search {
@@ -282,13 +376,21 @@ a:hover {
   font-size: 0.875rem;
 }
 
-.nav-heading,
 .toc-heading,
 .nav-section-heading {
   margin: 0 0 0.5rem;
   color: var(--fg-muted);
   font-size: 0.75rem;
   font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-heading {
+  margin: 0 0 0.65rem;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 850;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -349,7 +451,7 @@ a:hover {
 .doc-content h1 {
   margin: 0;
   color: var(--fg);
-  font-size: clamp(2rem, 4vw, 3.2rem);
+  font-size: clamp(1.75rem, 3vw, 2.55rem);
   line-height: 1.05;
   letter-spacing: 0;
 }
@@ -431,8 +533,89 @@ a:hover {
 .doc-content pre code {
   border: 0;
   background: transparent;
+  color: var(--syntax-text);
   padding: 0;
   font-size: 0.86rem;
+}
+
+.chroma .c,
+.chroma .c1,
+.chroma .ch,
+.chroma .cm,
+.chroma .cp,
+.chroma .cpf,
+.chroma .cs {
+  color: var(--syntax-comment);
+  font-style: italic;
+}
+
+.chroma .k,
+.chroma .kd,
+.chroma .kn,
+.chroma .kp,
+.chroma .kr {
+  color: var(--syntax-keyword);
+}
+
+.chroma .kc,
+.chroma .nb {
+  color: var(--syntax-constant);
+}
+
+.chroma .kt,
+.chroma .nc,
+.chroma .ne {
+  color: var(--syntax-type);
+}
+
+.chroma .nf,
+.chroma .fm,
+.chroma .shell-command {
+  color: var(--syntax-function);
+  font-weight: 650;
+}
+
+.chroma .s,
+.chroma .s1,
+.chroma .s2,
+.chroma .sb,
+.chroma .sc,
+.chroma .sd,
+.chroma .sh,
+.chroma .sx,
+.chroma .dl {
+  color: var(--syntax-string);
+}
+
+.chroma .se,
+.chroma .si {
+  color: var(--syntax-escape);
+}
+
+.chroma .m,
+.chroma .mb,
+.chroma .mf,
+.chroma .mh,
+.chroma .mi,
+.chroma .il,
+.chroma .mo {
+  color: var(--syntax-number);
+}
+
+.chroma .na,
+.chroma .nt,
+.chroma .nv,
+.chroma .vc,
+.chroma .vg,
+.chroma .vi,
+.chroma .vm {
+  color: var(--syntax-variable);
+}
+
+.chroma .o,
+.chroma .ow,
+.chroma .p {
+  color: var(--syntax-operator);
 }
 
 .copy-button {
@@ -569,13 +752,19 @@ h3:hover .heading-permalink,
   padding: 1.5rem;
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1280px) {
   .header-nav {
-    grid-template-columns: minmax(210px, auto) minmax(220px, 1fr);
+    grid-template-columns: minmax(210px, auto) minmax(220px, 1fr) auto;
   }
 
   .header-links {
     display: none;
+  }
+}
+
+@media (max-width: 1120px) {
+  .header-nav {
+    grid-template-columns: minmax(210px, auto) minmax(220px, 1fr) auto;
   }
 
   .site-shell,
@@ -592,12 +781,46 @@ h3:hover .heading-permalink,
 }
 
 @media (max-width: 720px) {
+  html {
+    scroll-padding-top: 1rem;
+  }
+
+  .site-header {
+    position: static;
+  }
+
   .header-nav {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.7rem;
   }
 
   .brand-link span {
     font-size: 0.95rem;
+  }
+
+  .github-card {
+    display: inline-flex;
+    grid-column: 2;
+    grid-row: 1;
+    width: 2.35rem;
+    height: 2.35rem;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .github-card .github-card-mark {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .github-card-repo,
+  .github-card-meta {
+    display: none;
+  }
+
+  .site-search {
+    grid-column: 1 / -1;
+    grid-row: 2;
   }
 
   .site-shell {

--- a/docs-site/assets/js/site.js
+++ b/docs-site/assets/js/site.js
@@ -1,0 +1,356 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const searchForm = document.querySelector(".site-search");
+  if (searchForm) {
+    initSearch(searchForm);
+  }
+
+  const sidebar = document.querySelector(".site-sidebar");
+  if (sidebar) {
+    initSidebarPersistence(sidebar);
+  }
+
+  let copyButtonIndex = 0;
+  document.querySelectorAll(".doc-content pre").forEach((block) => {
+    copyButtonIndex += 1;
+    const copyButtonNumber = copyButtonIndex;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "copy-button";
+    button.textContent = "Copy";
+    button.setAttribute("aria-label", `Copy code block ${copyButtonNumber}`);
+    button.addEventListener("click", async () => {
+      const code = block.querySelector("code");
+      if (!code || !navigator.clipboard) {
+        return;
+      }
+      await navigator.clipboard.writeText(code.innerText);
+      button.textContent = "Copied";
+      button.setAttribute("aria-label", `Copied code block ${copyButtonNumber}`);
+      window.setTimeout(() => {
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", `Copy code block ${copyButtonNumber}`);
+      }, 1500);
+    });
+    block.append(button);
+  });
+
+  document.querySelectorAll(".doc-content h2[id], .doc-content h3[id]").forEach((heading) => {
+    const link = document.createElement("a");
+    link.className = "heading-permalink";
+    link.href = `#${heading.id}`;
+    link.setAttribute("aria-label", `Link to ${heading.textContent}`);
+    link.textContent = "#";
+    heading.append(" ", link);
+  });
+});
+
+function initSidebarPersistence(sidebar) {
+  const storageKey = "crdsp.sidebar.scrollTop";
+  const storedScrollTop = Number.parseInt(storageGet("sessionStorage", storageKey) || "", 10);
+  if (Number.isFinite(storedScrollTop) && storedScrollTop > 0) {
+    window.requestAnimationFrame(() => {
+      sidebar.scrollTop = storedScrollTop;
+    });
+  }
+  let scheduled = false;
+  sidebar.addEventListener("scroll", () => {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    window.requestAnimationFrame(() => {
+      scheduled = false;
+      storageSet("sessionStorage", storageKey, String(Math.round(sidebar.scrollTop)));
+    });
+  }, { passive: true });
+}
+
+function initSearch(form) {
+  const input = form.querySelector("input[type='search']");
+  const panel = form.querySelector(".search-panel");
+  const resultsList = form.querySelector("#site-search-results");
+  const indexUrl = form.dataset.searchIndex;
+  let pages = [];
+  let activeIndex = -1;
+
+  if (!input || !panel || !resultsList || !indexUrl) {
+    return;
+  }
+
+  const loadIndex = async () => {
+    if (pages.length > 0) {
+      return pages;
+    }
+    const response = await fetch(indexUrl, { credentials: "same-origin" });
+    if (!response.ok) {
+      throw new Error(`Search index unavailable: ${response.status}`);
+    }
+    pages = await response.json();
+    return pages;
+  };
+
+  const closeResults = () => {
+    panel.hidden = true;
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
+    activeIndex = -1;
+  };
+
+  const clearSearch = () => {
+    input.value = "";
+    resultsList.replaceChildren();
+    closeResults();
+  };
+
+  const clearOrBlurSearch = () => {
+    if (input.value) {
+      clearSearch();
+      return;
+    }
+    closeResults();
+    if (document.activeElement === input) {
+      input.blur();
+    }
+  };
+
+  const setActive = (nextIndex) => {
+    const items = Array.from(resultsList.querySelectorAll("[role='option']"));
+    if (items.length === 0) {
+      activeIndex = -1;
+      input.removeAttribute("aria-activedescendant");
+      return;
+    }
+    activeIndex = (nextIndex + items.length) % items.length;
+    items.forEach((item, index) => {
+      item.setAttribute("aria-selected", index === activeIndex ? "true" : "false");
+    });
+    input.setAttribute("aria-activedescendant", items[activeIndex].id);
+  };
+
+  const renderResults = (matches, terms) => {
+    resultsList.replaceChildren();
+    if (matches.length === 0) {
+      renderStatusResult("No results");
+      return;
+    }
+    matches.forEach((match, index) => {
+      const page = match.page;
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      const title = document.createElement("span");
+      const snippet = document.createElement("small");
+      item.id = `site-search-result-${index}`;
+      item.setAttribute("role", "option");
+      item.setAttribute("aria-selected", "false");
+      link.href = page.url;
+      appendHighlightedText(title, page.title || "", terms);
+      appendHighlightedText(snippet, match.snippet || page.summary || page.section || "", terms);
+      link.append(title, snippet);
+      item.append(link);
+      resultsList.append(item);
+    });
+    panel.hidden = false;
+    input.setAttribute("aria-expanded", "true");
+    input.removeAttribute("aria-activedescendant");
+    activeIndex = -1;
+  };
+
+  const renderStatusResult = (message) => {
+    resultsList.replaceChildren();
+    const item = document.createElement("li");
+    const status = document.createElement("span");
+    item.className = "search-status";
+    item.setAttribute("role", "option");
+    item.setAttribute("aria-selected", "false");
+    status.textContent = message;
+    item.append(status);
+    resultsList.append(item);
+    panel.hidden = false;
+    input.setAttribute("aria-expanded", "true");
+    input.removeAttribute("aria-activedescendant");
+    activeIndex = -1;
+  };
+
+  const runSearch = async () => {
+    const query = input.value.trim().toLowerCase();
+    if (query.length < 2) {
+      closeResults();
+      resultsList.replaceChildren();
+      return;
+    }
+    try {
+      const terms = query.split(/\s+/).filter(Boolean);
+      const loadedPages = await loadIndex();
+      const matches = loadedPages
+        .map((page) => {
+          const title = (page.title || "").toLowerCase();
+          const haystack = `${title} ${page.section || ""} ${page.summary || ""} ${page.content || ""}`.toLowerCase();
+          if (!terms.every((term) => haystack.includes(term))) {
+            return null;
+          }
+          const score = terms.reduce((total, term) => total + (title.includes(term) ? 3 : 1), 0);
+          return { page, score, snippet: searchSnippet(page, terms) };
+        })
+        .filter(Boolean)
+        .sort((left, right) => right.score - left.score || left.page.title.localeCompare(right.page.title))
+        .slice(0, 8);
+      renderResults(matches, terms);
+    } catch {
+      renderStatusResult("Search unavailable");
+    }
+  };
+
+  document.addEventListener("keydown", (event) => {
+    if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+    if (event.key === "/" && !isEditable(event.target)) {
+      event.preventDefault();
+      input.focus();
+      input.select();
+      runSearch();
+      return;
+    }
+    if (event.key === "Escape" && (document.activeElement === input || input.value || !panel.hidden)) {
+      event.preventDefault();
+      clearOrBlurSearch();
+    }
+  });
+
+  input.addEventListener("input", runSearch);
+  input.addEventListener("focus", runSearch);
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const items = Array.from(resultsList.querySelectorAll("[role='option'] a"));
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].click();
+      return;
+    }
+    if (items[0]) {
+      items[0].click();
+    }
+  });
+  input.addEventListener("keydown", (event) => {
+    const items = Array.from(resultsList.querySelectorAll("[role='option'] a"));
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      clearOrBlurSearch();
+      return;
+    }
+    if (event.key === "ArrowDown" && items.length > 0) {
+      event.preventDefault();
+      setActive(activeIndex + 1);
+      return;
+    }
+    if (event.key === "ArrowUp" && items.length > 0) {
+      event.preventDefault();
+      setActive(activeIndex - 1);
+      return;
+    }
+    if (event.key === "Enter" && activeIndex >= 0 && items[activeIndex]) {
+      event.preventDefault();
+      items[activeIndex].click();
+    }
+  });
+  document.addEventListener("click", (event) => {
+    if (!form.contains(event.target)) {
+      closeResults();
+    }
+  });
+}
+
+function appendHighlightedText(parent, value, terms) {
+  const text = String(value);
+  const pattern = highlightPattern(terms);
+  if (!pattern) {
+    parent.textContent = text;
+    return;
+  }
+  let offset = 0;
+  for (const match of text.matchAll(pattern)) {
+    if (match.index > offset) {
+      parent.append(document.createTextNode(text.slice(offset, match.index)));
+    }
+    const mark = document.createElement("mark");
+    mark.className = "search-match";
+    mark.textContent = match[0];
+    parent.append(mark);
+    offset = match.index + match[0].length;
+  }
+  if (offset < text.length) {
+    parent.append(document.createTextNode(text.slice(offset)));
+  }
+}
+
+function highlightPattern(terms) {
+  const uniqueTerms = Array.from(new Set(terms.filter(Boolean))).sort((left, right) => right.length - left.length);
+  if (uniqueTerms.length === 0) {
+    return null;
+  }
+  return new RegExp(uniqueTerms.map(escapeRegExp).join("|"), "gi");
+}
+
+function searchSnippet(page, terms) {
+  const source = normalizeSearchText(page.content || page.summary || page.section || "");
+  if (!source) {
+    return page.section || "";
+  }
+  const lowerSource = source.toLowerCase();
+  const firstIndex = terms.reduce((best, term) => {
+    const index = lowerSource.indexOf(term);
+    if (index < 0) {
+      return best;
+    }
+    return best < 0 ? index : Math.min(best, index);
+  }, -1);
+  if (firstIndex < 0) {
+    return truncateSnippet(source, 180);
+  }
+  const context = 84;
+  const start = Math.max(0, firstIndex - context);
+  const end = Math.min(source.length, firstIndex + context);
+  const prefix = start > 0 ? "... " : "";
+  const suffix = end < source.length ? " ..." : "";
+  return `${prefix}${source.slice(start, end).trim()}${suffix}`;
+}
+
+function normalizeSearchText(value) {
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function truncateSnippet(value, length) {
+  const text = normalizeSearchText(value);
+  if (text.length <= length) {
+    return text;
+  }
+  return `${text.slice(0, length).trim()} ...`;
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isEditable(target) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return target.isContentEditable || tagName === "input" || tagName === "textarea" || tagName === "select";
+}
+
+function storageGet(storageName, key) {
+  try {
+    return window[storageName].getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storageSet(storageName, key, value) {
+  try {
+    window[storageName].setItem(key, value);
+  } catch {
+    // Storage can be disabled by browser privacy settings. The site still works without it.
+  }
+}

--- a/docs-site/assets/js/site.js
+++ b/docs-site/assets/js/site.js
@@ -9,6 +9,9 @@ document.addEventListener("DOMContentLoaded", () => {
     initSidebarPersistence(sidebar);
   }
 
+  initGitHubCard();
+  initShellCommandHighlighting();
+
   let copyButtonIndex = 0;
   document.querySelectorAll(".doc-content pre").forEach((block) => {
     copyButtonIndex += 1;
@@ -43,6 +46,254 @@ document.addEventListener("DOMContentLoaded", () => {
     heading.append(" ", link);
   });
 });
+
+const GITHUB_CARD_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+function initGitHubCard() {
+  const card = document.querySelector(".github-card");
+  if (!card || !card.dataset.githubRepo || !card.dataset.githubRepositoryApi || !window.fetch) {
+    return;
+  }
+
+  const cacheKey = `crdsp.github-card.${card.dataset.githubRepo}`;
+  const cached = githubCardCachedData(cacheKey);
+  if (cached && Date.now() - cached.cachedAt < GITHUB_CARD_CACHE_TTL_MS) {
+    renderGitHubCard(card, cached);
+    return;
+  }
+
+  refreshGitHubCard(card, cacheKey);
+}
+
+async function refreshGitHubCard(card, cacheKey) {
+  try {
+    const repo = await fetchGitHubJSON(card.dataset.githubRepositoryApi);
+    let release = null;
+    if (card.dataset.githubReleaseApi) {
+      try {
+        release = await fetchGitHubJSON(card.dataset.githubReleaseApi);
+      } catch {
+        release = null;
+      }
+    }
+
+    const data = {
+      repo: repo.full_name || card.dataset.githubRepo,
+      stars: normalizeGitHubCount(repo.stargazers_count),
+      forks: normalizeGitHubCount(repo.forks_count),
+      version: normalizeGitHubVersion(release?.tag_name || githubFieldText(card, "version")),
+      cachedAt: Date.now(),
+    };
+    renderGitHubCard(card, data);
+    storageSet("localStorage", cacheKey, JSON.stringify(data));
+  } catch {
+    // The fallback card remains useful when GitHub is unavailable or rate-limited.
+  }
+}
+
+async function fetchGitHubJSON(url) {
+  const response = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API unavailable: ${response.status}`);
+  }
+  return response.json();
+}
+
+function githubCardCachedData(cacheKey) {
+  try {
+    const parsed = JSON.parse(storageGet("localStorage", cacheKey) || "null");
+    if (!parsed || typeof parsed !== "object" || !Number.isFinite(parsed.cachedAt)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function renderGitHubCard(card, data) {
+  const repo = data.repo || card.dataset.githubRepo || githubFieldText(card, "repo");
+  const version = normalizeGitHubVersion(data.version || githubFieldText(card, "version"));
+  const stars = formatGitHubCount(data.stars ?? githubFieldText(card, "stars"));
+  const forks = formatGitHubCount(data.forks ?? githubFieldText(card, "forks"));
+
+  setGitHubFieldText(card, "repo", repo);
+  setGitHubFieldText(card, "version", version);
+  setGitHubFieldText(card, "stars", stars);
+  setGitHubFieldText(card, "forks", forks);
+  card.setAttribute("aria-label", `${repo} on GitHub, latest release ${version}, ${stars} stars, ${forks} forks`);
+}
+
+function setGitHubFieldText(card, field, value) {
+  const target = card.querySelector(`[data-github-field='${field}']`);
+  if (target) {
+    target.textContent = value;
+  }
+}
+
+function githubFieldText(card, field) {
+  return card.querySelector(`[data-github-field='${field}']`)?.textContent.trim() || "";
+}
+
+function normalizeGitHubVersion(value) {
+  return String(value || "").trim().replace(/^v(?=\d)/i, "");
+}
+
+function normalizeGitHubCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+function formatGitHubCount(value) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number >= 0) {
+    return number.toLocaleString("en-US");
+  }
+  return String(value || "0");
+}
+
+function initShellCommandHighlighting() {
+  document.querySelectorAll(".doc-content code.language-bash, .doc-content code.language-sh").forEach((block) => {
+    const lines = block.querySelectorAll(".cl");
+    const targets = lines.length > 0 ? lines : [block];
+    targets.forEach((line) => {
+      wrapTextRanges(line, shellCommandRanges(line.textContent || ""), "shell-command");
+    });
+  });
+}
+
+function shellCommandRanges(text) {
+  const ranges = [];
+  let index = 0;
+  let expectingCommand = true;
+
+  while (index < text.length) {
+    index = skipShellWhitespace(text, index);
+    if (index >= text.length || text[index] === "#") {
+      break;
+    }
+
+    if (expectingCommand) {
+      if (text[index] === "$" && /\s/.test(text[index + 1] || "")) {
+        index += 1;
+        continue;
+      }
+
+      const assignmentEnd = shellAssignmentEnd(text, index);
+      if (assignmentEnd > index) {
+        index = assignmentEnd;
+        continue;
+      }
+
+      const end = shellTokenEnd(text, index);
+      const token = text.slice(index, end);
+      if (isShellCommandToken(token)) {
+        ranges.push({ start: index, end });
+      }
+      expectingCommand = false;
+      index = end;
+      continue;
+    }
+
+    const separatorEnd = shellSeparatorEnd(text, index);
+    if (separatorEnd > index) {
+      expectingCommand = true;
+      index = separatorEnd;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return ranges;
+}
+
+function skipShellWhitespace(text, index) {
+  let next = index;
+  while (next < text.length && /\s/.test(text[next])) {
+    next += 1;
+  }
+  return next;
+}
+
+function shellAssignmentEnd(text, index) {
+  const match = text.slice(index).match(/^[A-Za-z_][A-Za-z0-9_]*=/);
+  if (!match) {
+    return index;
+  }
+  return shellTokenEnd(text, index + match[0].length);
+}
+
+function shellTokenEnd(text, index) {
+  let next = index;
+  while (next < text.length && !/\s/.test(text[next]) && !/[|;&]/.test(text[next])) {
+    next += 1;
+  }
+  return next;
+}
+
+function shellSeparatorEnd(text, index) {
+  const nextTwo = text.slice(index, index + 2);
+  if (nextTwo === "&&" || nextTwo === "||") {
+    return index + 2;
+  }
+  return /[|;]/.test(text[index] || "") ? index + 1 : index;
+}
+
+function isShellCommandToken(token) {
+  return /^[A-Za-z_./][A-Za-z0-9_./:-]*$/.test(token) && !token.startsWith("-");
+}
+
+function wrapTextRanges(container, ranges, className) {
+  if (ranges.length === 0) {
+    return;
+  }
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  const textNodes = [];
+  let offset = 0;
+  let node = walker.nextNode();
+  while (node) {
+    const start = offset;
+    const end = start + node.nodeValue.length;
+    textNodes.push({ node, start, end });
+    offset = end;
+    node = walker.nextNode();
+  }
+
+  textNodes.forEach(({ node: textNode, start, end }) => {
+    const overlaps = ranges
+      .map((range) => ({
+        start: Math.max(range.start, start) - start,
+        end: Math.min(range.end, end) - start,
+      }))
+      .filter((range) => range.start < range.end);
+
+    if (overlaps.length === 0) {
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    const value = textNode.nodeValue;
+    let cursor = 0;
+    overlaps.forEach((range) => {
+      if (range.start > cursor) {
+        fragment.append(document.createTextNode(value.slice(cursor, range.start)));
+      }
+      const span = document.createElement("span");
+      span.className = className;
+      span.textContent = value.slice(range.start, range.end);
+      fragment.append(span);
+      cursor = range.end;
+    });
+    if (cursor < value.length) {
+      fragment.append(document.createTextNode(value.slice(cursor)));
+    }
+    textNode.replaceWith(fragment);
+  });
+}
 
 function initSidebarPersistence(sidebar) {
   const storageKey = "crdsp.sidebar.scrollTop";

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -1,0 +1,49 @@
+---
+title: "CRD schema publisher"
+description: "Generate CRD schema docs and IDE validation catalogs directly from Kubernetes."
+weight: 10
+---
+
+`crd-schema-publisher` extracts CRD schemas from Kubernetes or YAML, converts Kubernetes built-in resource schemas from `/openapi/v2`, and publishes a searchable static site with interactive schema pages.
+
+<p>
+  <img src="screenshots/overview.gif" alt="Installing crd-schema-publisher, extracting CRD schemas, and browsing the generated schema site">
+</p>
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --create-namespace \
+  --set existingSecret.name=crd-schema-publisher-cloudflare
+```
+
+```bash
+curl -fsSL https://crdsp.shold.io | bash
+crd-schema-publisher extract -o ./schemas
+```
+
+<div class="home-grid">
+  <a href="getting-started/">Get started</a>
+  <a href="deploying/helm/">Deploy with Helm</a>
+  <a href="using-schemas/">Use published schemas</a>
+  <a href="https://kube-schemas.shold.io">View live demo</a>
+</div>
+
+> **Upgrading direct-volume deployments:** the active site now lives at `OUTPUT_DIR/current`. Existing sidecars or scripts that read the shared output volume directly must be updated. Cloudflare Pages users do not need to change anything.
+
+## Why
+
+Static CRD catalogs go stale, miss internal CRDs, and depend on external infrastructure. This tool publishes schemas from the cluster you actually run.
+
+- Always accurate for installed CRDs and optional built-in Kubernetes resources.
+- Self-hosted output that works with Cloudflare Pages, local serving, S3-compatible storage, git, or any static web server.
+- Single static binary with no runtime interpreters or package managers.
+- Controller-grade watch mode with informers, leader election, debounced refreshes, health probes, and metrics.
+
+The JSON Schema conversion is built for kubeconform and yaml-language-server compatibility.
+
+## Main workflows
+
+- Run a Kubernetes-native controller for real-time CRD watching.
+- Run a CronJob for scheduled extraction.
+- Run the local CLI to extract from a live cluster, convert CRD YAML, or render built-in schemas from Kubernetes OpenAPI.

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -1,14 +1,15 @@
 ---
-title: "CRD schema publisher"
+title: "crd-schema-publisher"
+linkTitle: "Overview"
 description: "Generate CRD schema docs and IDE validation catalogs directly from Kubernetes."
 weight: 10
 ---
 
 `crd-schema-publisher` extracts CRD schemas from Kubernetes or YAML, converts Kubernetes built-in resource schemas from `/openapi/v2`, and publishes a searchable static site with interactive schema pages.
 
-<p>
+<figure class="media-frame">
   <img src="screenshots/overview.gif" alt="Installing crd-schema-publisher, extracting CRD schemas, and browsing the generated schema site">
-</p>
+</figure>
 
 ```bash
 helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
@@ -29,21 +30,19 @@ crd-schema-publisher extract -o ./schemas
   <a href="https://kube-schemas.shold.io">View live demo</a>
 </div>
 
-> **Upgrading direct-volume deployments:** the active site now lives at `OUTPUT_DIR/current`. Existing sidecars or scripts that read the shared output volume directly must be updated. Cloudflare Pages users do not need to change anything.
-
 ## Why
 
-Static CRD catalogs go stale, miss internal CRDs, and depend on external infrastructure. This tool publishes schemas from the cluster you actually run.
+Static CRD catalogs go stale, miss internal CRDs, and depend on external infrastructure. `crd-schema-publisher` publishes schemas from your own cluster.
 
 - Always accurate for installed CRDs and optional built-in Kubernetes resources.
 - Self-hosted output that works with Cloudflare Pages, local serving, S3-compatible storage, git, or any static web server.
 - Single static binary with no runtime interpreters or package managers.
 - Controller-grade watch mode with informers, leader election, debounced refreshes, health probes, and metrics.
 
-The JSON Schema conversion is built for kubeconform and yaml-language-server compatibility.
+The JSON Schema conversion is built for kubeconform and IDE compatibility.
 
 ## Main workflows
 
 - Run a Kubernetes-native controller for real-time CRD watching.
 - Run a CronJob for scheduled extraction.
-- Run the local CLI to extract from a live cluster, convert CRD YAML, or render built-in schemas from Kubernetes OpenAPI.
+- Run the local CLI to extract from a live cluster, include Kubernetes built-ins, or convert CRD YAML.

--- a/docs-site/content/concepts/how-it-works.md
+++ b/docs-site/content/concepts/how-it-works.md
@@ -4,40 +4,86 @@ description: "Extraction, conversion, rendering, generation switching, and uploa
 weight: 190
 ---
 
-For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
+`crd-schema-publisher` has one core loop: collect Kubernetes schemas, normalize them for common tooling, render a static site, then publish or expose the finished snapshot.
 
-1. Connects to the Kubernetes API (in-cluster or via kubeconfig)
-2. Lists all CRDs and extracts `.spec.versions[].schema.openAPIV3Schema`
-3. Applies three JSON Schema transforms:
-   - Adds `additionalProperties: false` to structural child objects with `properties` - recurses into schema-valued locations only, preserving validation overlays and literal `default`/`enum` data while fixing a bug in the original where CRD fields named `properties` or other JSON Schema keywords corrupt the output
-   - Replaces Kubernetes int-or-string markers with a non-conflicting `oneOf` union, preserving safe metadata and moving type-specific assertions into the matching string or integer branch
-   - Allows null for optional fields (per-field precision, including optional `$ref` fields as ref-or-null `anyOf` wrappers)
+## At a Glance
 
-   These transforms handle nullable fields, int-or-string types, root objects, and keyword-colliding property names. A frozen golden test locks converter output to prevent regressions.
+| Stage | What Happens |
+| --- | --- |
+| Connect | Cluster-backed commands connect to the Kubernetes API in-cluster or through kubeconfig. |
+| Extract | The tool lists CRDs and reads `.spec.versions[].schema.openAPIV3Schema`. |
+| Normalize | JSON Schema transforms make the output friendlier to kubeconform and IDE validation. |
+| Write | Schemas are written in both primary and kubeval-compatible directory layouts. |
+| Render | Each schema gets an interactive HTML page with property trees, local `$ref` expansion, path-aware search, and autocomplete. |
+| Index | The site index groups schemas by source and API group, with client-side search and usage examples. |
+| Activate | Runtime generations atomically switch `OUTPUT_DIR/current` to the completed snapshot. |
+| Publish | When Cloudflare credentials are configured, the active generation uploads through the Cloudflare Pages API. |
 
-4. Writes schemas to both primary and kubeval-compatible directory formats inside a new generation snapshot
-5. Renders an interactive HTML documentation page for each schema with collapsible property trees, local `$ref` expansion, path-aware search, and autocomplete powered by a shared emitted `schema-search.js` asset
-6. Generates an HTML index grouped by schema source and API group with client-side search, schema statistics, and yaml-language-server usage examples
-7. Atomically switches `OUTPUT_DIR/current` to the completed generation so sidecars read a stable snapshot
-8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
+## Cluster-backed Pipeline
 
-The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
+The `run`, `extract`, and `watch` commands read from a Kubernetes cluster. `watch` adds informers, leader election, and debounced refresh cycles so CRD updates eventually produce a new active snapshot.
 
-Runtime modes can include optional schemas in generated snapshots. `--include-builtins` fetches `/openapi/v2` from the API server and writes authorable built-in types into the same generation as CRDs. When OpenAPI also contains CRD-backed definitions, CRD schemas take precedence and those OpenAPI duplicates are skipped. `--include-kustomize` writes kustomize's client-side config schemas. When more than one schema source is present, the index separates CRDs, built-ins, and Kustomize schemas; CRD-only output keeps the original API-group-only index. In the Helm chart, `config.includeBuiltins=true` adds `/openapi/v2` RBAC when `rbac.create=true`; `config.includeKustomize=true` does not require additional Kubernetes permissions.
+Runtime generations are written below `OUTPUT_DIR/.generations/<generation>`. After a generation completes, `OUTPUT_DIR/current` is switched atomically. Sidecars and local servers should read `OUTPUT_DIR/current` so they never serve a half-written site.
 
-`--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (for example `kubectl get --raw /openapi/v2`). Each authorable type that declares a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`; the empty API group is written under `core/`. Referenced definitions are bundled into each schema so validation and rendered child fields work without external references. When combined with CRD inputs, matching OpenAPI CRD definitions and their List types are skipped.
+Cloudflare publishing happens after activation. Uploads use direct Cloudflare Pages deployment APIs with BLAKE3 content hashing, batched uploads, and retry behavior.
+
+## Schema Transforms
+
+| Transform | Why It Exists |
+| --- | --- |
+| Structural object tightening | Adds `additionalProperties: false` to child objects with `properties`, recursing only through schema-valued locations. This preserves validation overlays and literal `default` or `enum` data while avoiding keyword-collision bugs. |
+| Kubernetes int-or-string support | Replaces Kubernetes int-or-string markers with a non-conflicting `oneOf` union. Metadata is preserved, and type-specific assertions move into the matching string or integer branch. |
+| Optional null support | Allows null for optional fields with per-field precision, including optional `$ref` fields as ref-or-null `anyOf` wrappers. |
+
+These transforms handle nullable fields, int-or-string types, root objects, and CRD fields named like JSON Schema keywords. A frozen golden test locks converter output to prevent regressions.
+
+## Offline Conversion
+
+The `convert` command skips Kubernetes access. It reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`.
+
+`convert` applies the same schema transforms as cluster-backed commands. It writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders schema HTML pages and an index.
+
+## Kubernetes Built-ins from OpenAPI
+
+Use `--openapi <swagger.json>` to convert Kubernetes built-in, non-CRD types from an OpenAPI v2 document.
 
 ```sh
 kubectl get --raw /openapi/v2 > swagger.json
 crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 ```
 
+Each authorable type that declares a group, version, and kind becomes a self-contained `<group>/<kind>_<version>.json`. The empty API group is written under `core/`.
+
+Referenced definitions are bundled into each schema so validation and rendered child fields work without external references. When combined with CRD inputs, matching OpenAPI CRD definitions and their List types are skipped.
+
 Combine `--openapi` with `--file` or `--dir` when you want one local site containing both built-ins and CRDs.
 
-`--kustomize` publishes schemas for kustomize's `Kustomization` and `Component` at `kustomize.config.k8s.io/kustomization_v1beta1.json` and `kustomize.config.k8s.io/component_v1alpha1.json`. These are client-side types with no usable upstream schemas, so they are reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module. Bumping that dependency updates the schemas. Combine them with the other inputs in a single run:
+## Kustomize Schemas
+
+`--kustomize` publishes schemas for kustomize's client-side config types:
+
+- `kustomize.config.k8s.io/kustomization_v1beta1.json`
+- `kustomize.config.k8s.io/component_v1alpha1.json`
+
+These types do not have usable upstream schemas. The project reflects them from the `sigs.k8s.io/kustomize/api` Go types pinned in this module. Bumping that dependency updates the generated schemas.
 
 ```sh
 crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render
 ```
 
-`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs; `--kustomize` is a single explicit opt-in and always emits the Kustomize config schemas when set.
+## Filtering
+
+`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs. The filters are comma-separated and case-insensitive.
+
+Kustomize is different: `--kustomize` is a single explicit opt-in and always emits the Kustomize config schemas when set. It is not filtered.
+
+## Mixed-source Sites
+
+Runtime modes can include optional schemas in generated snapshots:
+
+- `--include-builtins` fetches `/openapi/v2` from the API server and writes built-ins into the same generation as CRDs.
+- `--include-kustomize` adds kustomize's client-side config schemas.
+
+When more than one schema source is present, the generated index separates CRDs, built-ins, and Kustomize schemas. CRD-only output keeps the original API-group-only index.
+
+In the Helm chart, `config.includeBuiltins=true` adds `/openapi/v2` RBAC when `rbac.create=true`; `config.includeKustomize=true` does not require additional Kubernetes permissions.

--- a/docs-site/content/concepts/how-it-works.md
+++ b/docs-site/content/concepts/how-it-works.md
@@ -1,0 +1,43 @@
+---
+title: "How It Works"
+description: "Extraction, conversion, rendering, generation switching, and upload pipeline."
+weight: 190
+---
+
+For cluster-backed commands (`run`, `extract`, and `watch`), the pipeline is:
+
+1. Connects to the Kubernetes API (in-cluster or via kubeconfig)
+2. Lists all CRDs and extracts `.spec.versions[].schema.openAPIV3Schema`
+3. Applies three JSON Schema transforms:
+   - Adds `additionalProperties: false` to structural child objects with `properties` - recurses into schema-valued locations only, preserving validation overlays and literal `default`/`enum` data while fixing a bug in the original where CRD fields named `properties` or other JSON Schema keywords corrupt the output
+   - Replaces Kubernetes int-or-string markers with a non-conflicting `oneOf` union, preserving safe metadata and moving type-specific assertions into the matching string or integer branch
+   - Allows null for optional fields (per-field precision, including optional `$ref` fields as ref-or-null `anyOf` wrappers)
+
+   These transforms handle nullable fields, int-or-string types, root objects, and keyword-colliding property names. A frozen golden test locks converter output to prevent regressions.
+
+4. Writes schemas to both primary and kubeval-compatible directory formats inside a new generation snapshot
+5. Renders an interactive HTML documentation page for each schema with collapsible property trees, local `$ref` expansion, path-aware search, and autocomplete powered by a shared emitted `schema-search.js` asset
+6. Generates an HTML index grouped by schema source and API group with client-side search, schema statistics, and yaml-language-server usage examples
+7. Atomically switches `OUTPUT_DIR/current` to the completed generation so sidecars read a stable snapshot
+8. Uploads the active generation to Cloudflare Pages via the direct upload API (BLAKE3 content hashing, batched uploads with retry)
+
+The `convert` command skips Kubernetes access and reads CRD YAML from `--file`/`-f`, stdin (`-f -`), and/or a non-recursive `--dir`/`-d`. It applies the same schema transforms and writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders HTML pages and an index.
+
+Runtime modes can include optional schemas in generated snapshots. `--include-builtins` fetches `/openapi/v2` from the API server and writes authorable built-in types into the same generation as CRDs. When OpenAPI also contains CRD-backed definitions, CRD schemas take precedence and those OpenAPI duplicates are skipped. `--include-kustomize` writes kustomize's client-side config schemas. When more than one schema source is present, the index separates CRDs, built-ins, and Kustomize schemas; CRD-only output keeps the original API-group-only index. In the Helm chart, `config.includeBuiltins=true` adds `/openapi/v2` RBAC when `rbac.create=true`; `config.includeKustomize=true` does not require additional Kubernetes permissions.
+
+`--openapi <swagger.json>` converts Kubernetes' built-in (non-CRD) types from an OpenAPI v2 document (for example `kubectl get --raw /openapi/v2`). Each authorable type that declares a group/version/kind becomes a self-contained `<group>/<kind>_<version>.json`; the empty API group is written under `core/`. Referenced definitions are bundled into each schema so validation and rendered child fields work without external references. When combined with CRD inputs, matching OpenAPI CRD definitions and their List types are skipped.
+
+```sh
+kubectl get --raw /openapi/v2 > swagger.json
+crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
+```
+
+Combine `--openapi` with `--file` or `--dir` when you want one local site containing both built-ins and CRDs.
+
+`--kustomize` publishes schemas for kustomize's `Kustomization` and `Component` at `kustomize.config.k8s.io/kustomization_v1beta1.json` and `kustomize.config.k8s.io/component_v1alpha1.json`. These are client-side types with no usable upstream schemas, so they are reflected from the `sigs.k8s.io/kustomize/api` Go types pinned in this module. Bumping that dependency updates the schemas. Combine them with the other inputs in a single run:
+
+```sh
+crd-schema-publisher convert -d ./crds --openapi swagger.json --kustomize -o ./schemas --render
+```
+
+`--kind`, `--group`, and `--version` filters limit CRD and OpenAPI inputs; `--kustomize` is a single explicit opt-in and always emits the Kustomize config schemas when set.

--- a/docs-site/content/deploying/_index.md
+++ b/docs-site/content/deploying/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Deploying"
+description: "Choose between Helm, raw manifests, watch mode, and CronJob mode."
+weight: 50
+---
+
+The Helm chart is the recommended deployment path. It installs controller mode by default for real-time CRD watching and can run extract-only when Cloudflare credentials are omitted.
+
+## Deployment Choices
+
+| Path | Use When |
+| --- | --- |
+| [Helm chart](helm/) | You want the supported, signed, configurable Kubernetes deployment. |
+| [Raw manifests](raw-manifests/) | You prefer plain YAML and can manage changes yourself. |
+| Watch mode | You want schemas updated soon after CRD changes. |
+| CronJob mode | You want scheduled extraction and can tolerate stale schemas between runs. |
+
+## Publishing Choices
+
+Cloudflare Pages is built in. Extract-only mode writes the generated site under `OUTPUT_DIR/current` for a built-in server, sidecar, object storage sync, or git push workflow.
+
+See [Publishing Backends](../publishing-backends/) for backend patterns.

--- a/docs-site/content/deploying/helm.md
+++ b/docs-site/content/deploying/helm.md
@@ -1,0 +1,76 @@
+---
+title: "Helm Chart"
+description: "Install and configure the signed OCI Helm chart."
+weight: 60
+---
+
+The Helm chart is distributed as an OCI artifact and signed with cosign. It installs in controller mode by default for real-time CRD watching with leader election. For scheduled runs, set `--set mode=cronjob`.
+
+## Install
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --create-namespace \
+  --set existingSecret.name=crd-schema-publisher-cloudflare
+```
+
+See [Artifact Verification](../../installation/verification/) for chart signature verification.
+
+## Credentials
+
+Cloudflare credentials are optional in both controller and CronJob modes. Without them, the workload runs in extract-only mode. Site generations are written under the output directory and the active snapshot is exposed at `OUTPUT_DIR/current`, but nothing is uploaded.
+
+This is useful when serving schemas locally with a sidecar web server or another publishing backend instead of Cloudflare Pages.
+
+To publish to Cloudflare Pages, provide an API token with Cloudflare Pages: Edit permission and your account ID. Two secret management options are supported:
+
+- `existingSecret` references a pre-existing Secret containing `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
+- `externalSecret` creates an [ExternalSecret](https://external-secrets.io) CR that syncs credentials from an external provider such as Vault, AWS Secrets Manager, or 1Password.
+
+```bash
+# Using External Secrets Operator
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --create-namespace \
+  --set externalSecret.enabled=true \
+  --set externalSecret.secretStoreRef.name=my-store \
+  --set externalSecret.secretStoreRef.kind=ClusterSecretStore
+```
+
+The default remote ref points to a `crd-schema-publisher-cloudflare` key with `api-token` and `account-id` properties. Override via `externalSecret.data` if your provider uses different paths.
+
+## Schema Filtering
+
+To publish only part of the cluster CRD catalog, set `config.filter.group`, `config.filter.kind`, and/or `config.filter.version`. Values are comma-separated and case-insensitive.
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --create-namespace \
+  --set config.filter.group=cert-manager.io \
+  --set-string 'config.filter.kind=Certificate\,Issuer'
+```
+
+Controller mode still watches all CRDs, then applies the filter to each generated output snapshot. If active filters match no CRDs or built-ins and Kustomize is not enabled, the next runtime build publishes an empty catalog instead of preserving a previous broader snapshot.
+
+## Runtime Built-ins and Kustomize
+
+Runtime modes publish CRDs only by default. Enable built-ins and Kustomize explicitly when you want one site for CRDs, Kubernetes built-in types, and kustomize's client-side `Kustomization` and `Component` schemas.
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set config.includeBuiltins=true \
+  --set config.includeKustomize=true
+```
+
+`config.includeBuiltins=true` reads `/openapi/v2` from the API server. With chart RBAC enabled, it also adds the required ClusterRole permission; with `rbac.create=false`, provide that permission yourself.
+
+`config.includeKustomize=true` does not require extra Kubernetes permissions. Filters apply to CRDs and built-ins; Kustomize is an explicit unfiltered opt-in.
+
+## Optional Features
+
+The chart also supports persistent output volume (`persistence`), built-in static serving (`serve`), Gateway API HTTPRoute (`serve.httpRoute`), extra volumes, volume mounts and containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard, NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects.
+
+See [values.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/charts/crd-schema-publisher/values.yaml) for all options.

--- a/docs-site/content/deploying/helm.md
+++ b/docs-site/content/deploying/helm.md
@@ -71,6 +71,16 @@ helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-sch
 
 ## Optional Features
 
-The chart also supports persistent output volume (`persistence`), built-in static serving (`serve`), Gateway API HTTPRoute (`serve.httpRoute`), extra volumes, volume mounts and containers (`extraVolumes`, `extraVolumeMounts`, `extraContainers`), PodMonitor, PrometheusRule, Grafana dashboard, NetworkPolicy, CiliumNetworkPolicy, PodDisruptionBudget, pod anti-affinity presets, topology spread constraints, and templated extra objects.
+Most installs can skip these options. Use them when you need retained output, in-cluster serving, observability resources, or stricter workload controls.
 
-See [values.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/charts/crd-schema-publisher/values.yaml) for all options.
+| Need | Chart values |
+| --- | --- |
+| Retain generated output across pod restarts | `persistence` |
+| Serve the active site from the pod | `serve` |
+| Expose the built-in server through Gateway API | `serve.httpRoute` |
+| Add sidecars, sync containers, custom mounts, or extra objects | `extraVolumes`, `extraVolumeMounts`, `extraContainers`, `extraObjects` |
+| Export Prometheus and Grafana resources | `metrics.podMonitor`, `metrics.prometheusRule`, `grafana.dashboard` |
+| Restrict network traffic | `networkPolicy`, `ciliumNetworkPolicy` |
+| Improve rollout availability | `podDisruptionBudget`, `affinity`, `podAntiAffinityPreset`, `topologySpreadConstraints` |
+
+See [Monitoring](../../operations/monitoring/) for metrics and dashboard setup, and [values.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/charts/crd-schema-publisher/values.yaml) for the full option reference.

--- a/docs-site/content/deploying/raw-manifests.md
+++ b/docs-site/content/deploying/raw-manifests.md
@@ -1,0 +1,41 @@
+---
+title: "Raw Manifests"
+description: "Deploy watch mode or CronJob mode with plain Kubernetes YAML."
+weight: 70
+---
+
+For users who prefer raw YAML without Helm, deploy manifests are available in [deploy/](https://github.com/sholdee/crd-schema-publisher/blob/main/deploy/).
+
+## Watch Mode
+
+Watch mode reacts to CRD changes in real time with debounced schema refreshes, uploading only when Cloudflare credentials are configured. It supports leader election for safe rolling updates.
+
+The container runs with `args: ["watch"]`. See [deploy/deployment.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/deploy/deployment.yaml).
+
+```bash
+kubectl apply -f deploy/common.yaml -f deploy/deployment.yaml
+```
+
+## CronJob Mode
+
+CronJob mode runs scheduled schema extraction, uploading to Cloudflare Pages only when credentials are configured. It is simpler than watch mode, but schemas are only updated when the job runs.
+
+The example uses a daily schedule. Adjust the `schedule` field as needed. It uses the default `run` command. See [deploy/cronjob.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/deploy/cronjob.yaml).
+
+```bash
+kubectl apply -f deploy/common.yaml -f deploy/cronjob.yaml
+```
+
+## Shared Manifests
+
+Both modes share [deploy/common.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/deploy/common.yaml), which provides namespace, ServiceAccount, RBAC with ClusterRole access for CRD reads, and a hardened security context.
+
+The shared security context runs as nonroot, uses a read-only root filesystem, and drops capabilities.
+
+## Credentials and Extract-only Mode
+
+The deploy manifests include an empty placeholder Secret named `crd-schema-publisher-cloudflare`. Fill in the values in `common.yaml` directly, or replace the Secret with your own secrets management such as ExternalSecret or Sealed Secret.
+
+If Cloudflare credentials are empty or omitted, workloads run in extract-only mode. Site generations are written under `OUTPUT_DIR/.generations`, and the active snapshot is exposed at `OUTPUT_DIR/current`, but nothing is uploaded.
+
+Without Cloudflare credentials, raw CronJob mode is extract-only. With the default `emptyDir` output volume, extracted schemas are discarded when the Job pod exits unless you replace it with retained storage or a backend sync.

--- a/docs-site/content/development/_index.md
+++ b/docs-site/content/development/_index.md
@@ -1,0 +1,111 @@
+---
+title: "Development"
+description: "Run, preview, build, lint, and contribute to crd-schema-publisher."
+weight: 200
+---
+
+## Run Locally
+
+Use the package path (`go run ./cmd/ <command>`) for local subcommands so Go compiles every file in `cmd/`. Single-file invocation (`go run ./cmd/main.go --help` or `--version`) is only kept for top-level smoke checks.
+
+```bash
+# Extract schemas from a local cluster (no upload)
+KUBECTL_CONTEXT=my-cluster OUTPUT_DIR=./output go run ./cmd/ extract
+# Writes the active snapshot under ./output/current
+
+# Full run with upload
+mkdir -p ./output
+KUBECTL_CONTEXT=my-cluster \
+  CLOUDFLARE_API_TOKEN=xxx \
+  CLOUDFLARE_ACCOUNT_ID=xxx \
+  go run ./cmd/ --output-dir ./output
+
+# Convert CRD YAML files to JSON Schema (no cluster needed)
+go run ./cmd/ convert -f crd.yaml -o ./schemas
+
+# Convert Kubernetes built-ins from a cluster OpenAPI document
+kubectl get --raw /openapi/v2 > swagger.json
+go run ./cmd/ convert --openapi swagger.json -o ./schemas --render
+
+# Convert all CRDs in a directory
+go run ./cmd/ convert -d ./crds/ -o ./schemas
+
+# Pipe from kubectl
+kubectl get crds -o yaml | go run ./cmd/ convert -f - -o ./schemas
+
+# Filter by kind and group
+go run ./cmd/ extract --output-dir ./schemas --kind certificate,issuer --group cert-manager.io
+
+# Filter a runtime extraction through env vars
+SCHEMA_FILTER_GROUP=cert-manager.io go run ./cmd/ --output-dir ./output
+```
+
+## Preview the Site Locally
+
+Preview is useful for UI development and local inspection. It needs no cluster or credentials when using sample data.
+
+```bash
+# Preview the index UI (no cluster or credentials needed)
+go run ./cmd/ preview
+# open http://127.0.0.1:8989
+
+# Preview with real extracted schemas
+go run ./cmd/ preview --output-dir ./output
+# Serves the active snapshot from ./output/current
+
+# Preview a subpath deployment locally
+BASE_PATH=/iac go run ./cmd/ preview
+# open http://127.0.0.1:8989/iac/
+```
+
+## Build
+
+```bash
+# Native build
+go build -o crd-schema-publisher ./cmd/
+
+# Example static cross-compile
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o crd-schema-publisher ./cmd/
+
+# Build all release binaries locally
+for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+  GOOS="${pair%/*}" GOARCH="${pair#*/}"
+  CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
+    go build -ldflags="-s -w" -o "crd-schema-publisher-${GOOS}-${GOARCH}" ./cmd/
+done
+
+# Docker (multi-arch)
+docker buildx build --platform linux/amd64,linux/arm64 -t crd-schema-publisher .
+```
+
+## Linting
+
+This project uses [golangci-lint](https://golangci-lint.run/) with strict linters enabled:
+
+```bash
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+golangci-lint run
+```
+
+Enable the pre-commit hook to enforce linting before each commit:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+If you change the extracted schema search module or its tests, also run:
+
+```bash
+node --test theme/schema_search.test.js
+```
+
+## Renovate
+
+Dependencies are managed by [Renovate](https://docs.renovatebot.com/). Minor and patch updates for Go modules, GitHub Actions, Docker images, and CI tools are automerged after required status checks pass.
+
+## Community
+
+- [Home Operations Discord](https://discord.gg/home-operations)
+- [Contributing](https://github.com/sholdee/crd-schema-publisher/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/sholdee/crd-schema-publisher/blob/main/CODE_OF_CONDUCT.md)
+- [Security Policy](https://github.com/sholdee/crd-schema-publisher/blob/main/SECURITY.md)

--- a/docs-site/content/getting-started/_index.md
+++ b/docs-site/content/getting-started/_index.md
@@ -27,7 +27,7 @@ Install the standalone CLI:
 curl -fsSL https://crdsp.shold.io | bash
 ```
 
-Extract schemas from a kubeconfig context, convert CRD YAML, or render Kubernetes built-ins from the cluster OpenAPI document:
+Extract schemas from a kubeconfig context, include Kubernetes built-ins from the API server, or convert CRD YAML:
 
 ```bash
 # Extract from the current kubeconfig context
@@ -36,12 +36,11 @@ crd-schema-publisher extract -o ./schemas
 # Extract from a specific context
 crd-schema-publisher extract --context my-cluster -o ./schemas
 
+# Extract CRDs and Kubernetes built-ins from the current cluster
+crd-schema-publisher extract -o ./schemas --include-builtins
+
 # Convert CRD YAML without a cluster
 crd-schema-publisher convert -f crd.yaml -o ./schemas
-
-# Convert Kubernetes built-in resources from the current cluster
-kubectl get --raw /openapi/v2 > swagger.json
-crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
 ```
 
 For source builds, use `go run ./cmd/` in place of `crd-schema-publisher`. See [Installation](../installation/) for installer options and manual downloads, and [Commands](../reference/commands/) for flags and command behavior.

--- a/docs-site/content/getting-started/_index.md
+++ b/docs-site/content/getting-started/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Getting Started"
+description: "Deploy the chart, install the CLI, and point tools at your published schemas."
+weight: 20
+---
+
+Use `crd-schema-publisher` as a Kubernetes controller, a scheduled CronJob, or a local CLI. The quickest path is Helm for clusters and the installer for local extraction or conversion.
+
+## Deploy to a Cluster
+
+Install the Helm chart in controller mode for real-time CRD watching. Provide Cloudflare credentials to publish directly to Cloudflare Pages, or omit credentials to run extract-only and serve `OUTPUT_DIR/current` yourself.
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --create-namespace \
+  --set existingSecret.name=crd-schema-publisher-cloudflare
+```
+
+See [Helm Chart](../deploying/helm/) for credentials, CronJob mode, alternative backends, and chart verification.
+
+## Install and Run the CLI
+
+Install the standalone CLI:
+
+```bash
+curl -fsSL https://crdsp.shold.io | bash
+```
+
+Extract schemas from a kubeconfig context, convert CRD YAML, or render Kubernetes built-ins from the cluster OpenAPI document:
+
+```bash
+# Extract from the current kubeconfig context
+crd-schema-publisher extract -o ./schemas
+
+# Extract from a specific context
+crd-schema-publisher extract --context my-cluster -o ./schemas
+
+# Convert CRD YAML without a cluster
+crd-schema-publisher convert -f crd.yaml -o ./schemas
+
+# Convert Kubernetes built-in resources from the current cluster
+kubectl get --raw /openapi/v2 > swagger.json
+crd-schema-publisher convert --openapi swagger.json -o ./schemas --render
+```
+
+For source builds, use `go run ./cmd/` in place of `crd-schema-publisher`. See [Installation](../installation/) for installer options and manual downloads, and [Commands](../reference/commands/) for flags and command behavior.
+
+## Use Published Schemas
+
+Once published, schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`, for example `cert-manager.io/certificate_v1.json` or `core/pod_v1.json`.
+
+```yaml
+# yaml-language-server: $schema=https://kube-schemas.example.com/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example
+```
+
+See [Using Schemas](../using-schemas/) for IDE and kubeconform examples.
+
+## Next Steps
+
+- [Deploy with Helm](../deploying/helm/)
+- [Install the standalone CLI](../installation/)
+- [Use published schemas](../using-schemas/)
+- [Choose a publishing backend](../publishing-backends/)

--- a/docs-site/content/installation/_index.md
+++ b/docs-site/content/installation/_index.md
@@ -1,0 +1,62 @@
+---
+title: "Installation"
+description: "Install the standalone CLI with the installer, direct binary downloads, or mise."
+weight: 30
+---
+
+The quick installer is the recommended path for local CLI use. Static binaries for Linux and macOS on amd64 and arm64 are attached to each [GitHub Release](https://github.com/sholdee/crd-schema-publisher/releases).
+
+The installer detects Linux/macOS and amd64/arm64, verifies the selected binary against the release checksum manifest, optionally verifies the checksum Sigstore bundle when `cosign` is available, and installs to an existing `crd-schema-publisher` path or `/usr/local/bin/crd-schema-publisher`.
+
+## Quick Install
+
+Install or update to the latest release:
+
+```bash
+curl -fsSL https://crdsp.shold.io | bash
+```
+
+## Non-interactive Install
+
+Use `--yes` for automation:
+
+```bash
+curl -fsSL https://crdsp.shold.io | bash -s -- --yes
+```
+
+## Install a Specific Release
+
+Pin a release version:
+
+```bash
+curl -fsSL https://crdsp.shold.io | bash -s -- --version vYYYY.MDD.HMMSS
+```
+
+## Manual Download
+
+Download a release binary directly when you do not want to run the installer:
+
+```bash
+# Download the latest release (example: Linux amd64)
+curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/crd-schema-publisher-linux-amd64
+chmod +x crd-schema-publisher-linux-amd64
+```
+
+## Optional mise-managed CLI Install
+
+If you manage project CLIs with [mise](https://mise.jdx.dev/), install the released CLI through the aqua backend:
+
+```bash
+mise use aqua:sholdee/crd-schema-publisher@latest
+```
+
+Or pin a release in `mise.toml`:
+
+```toml
+[tools]
+"aqua:sholdee/crd-schema-publisher" = "2026.519.317"
+```
+
+## Verification
+
+See [Artifact Verification](verification/) for release checksum, Sigstore bundle, binary attestation, Helm chart signature, and container image verification commands.

--- a/docs-site/content/installation/verification.md
+++ b/docs-site/content/installation/verification.md
@@ -1,0 +1,56 @@
+---
+title: "Artifact Verification"
+description: "Verify release checksums, binary provenance, Helm chart signatures, and container images."
+weight: 40
+---
+
+Use release checksums, Sigstore bundles, GitHub artifact attestations, and cosign signatures to verify the artifacts you install or deploy.
+
+## Verify Release Artifacts
+
+```bash
+# Verify the signed checksum manifest
+curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/checksums-sha256.txt
+curl -LO https://github.com/sholdee/crd-schema-publisher/releases/latest/download/checksums-sha256.txt.sigstore.json
+cosign verify-blob checksums-sha256.txt \
+  --bundle checksums-sha256.txt.sigstore.json \
+  --certificate-identity 'https://github.com/sholdee/crd-schema-publisher/.github/workflows/release.yaml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# Verify the binary against the trusted checksum manifest
+sha256sum -c --ignore-missing checksums-sha256.txt
+
+# Optional: verify build provenance for the binary
+gh attestation verify ./crd-schema-publisher-linux-amd64 \
+  --repo sholdee/crd-schema-publisher \
+  --signer-workflow sholdee/crd-schema-publisher/.github/workflows/release.yaml \
+  --source-ref refs/heads/main
+```
+
+## Verify the Helm Chart
+
+The chart is distributed as an OCI artifact and signed with cosign. Substitute the version you installed. You can find it with `helm list`.
+
+```bash
+cosign verify ghcr.io/sholdee/charts/crd-schema-publisher:<VERSION> \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp github.com/sholdee/crd-schema-publisher
+```
+
+## Verify the Container Image
+
+Pre-built multi-arch images for amd64 and arm64 are published to GHCR:
+
+```text
+ghcr.io/sholdee/crd-schema-publisher:latest
+```
+
+Releases are triggered manually via the release workflow, producing a date-based tag such as `vYYYY.MDD.HMMSS` and `latest`. Release notes include the image digest, OCI Helm chart reference, signed checksum manifest, binary provenance link, and standalone binary attachments.
+
+Images use `gcr.io/distroless/static:nonroot` as the runtime base. The image has no shell or package manager and runs as UID 65534. Production images are signed with cosign keyless signing via GitHub Actions OIDC:
+
+```bash
+cosign verify ghcr.io/sholdee/crd-schema-publisher:latest \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp github.com/sholdee/crd-schema-publisher
+```

--- a/docs-site/content/operations/monitoring.md
+++ b/docs-site/content/operations/monitoring.md
@@ -1,0 +1,87 @@
+---
+title: "Monitoring"
+description: "Prometheus metrics, PodMonitor setup, and Grafana dashboard options."
+weight: 170
+---
+
+In watch mode, the health server exposes a `/metrics` endpoint on `HEALTH_PORT` (default 8080) in Prometheus text format.
+
+| Metric                                           | Type    | Description                                   |
+| ------------------------------------------------ | ------- | --------------------------------------------- |
+| `crdpublisher_publish_cycle_duration_seconds`    | gauge   | Duration of the most recent publish cycle     |
+| `crdpublisher_publish_cycle_total`               | counter | Publish cycles by result (`success`, `error`) |
+| `crdpublisher_crds_discovered`                   | gauge   | CRDs found in the most recent cycle           |
+| `crdpublisher_schemas_written`                   | gauge   | Schemas written in the most recent cycle      |
+| `crdpublisher_last_successful_publish_timestamp` | gauge   | Unix epoch of the last successful publish     |
+| `crdpublisher_watchdog_timestamp`                | gauge   | Unix epoch of the last debounce loop tick     |
+| `crdpublisher_publish_skipped_total`             | counter | Debounce skips (publish already in progress)  |
+| `crdpublisher_leader`                            | gauge   | Whether this pod is the current leader        |
+
+The watchdog timestamp enables dead man's switch alerting - it updates on every debounce loop tick (regardless of whether a publish occurs), so `time() - crdpublisher_watchdog_timestamp` staying fresh proves the watcher is alive. The publish timestamp separately tracks when content was last pushed.
+
+The Helm chart includes a PodMonitor - enable it with `--set metrics.podMonitor.enabled=true`. For raw manifests or vanilla Prometheus Operator, create a PodMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: crd-schema-publisher
+spec:
+  selector:
+    matchLabels:
+      app: crd-schema-publisher
+  podMetricsEndpoints:
+    - port: health
+      path: /metrics
+```
+
+For vanilla Prometheus, add `prometheus.io/*` annotations to the pod template or configure a static scrape target.
+
+## Grafana Dashboard
+
+The Helm chart can install the included Grafana dashboard in either sidecar-discovery mode or Grafana Operator mode.
+
+For Grafana sidecars that discover dashboard `ConfigMap` objects:
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set grafana.dashboard.enabled=true
+```
+
+For Grafana Operator:
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set grafana.dashboard.operator.enabled=true
+```
+
+Operator mode renders a `GrafanaDashboard` that references the embedded dashboard `ConfigMap`. It selects Grafana instances with `dashboards: grafana` by default. Custom `grafana.dashboard.operator.instanceSelector` values replace that fallback instead of being merged with it:
+
+```yaml
+grafana:
+  dashboard:
+    operator:
+      enabled: true
+      instanceSelector:
+        matchLabels:
+          grafana.internal/instance: home
+```
+
+To intentionally match all Grafana instances visible to the operator, set `grafana.dashboard.operator.defaultInstanceSelector.enabled=false`.
+
+Use `grafana.dashboard.operator.folder` for a Grafana folder title, `grafana.dashboard.operator.folderRef` for a `GrafanaFolder` resource reference, or `grafana.dashboard.operator.folderUID` for an existing Grafana folder UID. Set only one folder option.
+
+If your Grafana datasource name is not resolved automatically, map the bundled dashboard input with:
+
+```yaml
+grafana:
+  dashboard:
+    operator:
+      datasources:
+        - inputName: DS_PROMETHEUS
+          datasourceName: Prometheus
+```
+
+Grafana Operator and its CRDs must already be installed in the cluster.

--- a/docs-site/content/operations/output-structure.md
+++ b/docs-site/content/operations/output-structure.md
@@ -1,0 +1,29 @@
+---
+title: "Output Structure"
+description: "Generated site layout, stable read paths, metadata, and convert cleanup behavior."
+weight: 180
+---
+
+Cluster-backed site generation (`run`, `extract`, `watch`) and preview temp generations use this layout:
+
+```text
+<output-dir>/
+  .generations/
+    <generation>/
+      <apigroup>/
+        <kind>_<version>.json          # JSON schema
+        <kind>_<version>.html          # Interactive documentation page
+      _meta/
+        kinds.json                     # Internal Kind casing manifest
+        schema-metadata.json           # Internal index source manifest
+      master-standalone/
+        <apigroup>-<kind>-stable-<version>.json  # kubeval-compatible format
+      index.html                       # Browsable schema index
+      schema-search.js                 # Shared schema-page search/autocomplete module
+      favicon.svg                      # Constellation icon
+  current -> .generations/<generation> # Stable read path for sidecars and local servers
+```
+
+Direct-volume consumers should read or serve `OUTPUT_DIR/current`, not the flat root of `OUTPUT_DIR`. `_meta/` is internal tool state; first-party Cloudflare, git, S3, and Caddy examples exclude it from published or served output.
+
+`convert` writes schema files directly into `--output-dir` instead of creating `.generations/current`. It records generated files in `_meta/convert-manifest.json` so reruns can remove stale generated artifacts while preserving files that existed before `convert` ran.

--- a/docs-site/content/publishing-backends/_index.md
+++ b/docs-site/content/publishing-backends/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Publishing Backends"
+description: "Publish generated schema sites with Cloudflare Pages, the built-in server, sidecars, object storage, or git."
+weight: 80
+---
+
+Runtime modes can publish directly to Cloudflare Pages when credentials are present. Without credentials, the workload runs extract-only and writes a complete generated site to `OUTPUT_DIR/current`.
+
+Use extract-only mode when another container or process should serve or sync the generated site.
+
+## Supported Patterns
+
+| Pattern | Backend | Example |
+| --- | --- | --- |
+| [Built-in server](built-in-server/) | Controller HTTP server | `serve.enabled=true`, [values file](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/built-in-server/values.yaml) |
+| [Caddy sidecar](caddy-sidecar/) | Local HTTP | [examples/caddy-sidecar/values.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/caddy-sidecar/values.yaml) |
+| [S3-compatible storage](s3/) | AWS S3, Backblaze B2, MinIO, R2, GCS | [examples/rclone-s3/values.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/rclone-s3/values.yaml) |
+| [Git push](git-push/) | GitHub Pages, GitLab Pages, Gitea, Bitbucket | [examples/git-push/values.yaml](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/git-push/values.yaml) |
+| [GitHub Pages subpaths](github-pages/) | Project Pages path prefixes | `config.basePath` |
+
+The built-in server is the smallest in-cluster option. Sidecar examples use the chart's `extraContainers` and `extraObjects` values so you can adapt the same pattern to another web server, object storage sync tool, or git host without changing `crd-schema-publisher`.
+
+Examples that push to external storage run stateless with an `emptyDir`. The Caddy example uses a persistent volume because it serves directly from the cluster.
+
+Each example is a self-contained values file. Copy it, fill in your credentials, and install it. See the comments in each file for what to customize.

--- a/docs-site/content/publishing-backends/built-in-server.md
+++ b/docs-site/content/publishing-backends/built-in-server.md
@@ -1,0 +1,19 @@
+---
+title: "Built-in Server"
+description: "Serve the active generated site directly from the controller container."
+weight: 90
+---
+
+For simple in-cluster deployments, the controller can serve the active generated site directly from `OUTPUT_DIR/current`.
+
+```bash
+helm upgrade --install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher \
+  --set serve.enabled=true
+```
+
+The site is exposed on the chart Service port named `site` and defaults to non-privileged port `8081`. Health and metrics stay on the `health` port.
+
+Built-in serving is controller-only, requires `replicaCount=1`, and switches the Deployment strategy to `Recreate` so traffic is not routed to a new pod before it has published its first site.
+
+Use the complete [built-in server values file](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/built-in-server/values.yaml) for persistence and Gateway API `HTTPRoute` setup. Customize the `HTTPRoute` `parentRefs` and `hostnames` for your Gateway.

--- a/docs-site/content/publishing-backends/caddy-sidecar.md
+++ b/docs-site/content/publishing-backends/caddy-sidecar.md
@@ -1,0 +1,44 @@
+---
+title: "Caddy Sidecar"
+description: "Serve schemas directly from the cluster with a sidecar web server."
+weight: 100
+---
+
+The Caddy sidecar pattern runs `crd-schema-publisher` in extract-only mode and serves the active generated site from the same pod. It does not require Cloudflare credentials.
+
+See the complete [Caddy sidecar values file](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/caddy-sidecar/values.yaml).
+
+## When to Use This
+
+Use this when you want schemas and generated documentation served directly from the cluster through your own Gateway or ingress. The example uses Caddy, but the same `extraContainers` pattern works with nginx or another web server.
+
+The example uses a persistent volume so generated schemas remain available across pod restarts.
+
+## Install
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher --create-namespace \
+  -f examples/caddy-sidecar/values.yaml
+```
+
+## Customize
+
+Set these values before installing:
+
+| Area | What to change |
+| --- | --- |
+| Storage | `persistence.storageClass`, if your cluster needs a specific StorageClass |
+| Gateway | `HTTPRoute` `parentRefs` for your Gateway name and namespace |
+| Hostname | `HTTPRoute` `hostnames` for the public schema hostname |
+| Server | Caddy image, Caddyfile, or sidecar container if you prefer another web server |
+
+The example mounts the shared output volume at `/srv` and serves `/srv/current`. The Caddyfile enables directory browsing and hides `_meta`.
+
+## Operational Notes
+
+The publisher writes complete site generations under the output directory and exposes the active snapshot at `/srv/current` for Caddy to serve.
+
+`Recreate` strategy is required with `ReadWriteOnce` persistence. A rolling update can deadlock because the new pod cannot mount the PVC until the old pod releases it.
+
+The Caddy liveness probe checks the sidecar port instead of generated content. That keeps startup before the first successful build from becoming a restart loop.

--- a/docs-site/content/publishing-backends/git-push.md
+++ b/docs-site/content/publishing-backends/git-push.md
@@ -1,0 +1,45 @@
+---
+title: "Git Push"
+description: "Commit generated schema changes to a git repository for static hosting."
+weight: 120
+---
+
+The git-push sidecar pattern runs `crd-schema-publisher` in extract-only mode and periodically commits the active generated site to a git repository. It does not require Cloudflare credentials.
+
+See the complete [git-push values file](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/git-push/values.yaml).
+
+## When to Use This
+
+Use this when a git repository should be the publishing target for a static host. The example is written for GitHub, but the pattern works with GitLab, Gitea, Bitbucket, or another git host by changing the remote URL format in the sidecar command.
+
+No persistence is needed. The publisher re-extracts on startup, and the sidecar re-syncs the full generated site from the default `emptyDir`.
+
+## GitHub Pages
+
+This works well with GitHub Pages. Set the target repository's Pages source to the `gh-pages` branch, and the pushed schema site is published as static content.
+
+The sidecar handles fresh repositories by initializing the target branch and existing repositories by cloning the configured branch before applying incremental updates.
+
+If your GitHub Pages site serves from a project subpath such as `https://user.github.io/repo/`, set `config.basePath` to the repository path so generated HTML links include the prefix.
+
+## Install
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher --create-namespace \
+  -f examples/git-push/values.yaml
+```
+
+## Credentials
+
+Create a fine-grained GitHub personal access token scoped to the target repository with `contents:write` permission. Store it in the Secret key `github-token`, and store the target repository as `owner/repo` in `github-repo`.
+
+The example sets `GIT_BRANCH` to `gh-pages`. Change it only if your static host publishes from a different branch.
+
+The sidecar waits for `/data/current/index.html` before changing the repository. If that path never appears, it stays fail-closed and does not rewrite the target repository.
+
+## Resource Sizing
+
+Memory usage scales with CRD count because the initial git commit stages all files at once. `256Mi` handles about `200` CRDs; increase the limit for larger clusters.
+
+The default loop sleeps for 30 seconds between sync attempts. It can be lowered to 15 seconds safely; no-op cycles are near-zero cost.

--- a/docs-site/content/publishing-backends/github-pages.md
+++ b/docs-site/content/publishing-backends/github-pages.md
@@ -1,0 +1,24 @@
+---
+title: "GitHub Pages Subpaths"
+description: "Set a base path when serving generated schema sites from GitHub Pages project paths."
+weight: 130
+---
+
+When serving schemas from a GitHub Pages project path such as `https://user.github.io/iac/`, set the base path so generated HTML links include the subpath.
+
+```bash
+BASE_PATH=/iac
+```
+
+Or in the Helm chart:
+
+```yaml
+config:
+  basePath: "/iac"
+```
+
+Without this setting, generated links resolve against the host root and break on project Pages sites.
+
+Cloudflare Pages and root hosts do not need this setting because they serve from `/`. Cloudflare Pages users do not need to change anything for subpath handling.
+
+If you already use the first-party `git-push` or `rclone-s3` examples, update them to read `/data/current`. Older example configs fail closed after upgrading to a new image: syncing stops, but existing remote content is not deleted or overwritten.

--- a/docs-site/content/publishing-backends/s3.md
+++ b/docs-site/content/publishing-backends/s3.md
@@ -1,0 +1,55 @@
+---
+title: "S3-compatible Storage"
+description: "Sync generated schemas to S3-compatible object storage with rclone."
+weight: 110
+---
+
+The rclone sidecar pattern runs `crd-schema-publisher` in extract-only mode and syncs the active generated site to S3-compatible object storage every 60 seconds. It does not require Cloudflare credentials.
+
+See the complete [rclone S3 values file](https://github.com/sholdee/crd-schema-publisher/blob/main/examples/rclone-s3/values.yaml).
+
+## When to Use This
+
+Use this when an object storage bucket should be the static hosting source or when another CDN fronts the bucket.
+
+No persistence is needed for this example. The publisher re-extracts on startup, and the sidecar re-syncs the full generated site from the default `emptyDir`.
+
+## Install
+
+```bash
+helm install crd-schema-publisher oci://ghcr.io/sholdee/charts/crd-schema-publisher \
+  --namespace crd-schema-publisher --create-namespace \
+  -f examples/rclone-s3/values.yaml
+```
+
+## Providers
+
+Set `RCLONE_CONFIG_S3_PROVIDER` and `RCLONE_CONFIG_S3_ENDPOINT` for your backend:
+
+| Provider | `RCLONE_CONFIG_S3_PROVIDER` | `RCLONE_CONFIG_S3_ENDPOINT` |
+| --- | --- | --- |
+| AWS S3 | `AWS` | Omit to use the default AWS endpoint |
+| Backblaze B2 | `Other` | `s3.us-west-002.backblazeb2.com` |
+| MinIO | `Minio` | `https://minio.example.com` |
+| Cloudflare R2 | `Cloudflare` | `https://<account-id>.r2.cloudflarestorage.com` |
+| GCS | `GCS` | `https://storage.googleapis.com` |
+
+Set `RCLONE_S3_BUCKET` to the bucket name. It can include an optional path prefix.
+
+## Sync Semantics
+
+The sidecar waits for `/data/current/index.html` before syncing. If that path never appears, it stays fail-closed and does not delete remote content. Adjust the `sleep 60` interval in the sidecar command if you need a different sync cadence.
+
+The example runs:
+
+```bash
+rclone sync /data/current s3:${RCLONE_S3_BUCKET} --exclude "/_meta/**" --checksum --verbose --transfers 4
+```
+
+Warning: `rclone sync` is one-way and deletes destination files that no longer exist locally. If you want additive-only behavior and never want remote files deleted, replace `rclone sync` with `rclone copy` in the sidecar command.
+
+## Credentials
+
+The example creates an inline Kubernetes Secret with `access-key-id`, `secret-access-key`, and `bucket-name` placeholder values. Replace those values, use your preferred secret manager, or point the `secretKeyRef` entries at a pre-created Secret.
+
+All rclone configuration is provided through `RCLONE_CONFIG_*` environment variables, and `RCLONE_CONFIG` is set to an empty string to suppress default config file lookup.

--- a/docs-site/content/reference/commands.md
+++ b/docs-site/content/reference/commands.md
@@ -1,0 +1,37 @@
+---
+title: "Commands"
+description: "CLI commands, output directory behavior, filters, and command-specific flags."
+weight: 160
+---
+
+## Command Behavior
+
+```text
+crd-schema-publisher [command]
+
+Commands:
+  run       Extract schemas and upload to Cloudflare Pages when credentials are configured (default)
+  extract   Extract schemas from a Kubernetes cluster
+  convert   Convert CRD YAML files and Kubernetes OpenAPI built-ins to JSON Schema
+  upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
+  watch     Watch for CRD changes and upload when credentials are configured
+  preview   Serve a local preview of the documentation site
+```
+
+| Command(s)               | Output directory behavior                                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `extract`                | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; does not fall back to `/output`.                      |
+| `convert`                | Requires `--output-dir`/`-o`; does not read `OUTPUT_DIR`.                                                    |
+| `run`, `watch`, `upload` | Accept `--output-dir`/`-o`; output root must already exist.                                                  |
+| `preview`                | Uses sample data by default; reads real extracted output only when `--output-dir`/`-o` is passed explicitly. |
+
+| Command(s)                | Filters and command-specific flags                                                                                                                                                                   |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run`, `extract`, `watch` | Support comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters. Defaults can also come from `SCHEMA_FILTER_KIND`, `SCHEMA_FILTER_GROUP`, and `SCHEMA_FILTER_VERSION`.        |
+| `run`, `extract`, `watch` | Support `--include-builtins`/`SCHEMA_INCLUDE_BUILTINS` to include built-ins from the API server OpenAPI v2 document.                                                                                 |
+| `run`, `extract`, `watch` | Support `--include-kustomize`/`SCHEMA_INCLUDE_KUSTOMIZE` to include kustomize's client-side config schemas.                                                                                          |
+| `extract`                 | Supports `--context`, `--base-path`, and `--skip-render`.                                                                                                                                            |
+| `convert`                 | Supports comma-separated, case-insensitive `--kind`, `--group`, and `--version` filters for CRD YAML and OpenAPI inputs.                                                                             |
+| `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
+| `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
+| `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` and `Component` schemas, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                             |

--- a/docs-site/content/reference/configuration.md
+++ b/docs-site/content/reference/configuration.md
@@ -1,0 +1,39 @@
+---
+title: "Configuration"
+description: "Environment variables and runtime configuration behavior."
+weight: 150
+---
+
+## Environment Variables
+
+Deployment/runtime configuration is primarily via environment variables. For local CLI use, `extract`, `convert`, `run`, `watch`, `upload`, and `preview` also expose command-specific flags such as `--output-dir`/`-o`. Variables marked _(watch)_ apply only to watch mode deployment.
+
+| Variable                   | Required    | Default                | Description                                                                                                           |
+| -------------------------- | ----------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`     | Upload only | -                      | Cloudflare API token with Pages permissions                                                                           |
+| `CLOUDFLARE_ACCOUNT_ID`    | Upload only | -                      | Cloudflare account ID                                                                                                 |
+| `CF_PAGES_PROJECT`         | No          | `kubernetes-schemas`   | Cloudflare Pages project name                                                                                         |
+| `OUTPUT_DIR`               | No          | `/output`              | Site output root. The active snapshot is exposed at `OUTPUT_DIR/current`                                              |
+| `KUBECTL_CONTEXT`          | No          | -                      | Kubernetes context name (local development only)                                                                      |
+| `DEBOUNCE_SECONDS`         | No          | `15`                   | Seconds to wait after last CRD event before publishing (watch mode)                                                   |
+| `POD_NAME`                 | Yes (watch) | -                      | Pod identity for leader election (set via downward API)                                                               |
+| `POD_NAMESPACE`            | Yes (watch) | -                      | Namespace for leader lease (set via downward API)                                                                     |
+| `LEASE_NAME`               | No          | `crd-schema-publisher` | Name of the Lease resource (watch mode)                                                                               |
+| `HEALTH_PORT`              | No          | `8080`                 | Port for liveness/readiness probes (watch mode)                                                                       |
+| `SERVE_SITE`               | No          | -                      | Set to `true` to serve `OUTPUT_DIR/current` from watch mode                                                           |
+| `SITE_PORT`                | No          | `8081`                 | Non-privileged static site server port when `SERVE_SITE=true`                                                         |
+| `SERVE_ACCESS_LOG`         | No          | -                      | Set to `true` to log each request served by the built-in static site server                                           |
+| `PREVIEW_ADDR`             | No          | `127.0.0.1:8989`       | Listen address for preview server (preview mode)                                                                      |
+| `SKIP_RENDER`              | No          | -                      | Set to `true` to skip HTML schema page rendering                                                                      |
+| `UPLOAD_BUCKET_SIZE_BYTES` | No          | `41943040`             | Cloudflare upload bucket size in bytes. Lower values reduce peak upload memory at the cost of more requests           |
+| `UPLOAD_CONCURRENCY`       | No          | `3`                    | Concurrent Cloudflare upload buckets. Lower values reduce peak upload memory at the cost of slower cache-miss uploads |
+| `BASE_PATH`                | No          | -                      | URL path prefix for subpath deployments (e.g., `/iac` for GitHub Pages at `user.github.io/iac/`)                      |
+| `SCHEMA_INCLUDE_BUILTINS`  | No          | -                      | Set to `true` to include Kubernetes built-ins from API server OpenAPI v2 (`run`, `extract`, `watch`)                  |
+| `SCHEMA_INCLUDE_KUSTOMIZE` | No          | -                      | Set to `true` to include kustomize's client-side config schemas (`run`, `extract`, `watch`)                           |
+| `SCHEMA_FILTER_KIND`       | No          | -                      | Restrict generated schemas to matching CRD kinds, comma-separated and case-insensitive (`run`, `extract`, `watch`)    |
+| `SCHEMA_FILTER_GROUP`      | No          | -                      | Restrict generated schemas to matching API groups, comma-separated and case-insensitive (`run`, `extract`, `watch`)   |
+| `SCHEMA_FILTER_VERSION`    | No          | -                      | Restrict generated schemas to matching API versions, comma-separated and case-insensitive (`run`, `extract`, `watch`) |
+
+Schema filters limit generated output only. In watch mode, the controller still watches all cluster CRDs and applies the filters during each publish cycle. If active filters match no CRDs or built-ins and Kustomize is not enabled, runtime builds publish an empty catalog instead of leaving stale schemas in place.
+
+Runtime modes stay CRD-only unless opt-ins are enabled. `--include-builtins` reads `/openapi/v2` from the API server and publishes built-ins into the same generation. `--include-kustomize` adds kustomize's client-side config schemas. Filters apply to CRDs and built-ins; Kustomize is explicit and unfiltered.

--- a/docs-site/content/using-schemas/_index.md
+++ b/docs-site/content/using-schemas/_index.md
@@ -1,0 +1,49 @@
+---
+title: "Using Schemas"
+description: "Use published schemas with yaml-language-server, VS Code, and kubeconform."
+weight: 140
+---
+
+Once published, your schemas are available at `https://<your-pages-domain>/<apigroup>/<kind>_<version>.json`. Core built-ins use the `core` group path, such as `core/pod_v1.json`. The published site also includes a browsable index with search and interactive HTML documentation for each schema.
+
+## IDE Validation (yaml-language-server)
+
+Add a modeline to any YAML file. Works in VS Code, Neovim, Helix, and any editor with yaml-language-server:
+
+```yaml
+# yaml-language-server: $schema=https://kube-schemas.example.com/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example
+```
+
+Or configure schemas globally in VS Code:
+
+```jsonc
+// .vscode/settings.json
+{
+  "yaml.schemas": {
+    "https://kube-schemas.example.com/cert-manager.io/certificate_v1.json": ["**/certificates/*.yaml"],
+  },
+}
+```
+
+## CI Validation (kubeconform)
+
+If your registry includes built-ins from runtime `--include-builtins` or offline `convert --openapi`, point kubeconform at both the `core` path and the grouped path:
+
+```bash
+kubeconform \
+  -strict \
+  -ignore-missing-schemas \
+  -schema-location 'https://kube-schemas.example.com/core/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+  -schema-location 'https://kube-schemas.example.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+  manifests/*.yaml
+```
+
+This project validates its own Helm chart manifests against its published schema registry in CI - see the `helm-lint` job in [`.github/workflows/ci.yaml`](https://github.com/sholdee/crd-schema-publisher/blob/main/.github/workflows/ci.yaml) for a working example.
+
+This validates Kubernetes built-ins and CRDs against the same published schema snapshot. If you publish only CRDs, keep `-schema-location default` before your custom registry path so kubeconform still validates built-ins.
+
+> **Note:** Schema files are written as lowercase (e.g., `certificate_v1.json`) while `{{.ResourceKind}}` expands to the original case (e.g., `Certificate`). This works on Cloudflare Pages because it serves paths case-insensitively - the same convention used by [datreeio/CRDs-catalog](https://github.com/datreeio/CRDs-catalog). If serving schemas from a case-sensitive host, use lowercase kind names in your template paths.

--- a/docs-site/hugo.yaml
+++ b/docs-site/hugo.yaml
@@ -8,6 +8,10 @@ disableKinds:
 params:
   description: "CRD docs and IDE validation, straight from the cluster."
   repositoryURL: "https://github.com/sholdee/crd-schema-publisher"
+  repositoryName: "sholdee/crd-schema-publisher"
+  repositoryLatestVersion: "2026.603.41610"
+  repositoryStars: "22"
+  repositoryForks: "2"
   demoURL: "https://kube-schemas.shold.io"
   installerURL: "https://crdsp.shold.io"
 

--- a/docs-site/hugo.yaml
+++ b/docs-site/hugo.yaml
@@ -1,0 +1,153 @@
+baseURL: "https://sholdee.github.io/crd-schema-publisher/"
+title: "crd-schema-publisher"
+locale: "en-US"
+disableKinds:
+  - taxonomy
+  - term
+
+params:
+  description: "CRD docs and IDE validation, straight from the cluster."
+  repositoryURL: "https://github.com/sholdee/crd-schema-publisher"
+  demoURL: "https://kube-schemas.shold.io"
+  installerURL: "https://crdsp.shold.io"
+
+outputs:
+  home:
+    - html
+    - search
+
+outputFormats:
+  search:
+    mediaType: application/json
+    baseName: index.search
+    isPlainText: true
+    notAlternative: true
+
+menus:
+  docs:
+    - name: Overview
+      url: ""
+      params:
+        group: Start
+      weight: 10
+    - name: Getting Started
+      url: getting-started/
+      params:
+        group: Start
+      weight: 20
+    - name: Installation
+      url: installation/
+      params:
+        group: Start
+      weight: 30
+    - name: Artifact Verification
+      url: installation/verification/
+      params:
+        group: Start
+      weight: 40
+    - name: Deploying
+      url: deploying/
+      params:
+        group: Deployment
+      weight: 50
+    - name: Helm Chart
+      url: deploying/helm/
+      params:
+        group: Deployment
+      weight: 60
+    - name: Raw Manifests
+      url: deploying/raw-manifests/
+      params:
+        group: Deployment
+      weight: 70
+    - name: Publishing Backends
+      url: publishing-backends/
+      params:
+        group: Backends
+      weight: 80
+    - name: Built-in Server
+      url: publishing-backends/built-in-server/
+      params:
+        group: Backends
+      weight: 90
+    - name: Caddy Sidecar
+      url: publishing-backends/caddy-sidecar/
+      params:
+        group: Backends
+      weight: 100
+    - name: S3-compatible Storage
+      url: publishing-backends/s3/
+      params:
+        group: Backends
+      weight: 110
+    - name: Git Push
+      url: publishing-backends/git-push/
+      params:
+        group: Backends
+      weight: 120
+    - name: GitHub Pages Subpaths
+      url: publishing-backends/github-pages/
+      params:
+        group: Backends
+      weight: 130
+    - name: Using Schemas
+      url: using-schemas/
+      params:
+        group: Usage
+      weight: 140
+    - name: Configuration
+      url: reference/configuration/
+      params:
+        group: Reference
+      weight: 150
+    - name: Commands
+      url: reference/commands/
+      params:
+        group: Reference
+      weight: 160
+    - name: Monitoring
+      url: operations/monitoring/
+      params:
+        group: Operations
+      weight: 170
+    - name: Output Structure
+      url: operations/output-structure/
+      params:
+        group: Operations
+      weight: 180
+    - name: How It Works
+      url: concepts/how-it-works/
+      params:
+        group: Concepts
+      weight: 190
+    - name: Development
+      url: development/
+      params:
+        group: Project
+      weight: 200
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+  tableOfContents:
+    startLevel: 2
+    endLevel: 3
+    ordered: false
+  highlight:
+    noClasses: false
+
+module:
+  mounts:
+    - source: content
+      target: content
+    - source: layouts
+      target: layouts
+    - source: assets
+      target: assets
+    - source: static
+      target: static
+    - source: ../docs/assets
+      target: static/assets
+    - source: ../docs/screenshots
+      target: static/screenshots

--- a/docs-site/layouts/_default/baseof.html
+++ b/docs-site/layouts/_default/baseof.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="{{ site.Language.Locale | default "en" }}">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    {{ partial "header.html" . }}
+    {{- $hasToc := gt (len .Fragments.Headings) 0 -}}
+    <div class="site-shell{{ if not $hasToc }} no-toc{{ end }}">
+      <aside class="site-sidebar" aria-label="Documentation navigation">
+        {{ partial "sidebar.html" . }}
+      </aside>
+      <main id="main-content" class="site-main" tabindex="-1">
+        {{ block "main" . }}{{ end }}
+      </main>
+      {{ if $hasToc }}
+        <aside class="site-toc" aria-label="Page table of contents">
+          {{ partial "toc.html" . }}
+        </aside>
+      {{ end }}
+    </div>
+    <footer class="site-footer">
+      <span>crd-schema-publisher documentation</span>
+      <span>CRD docs and IDE validation, straight from the cluster.</span>
+    </footer>
+  </body>
+</html>

--- a/docs-site/layouts/_default/list.html
+++ b/docs-site/layouts/_default/list.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+  <article class="doc-content">
+    <header class="doc-header">
+      <p class="eyebrow">{{ .Section | humanize }}</p>
+      <h1>{{ partial "title.html" . }}</h1>
+      {{ with .Params.description }}<p class="lead">{{ . }}</p>{{ end }}
+    </header>
+    {{ .Content }}
+    {{ if .Pages }}
+      <div class="page-list">
+        {{ range .Pages.ByWeight }}
+          <a class="page-list-item" href="{{ .RelPermalink }}">
+            <span>{{ .Title }}</span>
+            {{ with .Params.description }}<small>{{ . }}</small>{{ end }}
+          </a>
+        {{ end }}
+      </div>
+    {{ end }}
+  </article>
+{{ end }}

--- a/docs-site/layouts/_default/single.html
+++ b/docs-site/layouts/_default/single.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+  <article class="doc-content">
+    <header class="doc-header">
+      <p class="eyebrow">{{ .Section | humanize }}</p>
+      <h1>{{ partial "title.html" . }}</h1>
+      {{ with .Params.description }}<p class="lead">{{ . }}</p>{{ end }}
+    </header>
+    {{ .Content }}
+  </article>
+{{ end }}

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
   <article class="doc-content home-content">
+    <h1>{{ .Title }}</h1>
     {{ .Content }}
   </article>
 {{ end }}

--- a/docs-site/layouts/index.html
+++ b/docs-site/layouts/index.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+  <article class="doc-content home-content">
+    {{ .Content }}
+  </article>
+{{ end }}

--- a/docs-site/layouts/index.search.json
+++ b/docs-site/layouts/index.search.json
@@ -1,0 +1,15 @@
+{{- $pages := slice -}}
+{{- range where site.Pages "Kind" "in" (slice "page" "section") -}}
+  {{- $url := .RelPermalink -}}
+  {{- if and (not .IsHome) $url -}}
+    {{- $title := partial "title.html" . -}}
+    {{- $pages = $pages | append (dict
+      "title" ($title | plainify)
+      "url" $url
+      "section" (.Section | plainify)
+      "summary" (.Summary | plainify | htmlUnescape)
+      "content" (.Plain | plainify | htmlUnescape | truncate 4000)
+    ) -}}
+  {{- end -}}
+{{- end -}}
+{{- $pages | jsonify -}}

--- a/docs-site/layouts/partials/head.html
+++ b/docs-site/layouts/partials/head.html
@@ -1,0 +1,11 @@
+{{- $pageTitle := partial "title.html" . -}}
+{{- $description := site.Params.description | default "crd-schema-publisher documentation" -}}
+{{- $styles := resources.Get "css/site.css" | minify | fingerprint -}}
+{{- $script := resources.Get "js/site.js" | minify | fingerprint -}}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="{{ $description }}">
+<title>{{ if .IsHome }}{{ site.Title }} documentation{{ else }}{{ $pageTitle }} | {{ site.Title }}{{ end }}</title>
+<link rel="icon" type="image/svg+xml" href="{{ "assets/logo.svg" | relURL }}">
+<link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
+<script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}" defer></script>

--- a/docs-site/layouts/partials/header.html
+++ b/docs-site/layouts/partials/header.html
@@ -10,12 +10,6 @@
       <a href="{{ relURL "deploying/helm/" }}">Helm</a>
       <a href="{{ relURL "reference/configuration/" }}">Reference</a>
       <a href="{{ site.Params.demoURL }}">Live Demo</a>
-      <a class="github-link" href="{{ site.Params.repositoryURL }}">
-        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
-          <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
-        </svg>
-        <span>GitHub</span>
-      </a>
     </div>
     <form class="site-search" role="search" data-search-index="{{ "index.search.json" | relURL }}">
       <label class="visually-hidden" for="site-search-input">Search documentation</label>
@@ -32,5 +26,43 @@
         <ul id="site-search-results" role="listbox" aria-label="Search results"></ul>
       </div>
     </form>
+    <a
+      class="github-card"
+      href="{{ site.Params.repositoryURL }}"
+      data-github-repo="{{ site.Params.repositoryName }}"
+      data-github-repository-api="https://api.github.com/repos/{{ site.Params.repositoryName }}"
+      data-github-release-api="https://api.github.com/repos/{{ site.Params.repositoryName }}/releases/latest"
+      aria-label="{{ site.Params.repositoryName }} on GitHub, latest release {{ site.Params.repositoryLatestVersion }}, {{ site.Params.repositoryStars }} stars, {{ site.Params.repositoryForks }} forks"
+    >
+      <svg class="github-card-mark" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+        <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
+      </svg>
+      <span class="github-card-repo" data-github-field="repo">{{ site.Params.repositoryName }}</span>
+      <span class="github-card-meta">
+        <span class="github-card-stat github-card-version">
+          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" focusable="false">
+            <path d="M2.25 2.25h4.1L13.75 9.65l-4.1 4.1-7.4-7.4v-4.1Z"/>
+            <path d="M4.9 5.15h.01"/>
+          </svg>
+          <span data-github-field="version">{{ site.Params.repositoryLatestVersion }}</span>
+        </span>
+        <span class="github-card-stat">
+          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" focusable="false">
+            <path d="m8 1.75 1.93 3.91 4.32.63-3.13 3.05.74 4.3L8 11.61l-3.86 2.03.74-4.3-3.13-3.05 4.32-.63L8 1.75Z"/>
+          </svg>
+          <span data-github-field="stars">{{ site.Params.repositoryStars }}</span>
+        </span>
+        <span class="github-card-stat">
+          <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" focusable="false">
+            <circle cx="4" cy="3.5" r="1.5"/>
+            <circle cx="12" cy="3.5" r="1.5"/>
+            <circle cx="4" cy="12.5" r="1.5"/>
+            <path d="M4 5v6"/>
+            <path d="M12 5c-.25 2-1.7 3-4.35 3H6.5A2.5 2.5 0 0 0 4 10.5"/>
+          </svg>
+          <span data-github-field="forks">{{ site.Params.repositoryForks }}</span>
+        </span>
+      </span>
+    </a>
   </nav>
 </header>

--- a/docs-site/layouts/partials/header.html
+++ b/docs-site/layouts/partials/header.html
@@ -1,0 +1,36 @@
+<header class="site-header">
+  <nav class="header-nav" aria-label="Primary">
+    <a class="brand-link" href="{{ site.Home.RelPermalink }}" aria-label="crd-schema-publisher documentation home">
+      <img src="{{ "assets/logo.svg" | relURL }}" alt="" width="32" height="32">
+      <span>crd-schema-publisher</span>
+    </a>
+    <div class="header-links">
+      <a href="{{ site.Home.RelPermalink }}">Overview</a>
+      <a href="{{ relURL "getting-started/" }}">Getting Started</a>
+      <a href="{{ relURL "deploying/helm/" }}">Helm</a>
+      <a href="{{ relURL "reference/configuration/" }}">Reference</a>
+      <a href="{{ site.Params.demoURL }}">Live Demo</a>
+      <a class="github-link" href="{{ site.Params.repositoryURL }}">
+        <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+          <path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.19-3.37-1.19-.45-1.15-1.11-1.46-1.11-1.46-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.93 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.03c.85 0 1.7.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.83-2.34 4.67-4.57 4.92.36.31.68.92.68 1.86v2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
+    </div>
+    <form class="site-search" role="search" data-search-index="{{ "index.search.json" | relURL }}">
+      <label class="visually-hidden" for="site-search-input">Search documentation</label>
+      <input
+        id="site-search-input"
+        name="q"
+        type="search"
+        autocomplete="off"
+        placeholder="Search docs"
+        aria-controls="site-search-results"
+        aria-expanded="false"
+      >
+      <div class="search-panel" hidden>
+        <ul id="site-search-results" role="listbox" aria-label="Search results"></ul>
+      </div>
+    </form>
+  </nav>
+</header>

--- a/docs-site/layouts/partials/sidebar.html
+++ b/docs-site/layouts/partials/sidebar.html
@@ -1,0 +1,22 @@
+<nav class="docs-nav">
+  <p class="nav-heading">Docs</p>
+  {{ $groups := slice "Start" "Deployment" "Backends" "Usage" "Reference" "Operations" "Concepts" "Project" }}
+  {{ range $group := $groups }}
+    <div class="nav-section">
+      <p class="nav-section-heading">{{ $group }}</p>
+      <ul>
+        {{ range site.Menus.docs }}
+          {{ if eq (.Params.group | default "Reference") $group }}
+            {{- $entryURL := relURL .URL -}}
+            {{- $active := eq $entryURL $.RelPermalink -}}
+            <li>
+              <a href="{{ $entryURL }}"{{ if $active }} class="is-active" aria-current="page"{{ end }}>
+                {{ .Name }}
+              </a>
+            </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    </div>
+  {{ end }}
+</nav>

--- a/docs-site/layouts/partials/title.html
+++ b/docs-site/layouts/partials/title.html
@@ -1,0 +1,5 @@
+{{- with .Title -}}
+  {{- . -}}
+{{- else -}}
+  {{- site.Title -}}
+{{- end -}}

--- a/docs-site/layouts/partials/toc.html
+++ b/docs-site/layouts/partials/toc.html
@@ -1,0 +1,4 @@
+{{ if gt (len .Fragments.Headings) 0 }}
+  <p class="toc-heading">On This Page</p>
+  {{ .TableOfContents }}
+{{ end }}


### PR DESCRIPTION
## Summary
- Split the long README into a concise project overview that routes readers to the docs site.
- Add a Hugo docs site under `docs-site/` with migrated content, navigation, search, visual polish, and responsive behavior.
- Add GitHub Pages publishing workflow and docs checks in CI.

## Test Plan
- `go test ./...`
- `git diff --check main...HEAD`
- `/tmp/hugo-0.162.1/pkg/Payload/hugo --source docs-site --destination /tmp/crd-schema-publisher-docs-site --cleanDestinationDir --minify`
- Browser probes for GitHub header behavior, mobile header behavior, and heading sizing against the local preview.