### PR TITLE
chore: handle unchecked errors and deduplicate test scaffolding

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,7 +60,7 @@ func initLogger(cmd string) {
 }
 
 func printUsage(w io.Writer) {
-	fmt.Fprint(w, `crd-schema-publisher — CRD JSON Schema extraction and documentation
+	_, _ = fmt.Fprint(w, `crd-schema-publisher — CRD JSON Schema extraction and documentation
 
 Usage:
   crd-schema-publisher <command> [flags]
@@ -68,9 +68,9 @@ Usage:
 Commands:
 `)
 	for _, cmd := range commandSpecs {
-		fmt.Fprintf(w, "  %-8s  %s\n", cmd.name, cmd.description)
+		_, _ = fmt.Fprintf(w, "  %-8s  %s\n", cmd.name, cmd.description)
 	}
-	fmt.Fprint(w, `
+	_, _ = fmt.Fprint(w, `
 Use "crd-schema-publisher <command> --help" for more information.
 `)
 }
@@ -130,7 +130,7 @@ func stringFlagWithAlias(fs *flag.FlagSet, target *string, name, alias, value, u
 
 func printFlagDefaults(fs *flag.FlagSet) {
 	output := fs.Output()
-	fmt.Fprintf(output, "Usage of %s:\n", fs.Name())
+	_, _ = fmt.Fprintf(output, "Usage of %s:\n", fs.Name())
 
 	aliases := map[string]string{}
 	aliasNames := map[string]bool{}
@@ -153,13 +153,13 @@ func printFlagDefaults(fs *flag.FlagSet) {
 			displayName += " " + name
 		}
 
-		fmt.Fprintf(output, "  %s\n", displayName)
+		_, _ = fmt.Fprintf(output, "  %s\n", displayName)
 		if usage != "" {
-			fmt.Fprintf(output, "\t%s", usage)
+			_, _ = fmt.Fprintf(output, "\t%s", usage)
 			if f.DefValue != "" && f.DefValue != "false" {
-				fmt.Fprintf(output, " (default %q)", f.DefValue)
+				_, _ = fmt.Fprintf(output, " (default %q)", f.DefValue)
 			}
-			fmt.Fprintln(output)
+			_, _ = fmt.Fprintln(output)
 		}
 	})
 }

--- a/cmd/run_flow_test.go
+++ b/cmd/run_flow_test.go
@@ -87,72 +87,47 @@ func TestRunAll_RequiresPreexistingOutputDir(t *testing.T) {
 }
 
 func TestRunAll_OutputDirFlagOverridesEnvVar(t *testing.T) {
-	clientOrig := buildClientFunc
-	buildOrig := buildSiteFunc
-	publishOrig := publishOutputFunc
-	defer func() {
-		buildClientFunc = clientOrig
-		buildSiteFunc = buildOrig
-		publishOutputFunc = publishOrig
-	}()
+	for _, tc := range []struct {
+		name string
+		flag string
+	}{
+		{name: "long flag", flag: "--output-dir"},
+		{name: "short flag", flag: "-o"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientOrig := buildClientFunc
+			buildOrig := buildSiteFunc
+			publishOrig := publishOutputFunc
+			defer func() {
+				buildClientFunc = clientOrig
+				buildSiteFunc = buildOrig
+				publishOutputFunc = publishOrig
+			}()
 
-	var captured extractor.SiteBuildOptions
-	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
-		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
-	}
-	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
-		captured = opts
-		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
-	}
-	publishOutputFunc = func(string) error {
-		t.Fatal("publish should not be called for noop build")
-		return nil
-	}
+			var captured extractor.SiteBuildOptions
+			buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
+				return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+			}
+			buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
+				captured = opts
+				return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
+			}
+			publishOutputFunc = func(string) error {
+				t.Fatal("publish should not be called for noop build")
+				return nil
+			}
 
-	envDir := t.TempDir()
-	flagDir := t.TempDir()
-	t.Setenv("OUTPUT_DIR", envDir)
+			envDir := t.TempDir()
+			flagDir := t.TempDir()
+			t.Setenv("OUTPUT_DIR", envDir)
 
