### PR TITLE
fix: relax schema wrapping and release labels

### DIFF
--- a/hack/release-labeler/main.go
+++ b/hack/release-labeler/main.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/sholdee/crd-schema-publisher/hack/releaselabels"
@@ -14,13 +14,15 @@ import (
 
 type eventPayload struct {
 	PullRequest *struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		User   struct {
-			Login string `json:"login"`
-		} `json:"user"`
+		Number int `json:"number"`
 	} `json:"pull_request"`
+}
+
+type pullRequest struct {
+	Number int
+	Title  string
+	Body   string
+	Author string
 }
 
 func main() {
@@ -48,14 +50,19 @@ func run() error {
 		return errors.New("release-labeler requires a pull_request event payload")
 	}
 
+	client := ghClient{}
+	pr, err := currentPullRequest(client, repository, event.PullRequest.Number)
+	if err != nil {
+		return err
+	}
+
 	result := releaselabels.ForPullRequest(releaselabels.PullRequest{
-		Title:  event.PullRequest.Title,
-		Body:   event.PullRequest.Body,
-		Author: event.PullRequest.User.Login,
+		Title:  pr.Title,
+		Body:   pr.Body,
+		Author: pr.Author,
 	})
 
-	client := ghClient{}
-	if err := syncPullRequestLabels(client, repository, event.PullRequest.Number, result.Labels); err != nil {
+	if err := syncPullRequestLabels(client, repository, pr.Number, result.Labels); err != nil {
 		return err
 	}
 	if !result.Recognized {
@@ -82,9 +89,39 @@ func readEvent(path string) (eventPayload, error) {
 	return event, nil
 }
 
+type ghRunner interface {
+	run(args ...string) (string, error)
+}
+
 type ghClient struct{}
 
-func syncPullRequestLabels(client ghClient, repository string, number int, desiredLabels []string) error {
+func currentPullRequest(client ghRunner, repository string, number int) (pullRequest, error) {
+	output, err := client.run("api", fmt.Sprintf("repos/%s/pulls/%d", repository, number))
+	if err != nil {
+		return pullRequest{}, fmt.Errorf("fetching current pull request: %w", err)
+	}
+
+	var response struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		User   struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		return pullRequest{}, fmt.Errorf("parsing current pull request: %w", err)
+	}
+
+	return pullRequest{
+		Number: response.Number,
+		Title:  response.Title,
+		Body:   response.Body,
+		Author: response.User.Login,
+	}, nil
+}
+
+func syncPullRequestLabels(client ghRunner, repository string, number int, desiredLabels []string) error {
 	if err := ensureRepositoryLabels(client, repository); err != nil {
 		return err
 	}
@@ -112,13 +149,17 @@ func syncPullRequestLabels(client ghClient, repository string, number int, desir
 		return nil
 	}
 
-	if _, err := client.run("issue", "edit", strconv.Itoa(number), "--repo", repository, "--add-label", strings.Join(desiredLabels, ",")); err != nil {
+	args := []string{"api", "-X", "POST", fmt.Sprintf("repos/%s/issues/%d/labels", repository, number)}
+	for _, label := range desiredLabels {
+		args = append(args, "-f", fmt.Sprintf("labels[]=%s", label))
+	}
+	if _, err := client.run(args...); err != nil {
 		return fmt.Errorf("applying labels: %w", err)
 	}
 	return nil
 }
 
-func ensureRepositoryLabels(client ghClient, repository string) error {
+func ensureRepositoryLabels(client ghRunner, repository string) error {
 	for _, label := range releaselabels.LabelSpecs() {
 		if err := ensureRepositoryLabel(client, repository, label); err != nil {
 			return err
@@ -127,7 +168,7 @@ func ensureRepositoryLabels(client ghClient, repository string) error {
 	return nil
 }
 
-func ensureRepositoryLabel(client ghClient, repository string, label releaselabels.LabelSpec) error {
+func ensureRepositoryLabel(client ghRunner, repository string, label releaselabels.LabelSpec) error {
 	if _, err := client.run(
 		"label",
 		"create",
@@ -145,8 +186,8 @@ func ensureRepositoryLabel(client ghClient, repository string, label releaselabe
 	return nil
 }
 
-func currentIssueLabels(client ghClient, repository string, number int) ([]string, error) {
-	output, err := client.run("api", fmt.Sprintf("repos/%s/issues/%d/labels", repository, number), "--jq", ".[].name")
+func currentIssueLabels(client ghRunner, repository string, number int) ([]string, error) {
+	output, err := client.run("api", "--paginate", fmt.Sprintf("repos/%s/issues/%d/labels?per_page=100", repository, number), "--jq", ".[].name")
 	if err != nil {
 		return nil, fmt.Errorf("listing current labels: %w", err)
 	}
@@ -161,8 +202,11 @@ func currentIssueLabels(client ghClient, repository string, number int) ([]strin
 	return labels, nil
 }
 
-func deleteIssueLabel(client ghClient, repository string, number int, label string) error {
-	if _, err := client.run("issue", "edit", strconv.Itoa(number), "--repo", repository, "--remove-label", label); err != nil {
+func deleteIssueLabel(client ghRunner, repository string, number int, label string) error {
+	if _, err := client.run("api", "-X", "DELETE", fmt.Sprintf("repos/%s/issues/%d/labels/%s", repository, number, url.PathEscape(label))); err != nil {
+		if strings.Contains(err.Error(), "Not Found") {
+			return nil
+		}
 		return fmt.Errorf("deleting stale label %q: %w", label, err)
 	}
 	return nil

--- a/hack/release-labeler/main_test.go
+++ b/hack/release-labeler/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type fakeGhClient struct {
+	outputs map[string]string
+	calls   [][]string
+}
+
+func (f *fakeGhClient) run(args ...string) (string, error) {
+	f.calls = append(f.calls, slices.Clone(args))
+	for prefix, output := range f.outputs {
+		if strings.HasPrefix(strings.Join(args, " "), prefix) {
+			return output, nil
+		}
+	}
+	return "", nil
+}
+
+func TestCurrentPullRequestFetchesCurrentMetadata(t *testing.T) {
+	client := &fakeGhClient{
+		outputs: map[string]string{
+			"api repos/sholdee/crd-schema-publisher/pulls/156": `{"number":156,"title":"fix(renderer): relax schema description wrapping","body":"","user":{"login":"sholdee"}}`,
+		},
+	}
+
+	got, err := currentPullRequest(client, "sholdee/crd-schema-publisher", 156)
+	if err != nil {
+		t.Fatalf("currentPullRequest() error: %v", err)
+	}
+
+	want := pullRequest{
+		Number: 156,
+		Title:  "fix(renderer): relax schema description wrapping",
+		Body:   "",
+		Author: "sholdee",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("currentPullRequest() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSyncPullRequestLabelsUsesRestIssueLabels(t *testing.T) {
+	client := &fakeGhClient{
+		outputs: map[string]string{
+			"api --paginate repos/sholdee/crd-schema-publisher/issues/156/labels": "docs\ncustom\n",
+		},
+	}
+
+	if err := syncPullRequestLabels(client, "sholdee/crd-schema-publisher", 156, []string{"fix"}); err != nil {
+		t.Fatalf("syncPullRequestLabels() error: %v", err)
+	}
+
+	if !hasCall(client.calls, "api", "-X", "DELETE", "repos/sholdee/crd-schema-publisher/issues/156/labels/docs") {
+		t.Fatal("expected stale managed docs label to be removed through REST issue-label endpoint")
+	}
+	if hasCall(client.calls, "api", "-X", "DELETE", "repos/sholdee/crd-schema-publisher/issues/156/labels/custom") {
+		t.Fatal("non-managed custom label should not be removed")
+	}
+	if !hasCall(client.calls, "api", "-X", "POST", "repos/sholdee/crd-schema-publisher/issues/156/labels", "-f", "labels[]=fix") {
+		t.Fatal("expected desired label to be applied through REST issue-label endpoint")
+	}
+	if hasCommand(client.calls, "issue", "edit") {
+		t.Fatal("label sync must not use gh issue edit because pull_request_target tokens cannot use its GraphQL mutation")
+	}
+}
+
+func hasCall(calls [][]string, want ...string) bool {
+	for _, call := range calls {
+		if slices.Equal(call, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCommand(calls [][]string, prefix ...string) bool {
+	for _, call := range calls {
+		if len(call) >= len(prefix) && slices.Equal(call[:len(prefix)], prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -961,7 +961,7 @@ var schemaTemplate = `<!DOCTYPE html>
     font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
   }
   .prop-children { margin-top: 0.5rem; }
-  .leaf-desc { color: var(--fg-muted); font-size: 0.9rem; flex: 1 1 24rem; min-width: min(100%, 24rem); overflow-wrap: anywhere; }
+  .leaf-desc { color: var(--fg-muted); font-size: 0.9rem; flex: 1 1 12rem; min-width: min(100%, 12rem); overflow-wrap: anywhere; }
   .leaf-constraints {
     color: var(--fg-muted); font-size: 0.875rem; margin-top: 0.15rem;
     font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -694,7 +694,7 @@ func TestRenderSchema_BasicOutput(t *testing.T) {
 		{"background: var(--surface-accent-background);", "schema match surfaces hide starfield"},
 		{".prop > summary {\n    padding: 0.5rem 0.75rem; cursor: pointer;\n    font-size: 0.85rem; background: var(--surface-background); border-radius: 6px;\n    list-style: none; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;", "schema property summaries wrap on narrow screens"},
 		{"overflow-wrap: anywhere; white-space: normal;", "schema property names can wrap"},
-		{"flex: 1 1 24rem; min-width: min(100%, 24rem);", "leaf descriptions keep a readable width before wrapping"},
+		{"flex: 1 1 12rem; min-width: min(100%, 12rem);", "leaf descriptions wrap only under tighter width constraints"},
 		{"@media (max-width: 640px) {\n    .leaf-desc,\n    .leaf-constraints {\n      flex: 0 0 100%;", "leaf descriptions use full width on mobile"},
 		{".prop-content {\n      padding-left: 0.75rem;\n    }", "nested property content reduces indentation on mobile"},
 		{".search-clear {", "schema search clear button style"},


### PR DESCRIPTION
## Summary
- reduce generated schema leaf description wrap fallback from 24rem to 12rem
- keep the mobile full-width description rule unchanged
- switch release-label sync from gh issue edit to REST issue-label APIs so pull_request_target tokens can apply labels
- fetch current PR metadata at runtime and add command-level tests for label sync

## Verification
- go test ./renderer -run TestRenderSchema_BasicOutput
- go test ./renderer
- go test ./hack/releaselabels ./hack/release-labeler
- actionlint .github/workflows/pr-release-labels.yml
- go test ./...