### PR TITLE
docs: fix docs site accessibility issues

### DIFF
--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -511,6 +511,16 @@ a:hover {
   height: auto;
 }
 
+.doc-content a {
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+}
+
+.doc-content a:hover {
+  text-decoration-thickness: 0.12em;
+}
+
 .doc-content code {
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -637,9 +647,10 @@ a:hover {
   color: var(--accent);
 }
 
-.heading-permalink {
+.doc-content .heading-permalink {
   opacity: 0;
   font-size: 0.85em;
+  text-decoration: none;
 }
 
 h2:hover .heading-permalink,

--- a/docs-site/assets/js/site.js
+++ b/docs-site/assets/js/site.js
@@ -11,6 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   initGitHubCard();
   initShellCommandHighlighting();
+  initAccessibleTables();
 
   let copyButtonIndex = 0;
   document.querySelectorAll(".doc-content pre").forEach((block) => {
@@ -46,6 +47,29 @@ document.addEventListener("DOMContentLoaded", () => {
     heading.append(" ", link);
   });
 });
+
+function initAccessibleTables() {
+  document.querySelectorAll(".doc-content table").forEach((table, index) => {
+    if (!table.hasAttribute("tabindex")) {
+      table.tabIndex = 0;
+    }
+    if (!table.hasAttribute("aria-label")) {
+      const label = nearestTableHeading(table) || `Data table ${index + 1}`;
+      table.setAttribute("aria-label", label);
+    }
+  });
+}
+
+function nearestTableHeading(table) {
+  let current = table.previousElementSibling;
+  while (current) {
+    if (/^H[2-6]$/.test(current.tagName)) {
+      return `${current.textContent.trim()} table`;
+    }
+    current = current.previousElementSibling;
+  }
+  return "";
+}
 
 const GITHUB_CARD_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 

--- a/docs-site/layouts/partials/header.html
+++ b/docs-site/layouts/partials/header.html
@@ -17,8 +17,10 @@
         id="site-search-input"
         name="q"
         type="search"
+        role="combobox"
         autocomplete="off"
         placeholder="Search docs"
+        aria-autocomplete="list"
         aria-controls="site-search-results"
         aria-expanded="false"
       >

--- a/docs-site/layouts/partials/sidebar.html
+++ b/docs-site/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<nav class="docs-nav">
+<nav class="docs-nav" aria-label="Docs menu">
   <p class="nav-heading">Docs</p>
   {{ $groups := slice "Start" "Deployment" "Backends" "Usage" "Reference" "Operations" "Concepts" "Project" }}
   {{ range $group := $groups }}


### PR DESCRIPTION
## Summary
- add valid combobox semantics to docs search
- give the docs navigation landmark a unique label
- underline body content links so links are not color-only
- make docs tables keyboard-focusable when horizontally scrollable

## Verification
- node --check docs-site/assets/js/site.js
- /tmp/hugo-0.162.1/pkg/Payload/hugo --source docs-site --baseURL http://127.0.0.1:1317/crd-schema-publisher/
- BASE_URL=http://127.0.0.1:1317/crd-schema-publisher/ node /tmp/crdsp-axe-scan.mjs
  - axe-core 4.12.0
  - scannedPages: 23
  - scannedContexts: 46
  - violations: []