-	if err := runAll([]string{"--output-dir", flagDir}); err != nil {
-		t.Fatalf("runAll error: %v", err)
-	}
-	if captured.OutputDir != flagDir {
-		t.Fatalf("expected flag output dir %q, got %q", flagDir, captured.OutputDir)
-	}
-}
-
-func TestRunAll_OutputDirShortFlagOverridesEnvVar(t *testing.T) {
-	clientOrig := buildClientFunc
-	buildOrig := buildSiteFunc
-	publishOrig := publishOutputFunc
-	defer func() {
-		buildClientFunc = clientOrig
-		buildSiteFunc = buildOrig
-		publishOutputFunc = publishOrig
-	}()
-
-	var captured extractor.SiteBuildOptions
-	buildClientFunc = func(string) (*apiextensionsclient.Clientset, error) {
-		return apiextensionsclient.NewForConfig(&rest.Config{Host: "https://example.invalid"})
-	}
-	buildSiteFunc = func(opts extractor.SiteBuildOptions) (extractor.SiteBuildResult, error) {
-		captured = opts
-		return extractor.SiteBuildResult{Status: extractor.BuildResultNoop}, nil
-	}
-	publishOutputFunc = func(string) error {
-		t.Fatal("publish should not be called for noop build")
-		return nil
-	}
-
-	envDir := t.TempDir()
-	flagDir := t.TempDir()
-	t.Setenv("OUTPUT_DIR", envDir)
-
-	if err := runAll([]string{"-o", flagDir}); err != nil {
-		t.Fatalf("runAll error: %v", err)
-	}
-	if captured.OutputDir != flagDir {
-		t.Fatalf("expected short output dir %q, got %q", flagDir, captured.OutputDir)
+			if err := runAll([]string{tc.flag, flagDir}); err != nil {
+				t.Fatalf("runAll error: %v", err)
+			}
+			if captured.OutputDir != flagDir {
+				t.Fatalf("expected %s output dir %q, got %q", tc.flag, flagDir, captured.OutputDir)
+			}
+		})
 	}
 }
 

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -454,9 +454,12 @@ func goldenCRD() apiextensionsv1.CustomResourceDefinition {
 
 const goldenFixturePath = "testdata/golden_certificate_v1.json"
 
-func TestWriteSchemas_GoldenE2E(t *testing.T) {
+// runGoldenSchemaTest writes the CRD's schema to a temp dir and compares it
+// against the golden fixture, generating the fixture on first run.
+func runGoldenSchemaTest(t *testing.T, crd apiextensionsv1.CustomResourceDefinition, fixturePath, schemaRelPath, standaloneName string) {
+	t.Helper()
 	tmpDir := t.TempDir()
-	crds := []apiextensionsv1.CustomResourceDefinition{goldenCRD()}
+	crds := []apiextensionsv1.CustomResourceDefinition{crd}
 
 	count, err := WriteSchemas(crds, tmpDir)
 	if err != nil {
@@ -467,7 +470,7 @@ func TestWriteSchemas_GoldenE2E(t *testing.T) {
 	}
 
 	// Read actual output
-	actualPath := filepath.Join(tmpDir, "cert-manager.io", "certificate_v1.json")
+	actualPath := filepath.Join(tmpDir, schemaRelPath)
 	actual, err := os.ReadFile(actualPath)
 	if err != nil {
 		t.Fatalf("reading output schema: %v", err)
@@ -481,14 +484,14 @@ func TestWriteSchemas_GoldenE2E(t *testing.T) {
 	actualNorm, _ := json.MarshalIndent(actualObj, "", "  ")
 
 	// Read or generate golden fixture
-	golden, err := os.ReadFile(goldenFixturePath)
+	golden, err := os.ReadFile(fixturePath)
 	if err != nil {
 		// First run: generate the fixture
-		t.Logf("Golden fixture not found, generating: %s", goldenFixturePath)
-		if err := os.WriteFile(goldenFixturePath, append(actualNorm, '\n'), 0o644); err != nil {
+		t.Logf("Golden fixture not found, generating: %s", fixturePath)
+		if err := os.WriteFile(fixturePath, append(actualNorm, '\n'), 0o644); err != nil {
 			t.Fatalf("writing golden fixture: %v", err)
 		}
-		t.Fatalf("Golden fixture generated at %s — verify it manually, then re-run", goldenFixturePath)
+		t.Fatalf("Golden fixture generated at %s — verify it manually, then re-run", fixturePath)
 	}
 
 	// Normalize golden too
@@ -500,11 +503,11 @@ func TestWriteSchemas_GoldenE2E(t *testing.T) {
 
 	if string(actualNorm) != string(goldenNorm) {
 		t.Errorf("schema output does not match golden fixture %s\n\nTo update after an intentional change, delete the fixture and re-run.\n\ngot:\n%s\n\nwant:\n%s",
-			goldenFixturePath, string(actualNorm), string(goldenNorm))
+			fixturePath, string(actualNorm), string(goldenNorm))
 	}
 
 	// Also verify master-standalone output exists and matches
-	standalonePath := filepath.Join(tmpDir, "master-standalone", "cert-manager.io-certificate-stable-v1.json")
+	standalonePath := filepath.Join(tmpDir, "master-standalone", standaloneName)
 	standalone, err := os.ReadFile(standalonePath)
 	if err != nil {
 		t.Fatalf("master-standalone file not found: %v", err)
@@ -512,6 +515,12 @@ func TestWriteSchemas_GoldenE2E(t *testing.T) {
 	if string(actual) != string(standalone) {
 		t.Error("master-standalone output differs from primary output — both should be identical")
 	}
+}
+
+func TestWriteSchemas_GoldenE2E(t *testing.T) {
+	runGoldenSchemaTest(t, goldenCRD(), goldenFixturePath,
+		filepath.Join("cert-manager.io", "certificate_v1.json"),
+		"cert-manager.io-certificate-stable-v1.json")
 }
 
 func boolPtr(b bool) *bool { return &b }
@@ -597,63 +606,9 @@ func edgeCaseCRD() apiextensionsv1.CustomResourceDefinition {
 const goldenEdgeCaseFixturePath = "testdata/golden_edgecase_v1.json"
 
 func TestWriteSchemas_GoldenEdgeCases(t *testing.T) {
-	tmpDir := t.TempDir()
-	crds := []apiextensionsv1.CustomResourceDefinition{edgeCaseCRD()}
-
-	count, err := WriteSchemas(crds, tmpDir)
-	if err != nil {
-		t.Fatalf("WriteSchemas error: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 schema, got %d", count)
-	}
-
-	// Read actual output
-	actualPath := filepath.Join(tmpDir, "testing.example.io", "virtualservice_v1.json")
-	actual, err := os.ReadFile(actualPath)
-	if err != nil {
-		t.Fatalf("reading output schema: %v", err)
-	}
-
-	// Normalize: re-marshal to consistent formatting
-	var actualObj interface{}
-	if err := json.Unmarshal(actual, &actualObj); err != nil {
-		t.Fatalf("unmarshaling actual: %v", err)
-	}
-	actualNorm, _ := json.MarshalIndent(actualObj, "", "  ")
-
-	// Read or generate golden fixture
-	golden, err := os.ReadFile(goldenEdgeCaseFixturePath)
-	if err != nil {
-		// First run: generate the fixture
-		t.Logf("Golden fixture not found, generating: %s", goldenEdgeCaseFixturePath)
-		if err := os.WriteFile(goldenEdgeCaseFixturePath, append(actualNorm, '\n'), 0o644); err != nil {
-			t.Fatalf("writing golden fixture: %v", err)
-		}
-		t.Fatalf("Golden fixture generated at %s — verify it manually, then re-run", goldenEdgeCaseFixturePath)
-	}
-
-	// Normalize golden too
-	var goldenObj interface{}
-	if err := json.Unmarshal(golden, &goldenObj); err != nil {
-		t.Fatalf("unmarshaling golden fixture: %v", err)
-	}
-	goldenNorm, _ := json.MarshalIndent(goldenObj, "", "  ")
-
-	if string(actualNorm) != string(goldenNorm) {
-		t.Errorf("schema output does not match golden fixture %s\n\nTo update after an intentional change, delete the fixture and re-run.\n\ngot:\n%s\n\nwant:\n%s",
-			goldenEdgeCaseFixturePath, string(actualNorm), string(goldenNorm))
-	}
-
-	// Also verify master-standalone output exists and matches
-	standalonePath := filepath.Join(tmpDir, "master-standalone", "testing.example.io-virtualservice-stable-v1.json")
-	standalone, err := os.ReadFile(standalonePath)
-	if err != nil {
-		t.Fatalf("master-standalone file not found: %v", err)
-	}
-	if string(actual) != string(standalone) {
-		t.Error("master-standalone output differs from primary output — both should be identical")
-	}
+	runGoldenSchemaTest(t, edgeCaseCRD(), goldenEdgeCaseFixturePath,
+		filepath.Join("testing.example.io", "virtualservice_v1.json"),
+		"testing.example.io-virtualservice-stable-v1.json")
 }
 
 func TestWriteSchemas_NullableOptionalFields(t *testing.T) {

--- a/extractor/openapi_source.go
+++ b/extractor/openapi_source.go
@@ -52,7 +52,7 @@ func (s *APIServerOpenAPISource) FetchOpenAPIV2(ctx context.Context) ([]byte, er
 	if err != nil {
 		return nil, fmt.Errorf("fetching /openapi/v2: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1543,6 +1543,23 @@ func TestRenderSchema_BooleanSchemaInProperties(t *testing.T) {
 	}
 }
 
+// renderSchemaHTMLForTest writes the schema JSON under a temp dir, renders it,
+// and returns the resulting HTML.
+func renderSchemaHTMLForTest(t *testing.T, schema, fileName string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", fileName+".json"), []byte(schema), 0o644)
+
+	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", fileName+".json"), "test.io", fileName+".json", "")
+	if err != nil {
+		t.Fatalf("renderSchemaFile error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", fileName+".html"))
+	return string(data)
+}
+
 func TestRenderSchema_CompositionWithBooleanSchemas(t *testing.T) {
 	// JSON Schema allows boolean schemas (true/false) inside composition keywords
 	// (oneOf, anyOf, allOf). The renderer should handle these gracefully.
@@ -1561,17 +1578,7 @@ func TestRenderSchema_CompositionWithBooleanSchemas(t *testing.T) {
 		}
 	}`
 
-	tmpDir := t.TempDir()
-	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
-	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "thing_v1.json"), []byte(schema), 0o644)
-
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "thing_v1.json"), "test.io", "thing_v1.json", "")
-	if err != nil {
-		t.Fatalf("renderSchemaFile should handle boolean schemas in composition keywords: %v", err)
-	}
-
-	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "thing_v1.html"))
-	html := string(data)
+	html := renderSchemaHTMLForTest(t, schema, "thing_v1")
 
 	if !strings.Contains(html, "flexible") {
 		t.Error("should render the oneOf property with boolean schema")
@@ -1611,17 +1618,7 @@ func TestRenderSchema_DeepNesting(t *testing.T) {
 		}
 	}`
 
-	tmpDir := t.TempDir()
-	_ = os.MkdirAll(filepath.Join(tmpDir, "test.io"), 0o755)
-	_ = os.WriteFile(filepath.Join(tmpDir, "test.io", "deep_v1.json"), []byte(schema), 0o644)
-
-	err := renderSchemaFile(testTemplate(t), filepath.Join(tmpDir, "test.io", "deep_v1.json"), "test.io", "deep_v1.json", "")
-	if err != nil {
-		t.Fatalf("renderSchemaFile error: %v", err)
-	}
-
-	data, _ := os.ReadFile(filepath.Join(tmpDir, "test.io", "deep_v1.html"))
-	html := string(data)
+	html := renderSchemaHTMLForTest(t, schema, "deep_v1")
 
 	if !strings.Contains(html, "level1") {
 		t.Error("should show level1")

--- a/site/server_test.go
+++ b/site/server_test.go
@@ -126,7 +126,7 @@ func TestStartServerReturnsListenError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	server, err := StartServer(listener.Addr().String(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	if err == nil {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -760,7 +760,7 @@ func TestHealthServer_MetricsEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /metrics: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)


### PR DESCRIPTION
Addresses the issues CodeFactor flags under its default analyzer set, which is holding the repo at an A grade:

- **Unchecked error returns (9 sites)** — explicit `_, _ =` discards on usage-text `Fprint*` calls in `cmd/main.go`, and `defer func() { _ = x.Close() }()` for the response-body/listener closes in `extractor/openapi_source.go`, `site/server_test.go`, and `watcher/watcher_test.go`.
- **Duplicate code blocks (3 pairs)** —
  - `cmd/run_flow_test.go`: the long-flag/short-flag output-dir tests merged into one table-driven test.
  - `extractor/extractor_test.go`: golden E2E and edge-case tests now share `runGoldenSchemaTest`.
  - `renderer/renderer_test.go`: boolean-composition and deep-nesting tests now share `renderSchemaHTMLForTest`.

No behavior changes. `go test ./...` passes; `golangci-lint` clean under both the repo config and defaults (including `dupl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)