### PR TITLE
fix(ci): grant PR label write scope

### DIFF
--- a/.github/workflows/pr-release-labels.yml
+++ b/.github/workflows/pr-release-labels.yml
@@ -13,7 +13,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   release-labels:


### PR DESCRIPTION
## Summary
- grant `pull-requests: write` to the PR release-label workflow
- keep `issues: write` so the labeler can still create/update repository labels
- fixes the label application failure where REST returned 403 despite `Issues: write`

## Verification
- `actionlint .github/workflows/pr-release-labels.yml`
- `go test ./hack/release-labeler`
- `git diff --check`

## Notes
The failed #157 run showed `Issues: write` and `PullRequests: read`, then failed on `POST /issues/{number}/labels`. GitHub labels docs allow Pull requests write for label mutations, and the official PR labeler workflow recommends both scopes for PR labeling.

The `PR Release Labels` check on this PR is expected to fail because `pull_request_target` executes the workflow from the current base branch (`main`), where `PullRequests` is still read-only. The new permission can only be observed after this workflow change lands.