### PR TITLE
ci: add release note labeling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 ## Checklist
 
+- [ ] PR title starts with a release-note type (`feat`, `fix`, `docs`, `deps`, `refactor`, `perf`, `revert`, `ci`, `build`, `test`, or `chore`)
 - [ ] Tests pass (`go test ./...`)
 - [ ] Linter passes (`golangci-lint run`)
 - [ ] Pre-commit hook enabled (`git config core.hooksPath .githooks`)

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - feat
+    - title: Fixes
+      labels:
+        - fix
+    - title: Documentation
+      labels:
+        - docs
+    - title: Dependencies
+      labels:
+        - deps
+    - title: Code Refactoring
+      labels:
+        - refactor
+    - title: Performance Improvements
+      labels:
+        - perf
+    - title: Reverts
+      labels:
+        - revert
+    - title: Maintenance
+      labels:
+        - ci
+        - build
+        - test
+        - chore
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-release-labels.yml
+++ b/.github/workflows/pr-release-labels.yml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: PR Release Labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: pr-release-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  release-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Sync release labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./hack/release-labeler

--- a/hack/release-labeler/main.go
+++ b/hack/release-labeler/main.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/sholdee/crd-schema-publisher/hack/releaselabels"
+)
+
+type eventPayload struct {
+	PullRequest *struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		User   struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	} `json:"pull_request"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	eventPath := os.Getenv("GITHUB_EVENT_PATH")
+	repository := os.Getenv("GITHUB_REPOSITORY")
+	if eventPath == "" {
+		return errors.New("GITHUB_EVENT_PATH is required")
+	}
+	if repository == "" {
+		return errors.New("GITHUB_REPOSITORY is required")
+	}
+
+	event, err := readEvent(eventPath)
+	if err != nil {
+		return err
+	}
+	if event.PullRequest == nil {
+		return errors.New("release-labeler requires a pull_request event payload")
+	}
+
+	result := releaselabels.ForPullRequest(releaselabels.PullRequest{
+		Title:  event.PullRequest.Title,
+		Body:   event.PullRequest.Body,
+		Author: event.PullRequest.User.Login,
+	})
+
+	client := ghClient{}
+	if err := syncPullRequestLabels(client, repository, event.PullRequest.Number, result.Labels); err != nil {
+		return err
+	}
+	if !result.Recognized {
+		return fmt.Errorf(
+			"PR title must start with a release-note type: %s\nExamples: feat(index): add grouping, fix(renderer): improve layout, docs: update install guide",
+			strings.Join(releaselabels.PrimaryLabelNames(), ", "),
+		)
+	}
+
+	fmt.Printf("Applied release labels: %s\n", strings.Join(result.Labels, ", "))
+	return nil
+}
+
+func readEvent(path string) (eventPayload, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return eventPayload{}, fmt.Errorf("reading event payload: %w", err)
+	}
+
+	var event eventPayload
+	if err := json.Unmarshal(data, &event); err != nil {
+		return eventPayload{}, fmt.Errorf("parsing event payload: %w", err)
+	}
+	return event, nil
+}
+
+type ghClient struct{}
+
+func syncPullRequestLabels(client ghClient, repository string, number int, desiredLabels []string) error {
+	if err := ensureRepositoryLabels(client, repository); err != nil {
+		return err
+	}
+
+	existing, err := currentIssueLabels(client, repository, number)
+	if err != nil {
+		return err
+	}
+
+	desired := stringSet(desiredLabels)
+	managed := stringSet(releaselabels.ManagedLabelNames())
+	for _, label := range existing {
+		if _, isManaged := managed[label]; !isManaged {
+			continue
+		}
+		if _, shouldKeep := desired[label]; shouldKeep {
+			continue
+		}
+		if err := deleteIssueLabel(client, repository, number, label); err != nil {
+			return err
+		}
+	}
+
+	if len(desiredLabels) == 0 {
+		return nil
+	}
+
+	if _, err := client.run("issue", "edit", strconv.Itoa(number), "--repo", repository, "--add-label", strings.Join(desiredLabels, ",")); err != nil {
+		return fmt.Errorf("applying labels: %w", err)
+	}
+	return nil
+}
+
+func ensureRepositoryLabels(client ghClient, repository string) error {
+	for _, label := range releaselabels.LabelSpecs() {
+		if err := ensureRepositoryLabel(client, repository, label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureRepositoryLabel(client ghClient, repository string, label releaselabels.LabelSpec) error {
+	if _, err := client.run(
+		"label",
+		"create",
+		label.Name,
+		"--repo",
+		repository,
+		"--color",
+		label.Color,
+		"--description",
+		label.Description,
+		"--force",
+	); err != nil {
+		return fmt.Errorf("ensuring label %q: %w", label.Name, err)
+	}
+	return nil
+}
+
+func currentIssueLabels(client ghClient, repository string, number int) ([]string, error) {
+	output, err := client.run("api", fmt.Sprintf("repos/%s/issues/%d/labels", repository, number), "--jq", ".[].name")
+	if err != nil {
+		return nil, fmt.Errorf("listing current labels: %w", err)
+	}
+
+	var labels []string
+	for _, line := range strings.Split(output, "\n") {
+		label := strings.TrimSpace(line)
+		if label != "" {
+			labels = append(labels, label)
+		}
+	}
+	return labels, nil
+}
+
+func deleteIssueLabel(client ghClient, repository string, number int, label string) error {
+	if _, err := client.run("issue", "edit", strconv.Itoa(number), "--repo", repository, "--remove-label", label); err != nil {
+		return fmt.Errorf("deleting stale label %q: %w", label, err)
+	}
+	return nil
+}
+
+func (ghClient) run(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	cmd.Env = os.Environ()
+	if token := firstNonEmpty(os.Getenv("GH_TOKEN"), os.Getenv("GITHUB_TOKEN")); token != "" {
+		cmd.Env = append(cmd.Env, "GH_TOKEN="+token)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("gh %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}

--- a/hack/releaselabels/labels.go
+++ b/hack/releaselabels/labels.go
@@ -1,0 +1,155 @@
+package releaselabels
+
+import (
+	"regexp"
+	"strings"
+)
+
+// PullRequest contains the PR fields used for release-note labeling.
+type PullRequest struct {
+	Title  string
+	Body   string
+	Author string
+}
+
+// Result describes the release labels derived from a PR.
+type Result struct {
+	Labels     []string
+	Recognized bool
+}
+
+// LabelSpec is the repository label definition managed by the labeler.
+type LabelSpec struct {
+	Name        string
+	Color       string
+	Description string
+}
+
+var labelSpecs = []LabelSpec{
+	{Name: "feat", Color: "0e8a16", Description: "Release notes: user-facing feature"},
+	{Name: "fix", Color: "d73a4a", Description: "Release notes: bug fix"},
+	{Name: "docs", Color: "0075ca", Description: "Release notes: documentation"},
+	{Name: "deps", Color: "0366d6", Description: "Release notes: dependency update"},
+	{Name: "refactor", Color: "fbca04", Description: "Release notes: code refactoring"},
+	{Name: "perf", Color: "1d76db", Description: "Release notes: performance improvement"},
+	{Name: "revert", Color: "b60205", Description: "Release notes: reverted change"},
+	{Name: "ci", Color: "5319e7", Description: "Release notes: CI workflow maintenance"},
+	{Name: "build", Color: "5319e7", Description: "Release notes: build or packaging maintenance"},
+	{Name: "test", Color: "5319e7", Description: "Release notes: test maintenance"},
+	{Name: "chore", Color: "cfd3d7", Description: "Release notes: maintenance"},
+	{Name: "breaking", Color: "b60205", Description: "Release notes: breaking change"},
+}
+
+var primaryLabelNames = []string{"feat", "fix", "docs", "deps", "refactor", "perf", "revert", "ci", "build", "test", "chore"}
+
+var (
+	conventionalTitleRE = regexp.MustCompile(`(?i)^([a-z]+)(?:\(([^)]+)\))?(!)?:\s+.+`)
+	breakingTitleRE     = regexp.MustCompile(`(?i)^[a-z]+(?:\([^)]+\))?!:`)
+	breakingBodyRE      = regexp.MustCompile(`(?im)^BREAKING[ -]CHANGE:`)
+	titleLabels         = map[string]string{
+		"feat":     "feat",
+		"fix":      "fix",
+		"docs":     "docs",
+		"deps":     "deps",
+		"ci":       "ci",
+		"build":    "build",
+		"test":     "test",
+		"chore":    "chore",
+		"refactor": "refactor",
+		"perf":     "perf",
+		"revert":   "revert",
+		"style":    "chore",
+	}
+	primaryLabels = map[string]struct{}{
+		"feat":     {},
+		"fix":      {},
+		"docs":     {},
+		"deps":     {},
+		"refactor": {},
+		"perf":     {},
+		"revert":   {},
+		"ci":       {},
+		"build":    {},
+		"test":     {},
+		"chore":    {},
+	}
+)
+
+// LabelSpecs returns a defensive copy of the managed label definitions.
+func LabelSpecs() []LabelSpec {
+	specs := make([]LabelSpec, len(labelSpecs))
+	copy(specs, labelSpecs)
+	return specs
+}
+
+// ManagedLabelNames returns the labels that the PR labeler may add or remove.
+func ManagedLabelNames() []string {
+	names := make([]string, 0, len(labelSpecs))
+	for _, spec := range labelSpecs {
+		names = append(names, spec.Name)
+	}
+	return names
+}
+
+// PrimaryLabelNames returns labels accepted as the main release-note type.
+func PrimaryLabelNames() []string {
+	names := make([]string, len(primaryLabelNames))
+	copy(names, primaryLabelNames)
+	return names
+}
+
+// ForPullRequest maps a PR title/body/author to release-note labels.
+func ForPullRequest(pr PullRequest) Result {
+	var labels []string
+	primary := "deps"
+	if !isBotAuthor(pr.Author) {
+		primary = labelForTitle(pr.Title)
+	}
+	if primary != "" {
+		labels = append(labels, primary)
+	}
+	if primary != "" && isBreakingChange(pr.Title, pr.Body) {
+		labels = append(labels, "breaking")
+	}
+
+	return Result{
+		Labels:     labels,
+		Recognized: hasPrimaryLabel(labels),
+	}
+}
+
+func labelForTitle(title string) string {
+	match := conventionalTitleRE.FindStringSubmatch(strings.TrimSpace(title))
+	if match == nil {
+		return ""
+	}
+
+	typ := strings.ToLower(match[1])
+	scope := strings.ToLower(match[2])
+	if typ == "deps" || scope == "deps" || scope == "dependencies" {
+		return "deps"
+	}
+	return titleLabels[typ]
+}
+
+func isBreakingChange(title, body string) bool {
+	return breakingTitleRE.MatchString(strings.TrimSpace(title)) || breakingBodyRE.MatchString(body)
+}
+
+func hasPrimaryLabel(labels []string) bool {
+	for _, label := range labels {
+		if _, ok := primaryLabels[label]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isBotAuthor(author string) bool {
+	login := strings.ToLower(author)
+	return strings.HasSuffix(login, "[bot]") ||
+		strings.HasPrefix(login, "app/") ||
+		strings.Contains(login, "dependabot") ||
+		strings.Contains(login, "renovate") ||
+		strings.Contains(login, "pull-bunyan")
+}

--- a/hack/releaselabels/labels_test.go
+++ b/hack/releaselabels/labels_test.go
@@ -1,0 +1,148 @@
+package releaselabels
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestForPullRequestMapsConventionalTitles(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+		want Result
+	}{
+		{
+			name: "feature with scope",
+			pr:   PullRequest{Title: "feat(index): group schemas by source"},
+			want: Result{Labels: []string{"feat"}, Recognized: true},
+		},
+		{
+			name: "fix",
+			pr:   PullRequest{Title: "fix: repair generated schema layout"},
+			want: Result{Labels: []string{"fix"}, Recognized: true},
+		},
+		{
+			name: "docs",
+			pr:   PullRequest{Title: "docs(site): add installation guide"},
+			want: Result{Labels: []string{"docs"}, Recognized: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ForPullRequest(tt.pr); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ForPullRequest() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForPullRequestMapsDependencyUpdates(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+	}{
+		{name: "dependency scope", pr: PullRequest{Title: "chore(deps): update renovate"}},
+		{name: "dependency bot", pr: PullRequest{Title: "Update dependency golang", Author: "pull-bunyan[bot]"}},
+		{name: "dependency bot with recognized title", pr: PullRequest{Title: "fix: update Kubernetes dependency", Author: "pull-bunyan[bot]"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := Result{Labels: []string{"deps"}, Recognized: true}
+			if got := ForPullRequest(tt.pr); !reflect.DeepEqual(got, want) {
+				t.Fatalf("ForPullRequest() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestForPullRequestMapsCommonReleasePleaseCategories(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+		want Result
+	}{
+		{
+			name: "refactor",
+			pr:   PullRequest{Title: "refactor(renderer): simplify property rows"},
+			want: Result{Labels: []string{"refactor"}, Recognized: true},
+		},
+		{
+			name: "performance",
+			pr:   PullRequest{Title: "perf(renderer): speed up schema search"},
+			want: Result{Labels: []string{"perf"}, Recognized: true},
+		},
+		{
+			name: "revert",
+			pr:   PullRequest{Title: "revert: feat(index): group schemas by source"},
+			want: Result{Labels: []string{"revert"}, Recognized: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ForPullRequest(tt.pr); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ForPullRequest() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForPullRequestGroupsStyleUnderMaintenance(t *testing.T) {
+	want := Result{Labels: []string{"chore"}, Recognized: true}
+	if got := ForPullRequest(PullRequest{Title: "style: format docs"}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ForPullRequest() = %#v, want %#v", got, want)
+	}
+}
+
+func TestForPullRequestAddsBreakingLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+		want Result
+	}{
+		{
+			name: "bang marker",
+			pr:   PullRequest{Title: "feat!: remove legacy output path"},
+			want: Result{Labels: []string{"feat", "breaking"}, Recognized: true},
+		},
+		{
+			name: "body footer",
+			pr: PullRequest{
+				Title: "fix(renderer): remove legacy behavior",
+				Body:  "BREAKING CHANGE: generated pages no longer support old markup.",
+			},
+			want: Result{Labels: []string{"fix", "breaking"}, Recognized: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ForPullRequest(tt.pr); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ForPullRequest() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForPullRequestRejectsHumanTitlesWithoutReleaseType(t *testing.T) {
+	want := Result{Labels: nil, Recognized: false}
+	if got := ForPullRequest(PullRequest{Title: "improve the docs site"}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ForPullRequest() = %#v, want %#v", got, want)
+	}
+}
+
+func TestManagedLabelNames(t *testing.T) {
+	want := []string{"feat", "fix", "docs", "deps", "refactor", "perf", "revert", "ci", "build", "test", "chore", "breaking"}
+	if got := ManagedLabelNames(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ManagedLabelNames() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPrimaryLabelNames(t *testing.T) {
+	want := []string{"feat", "fix", "docs", "deps", "refactor", "perf", "revert", "ci", "build", "test", "chore"}
+	if got := PrimaryLabelNames(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("PrimaryLabelNames() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add GitHub generated release note categories for bare Conventional Commit labels
- add a PR workflow that creates/syncs release-note labels from PR titles and fails unrecognized human PR titles
- implement the label mapping in Go with unit tests and add a PR checklist hint

## Verification
- go test ./hack/releaselabels
- go test ./hack/release-labeler
- go test ./...
- actionlint .github/workflows/pr-release-labels.yml
- git diff --check