### PR TITLE
feat(cmd): add render command for standalone HTML rendering

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 
 	"github.com/sholdee/crd-schema-publisher/extractor"
-	"github.com/sholdee/crd-schema-publisher/index"
-	"github.com/sholdee/crd-schema-publisher/renderer"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -207,17 +205,6 @@ func writeConvertInputs(
 	return count, nil
 }
 
-func renderConvertOutput(outputDir, basePath string) error {
-	normalizedBasePath := normalizeBasePath(basePath)
-	if err := renderer.RenderAll(outputDir, normalizedBasePath); err != nil {
-		return fmt.Errorf("rendering schemas: %w", err)
-	}
-	if err := index.Generate(outputDir, normalizedBasePath); err != nil {
-		return fmt.Errorf("generating index: %w", err)
-	}
-	return nil
-}
-
 func validateConvertInputs(fileFlag, dirFlag, openapiPath string, kustomize bool) error {
 	if fileFlag == "" && dirFlag == "" && openapiPath == "" && !kustomize {
 		return fmt.Errorf("one of --file, --dir, --openapi, or --kustomize is required")
@@ -298,7 +285,7 @@ func runConvert(args []string) error {
 	}
 
 	if *render {
-		if err := renderConvertOutput(outputDir, *basePath); err != nil {
+		if err := renderOutput(outputDir, *basePath); err != nil {
 			return err
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ var commandSpecs = []commandSpec{
 	{name: "run", description: "Extract schemas and upload when credentials are configured (default)"},
 	{name: "extract", description: "Extract schemas from a Kubernetes cluster"},
 	{name: "convert", description: "Convert CRD YAML files to JSON Schema"},
+	{name: "render", description: "Render HTML documentation pages for an existing schema directory"},
 	{name: "upload", description: "Upload schemas to Cloudflare Pages"},
 	{name: "watch", description: "Watch for CRD changes and upload when credentials are configured"},
 	{name: "preview", description: "Serve a local preview of the documentation site"},

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1482,6 +1482,109 @@ func TestRunConvert_KustomizeExplicitOptInIgnoresFilters(t *testing.T) {
 	}
 }
 
+func TestRunRender_RendersConvertOutput(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+	inputFile := writeCertificateCRDFixture(t, dir)
+
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("runConvert error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); !os.IsNotExist(err) {
+		t.Fatal("expected no index.html before render")
+	}
+
+	if err := runRender([]string{"--output-dir", outputDir}); err != nil {
+		t.Fatalf("runRender error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.html")); err != nil {
+		t.Fatal("expected rendered HTML schema page")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); err != nil {
+		t.Fatal("expected generated index.html")
+	}
+}
+
+func TestRunRender_RecordsArtifactsInConvertManifest(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+	inputFile := writeCertificateCRDFixture(t, dir)
+
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("runConvert error: %v", err)
+	}
+	// User file added between convert and render must stay out of the manifest
+	userFile := filepath.Join(outputDir, "notes.txt")
+	if err := os.WriteFile(userFile, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runRender([]string{"--output-dir", outputDir}); err != nil {
+		t.Fatalf("runRender error: %v", err)
+	}
+
+	// A later convert run should clean the standalone render's artifacts
+	if err := runConvert([]string{"--file", inputFile, "--output-dir", outputDir}); err != nil {
+		t.Fatalf("second runConvert error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); !os.IsNotExist(err) {
+		t.Fatal("expected index.html from standalone render to be cleaned")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.html")); !os.IsNotExist(err) {
+		t.Fatal("expected rendered HTML page from standalone render to be cleaned")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "cert-manager.io", "certificate_v1.json")); err != nil {
+		t.Fatal("expected schema to exist after second run")
+	}
+	data, err := os.ReadFile(userFile)
+	if err != nil {
+		t.Fatal("expected user file to survive render manifest update and cleanup")
+	}
+	if string(data) != "keep me" {
+		t.Fatalf("user file content changed: %q", data)
+	}
+}
+
+func TestRunRender_UsesActiveGenerationForRuntimeLayout(t *testing.T) {
+	outputDir := t.TempDir()
+	generationName := "20240101T000000.000000000Z-test"
+	generationDir := filepath.Join(outputDir, ".generations", generationName)
+	if err := os.MkdirAll(filepath.Join(generationDir, "cert-manager.io"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	schemaPath := filepath.Join(generationDir, "cert-manager.io", "certificate_v1.json")
+	if err := os.WriteFile(schemaPath, []byte(`{"type":"object"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(".generations", generationName), filepath.Join(outputDir, "current")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runRender([]string{"--output-dir", outputDir}); err != nil {
+		t.Fatalf("runRender error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(generationDir, "cert-manager.io", "certificate_v1.html")); err != nil {
+		t.Fatal("expected rendered HTML page inside the active generation")
+	}
+	if _, err := os.Stat(filepath.Join(generationDir, "index.html")); err != nil {
+		t.Fatal("expected generated index.html inside the active generation")
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "index.html")); !os.IsNotExist(err) {
+		t.Fatal("expected output root to stay untouched when current symlink exists")
+	}
+}
+
+func TestRunRender_RequiresExistingOutputDir(t *testing.T) {
+	err := runRender([]string{"--output-dir", filepath.Join(t.TempDir(), "missing")})
+	if err == nil {
+		t.Fatal("expected error for missing output directory")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("expected error about missing directory, got: %v", err)
+	}
+}
+
 func TestRunConvert_ValidatesOutputDir(t *testing.T) {
 	dir := t.TempDir()
 	inputFile := filepath.Join(dir, "crd.yaml")

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/sholdee/crd-schema-publisher/extractor"
+	"github.com/sholdee/crd-schema-publisher/index"
+	"github.com/sholdee/crd-schema-publisher/renderer"
+)
+
+func init() {
+	registerCommand("render", runRender)
+}
+
+func runRender(args []string) error {
+	cfg, err := parseRenderConfig(args, os.Getenv)
+	if err != nil {
+		return err
+	}
+	if err := requireExistingOutputDir(cfg.OutputDir, "Set OUTPUT_DIR or pass --output-dir to a directory containing extracted or converted schemas"); err != nil {
+		return err
+	}
+
+	renderDir, err := resolveRenderDir(cfg.OutputDir)
+	if err != nil {
+		return err
+	}
+
+	manifest, err := readConvertManifest(renderDir)
+	if err != nil {
+		return err
+	}
+	var preRender map[string]bool
+	if manifest != nil {
+		preRender = snapshotFiles(renderDir)
+	}
+
+	slog.Info("rendering schema pages", "dir", renderDir)
+	if err := renderOutput(renderDir, cfg.BasePath); err != nil {
+		return err
+	}
+
+	if manifest != nil {
+		// Record rendered files in the convert manifest so a later convert
+		// run cleans them instead of leaving stale pages behind. Treating
+		// manifest entries as non-pre-existing keeps them recorded alongside
+		// the new render output.
+		for _, rel := range manifest {
+			delete(preRender, rel)
+		}
+		if err := writeConvertManifest(renderDir, preRender); err != nil {
+			return fmt.Errorf("updating convert manifest: %w", err)
+		}
+	}
+
+	slog.Info("render complete", "dir", renderDir)
+	return nil
+}
+
+// resolveRenderDir returns the active generation when outputDir uses the
+// runtime layout (a "current" symlink into .generations); otherwise the
+// directory itself is rendered, matching the flat convert layout.
+func resolveRenderDir(outputDir string) (string, error) {
+	activeDir := extractor.ActiveOutputDir(outputDir)
+	resolved, err := filepath.EvalSymlinks(activeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return outputDir, nil
+		}
+		return "", fmt.Errorf("resolving active output: %w", err)
+	}
+	return resolved, nil
+}
+
+func renderOutput(outputDir, basePath string) error {
+	normalizedBasePath := normalizeBasePath(basePath)
+	if err := renderer.RenderAll(outputDir, normalizedBasePath); err != nil {
+		return fmt.Errorf("rendering schemas: %w", err)
+	}
+	if err := index.Generate(outputDir, normalizedBasePath); err != nil {
+		return fmt.Errorf("generating index: %w", err)
+	}
+	return nil
+}

--- a/cmd/runtime_config.go
+++ b/cmd/runtime_config.go
@@ -28,6 +28,11 @@ type extractConfig struct {
 	IncludeKustomize bool
 }
 
+type renderCommandConfig struct {
+	OutputDir string
+	BasePath  string
+}
+
 type uploadCommandConfig struct {
 	OutputDir         string
 	ExplicitOutputDir bool
@@ -97,6 +102,23 @@ func parseExtractConfig(args []string, env envGetter) (extractConfig, error) {
 		Filter:           extractor.ParseFilter(*kind, *group, *version),
 		IncludeBuiltins:  *includeBuiltins,
 		IncludeKustomize: *includeKustomize,
+	}, nil
+}
+
+func parseRenderConfig(args []string, env envGetter) (renderCommandConfig, error) {
+	fs := newCommandFlagSet("render")
+	var outputDir string
+	stringFlagWithAlias(fs, &outputDir, "output-dir", "o", envDefault(env, "OUTPUT_DIR", ""), "output directory containing JSON schemas")
+	basePath := fs.String("base-path", envDefault(env, "BASE_PATH", ""), "URL path prefix for subpath deployments")
+	if err := fs.Parse(args); err != nil {
+		return renderCommandConfig{}, err
+	}
+	if extras := fs.Args(); len(extras) > 0 {
+		return renderCommandConfig{}, fmt.Errorf("unexpected arguments for render: %s", strings.Join(extras, " "))
+	}
+	return renderCommandConfig{
+		OutputDir: outputDir,
+		BasePath:  *basePath,
 	}, nil
 }
 

--- a/cmd/runtime_config_test.go
+++ b/cmd/runtime_config_test.go
@@ -137,6 +137,28 @@ func TestExtractConfig_IncludeEnvDefaults(t *testing.T) {
 	}
 }
 
+func TestRenderConfig_UsesEnvDefaultsAndFlagOverrides(t *testing.T) {
+	env := mapEnv(map[string]string{
+		"OUTPUT_DIR": "/env-output",
+		"BASE_PATH":  "/env-base",
+	})
+	cfg, err := parseRenderConfig(nil, env)
+	if err != nil {
+		t.Fatalf("parseRenderConfig: %v", err)
+	}
+	if cfg.OutputDir != "/env-output" || cfg.BasePath != "/env-base" {
+		t.Fatalf("unexpected render config from env: %#v", cfg)
+	}
+
+	cfg, err = parseRenderConfig([]string{"-o", "/flag-output", "--base-path", "/flag-base"}, env)
+	if err != nil {
+		t.Fatalf("parseRenderConfig: %v", err)
+	}
+	if cfg.OutputDir != "/flag-output" || cfg.BasePath != "/flag-base" {
+		t.Fatalf("expected flags to override env: %#v", cfg)
+	}
+}
+
 func TestUploadConfig_FlagOutputDirOverridesEnv(t *testing.T) {
 	cfg, err := parseUploadCommandConfig([]string{"--output-dir", "/flag-output"}, mapEnv(map[string]string{"OUTPUT_DIR": "/env-output"}))
 	if err != nil {
@@ -168,6 +190,7 @@ func TestCommandConfig_RejectsUnexpectedArgs(t *testing.T) {
 			return err
 		}, want: "unexpected arguments for run: unexpected"},
 		{name: "extract", run: func() error { _, err := parseExtractConfig([]string{"unexpected"}, mapEnv(nil)); return err }, want: "unexpected arguments for extract: unexpected"},
+		{name: "render", run: func() error { _, err := parseRenderConfig([]string{"unexpected"}, mapEnv(nil)); return err }, want: "unexpected arguments for render: unexpected"},
 		{name: "upload", run: func() error { _, err := parseUploadCommandConfig([]string{"unexpected"}, mapEnv(nil)); return err }, want: "unexpected arguments for upload: unexpected"},
 		{name: "preview", run: func() error { _, err := parsePreviewConfig([]string{"unexpected"}); return err }, want: "unexpected arguments for preview: unexpected"},
 	}

--- a/docs-site/content/concepts/how-it-works.md
+++ b/docs-site/content/concepts/how-it-works.md
@@ -43,6 +43,18 @@ The `convert` command skips Kubernetes access. It reads CRD YAML from `--file`/`
 
 `convert` applies the same schema transforms as cluster-backed commands. It writes flat output directly to `--output-dir`/`-o`; with `--render`, it also renders schema HTML pages and an index.
 
+## Standalone Rendering
+
+The `render` command renders schema HTML pages and an index for an existing output directory. This decouples rendering from extraction and conversion, so schemas can be inspected or modified in between:
+
+```sh
+crd-schema-publisher extract -o ./schemas --skip-render
+# modify schemas under ./schemas/current/ as needed
+crd-schema-publisher render -o ./schemas
+```
+
+When `OUTPUT_DIR/current` exists (runtime layout), `render` renders the active generation in place; otherwise it renders the flat directory produced by `convert`. When a convert manifest is present, rendered files are recorded in it so a later `convert` run cleans them.
+
 ## Kubernetes Built-ins from OpenAPI
 
 Use `--openapi <swagger.json>` to convert Kubernetes built-in, non-CRD types from an OpenAPI v2 document.

--- a/docs-site/content/reference/commands.md
+++ b/docs-site/content/reference/commands.md
@@ -13,6 +13,7 @@ Commands:
   run       Extract schemas and upload to Cloudflare Pages when credentials are configured (default)
   extract   Extract schemas from a Kubernetes cluster
   convert   Convert CRD YAML files and Kubernetes OpenAPI built-ins to JSON Schema
+  render    Render HTML documentation pages for an existing schema directory
   upload    Upload the active site from OUTPUT_DIR/current to Cloudflare Pages
   watch     Watch for CRD changes and upload when credentials are configured
   preview   Serve a local preview of the documentation site
@@ -22,6 +23,7 @@ Commands:
 | ------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `extract`                | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; does not fall back to `/output`.                      |
 | `convert`                | Requires `--output-dir`/`-o`; does not read `OUTPUT_DIR`.                                                    |
+| `render`                 | Requires explicit `--output-dir`/`-o` or `OUTPUT_DIR`; renders the active `current` generation when present. |
 | `run`, `watch`, `upload` | Accept `--output-dir`/`-o`; output root must already exist.                                                  |
 | `preview`                | Uses sample data by default; reads real extracted output only when `--output-dir`/`-o` is passed explicitly. |
 
@@ -35,3 +37,4 @@ Commands:
 | `convert`                 | Supports `--file`/`-f`, non-recursive `--dir`/`-d` YAML loading, optional `--render`, and `--base-path` for rendered links.                                                                          |
 | `convert`                 | `--openapi` converts a Kubernetes OpenAPI v2 (swagger) document of built-in types into self-contained per-kind schemas, combinable with `--file`/`--dir` to render CRDs and built-ins into one site. |
 | `convert`                 | `--kustomize` explicitly publishes kustomize's `Kustomization` and `Component` schemas, reflected from the pinned `sigs.k8s.io/kustomize/api` types. It is not filtered.                             |
+| `render`                  | Supports `--base-path` for rendered links. Renders schema HTML pages and an index for existing output, e.g. after `extract --skip-render` or `convert` without `--render`.                           |


### PR DESCRIPTION
## What

Renders schema HTML pages and an index for an existing output directory, decoupling rendering from extraction and conversion so schemas can be inspected or modified in between, e.g. after 'extract --skip-render' or 'convert' without '--render'.

When OUTPUT_DIR/current exists (runtime layout), the active generation is rendered in place; otherwise the flat convert layout is rendered directly. When a convert manifest is present, rendered files are recorded in it so a later convert run cleans them.

## Checklist

- [x] PR title starts with a release-note type (`feat`, `fix`, `docs`, `deps`, `refactor`, `perf`, `revert`, `ci`, `build`, `test`, or `chore`)
- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Pre-commit hook enabled (`git config core.hooksPath .githooks`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] GitHub Actions pinned by SHA with version comment (if modified)
