### PR TITLE
chore: CodeFactor badge swap + dead nil-check removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://goreportcard.com/report/github.com/sholdee/crd-schema-publisher"><img src="https://goreportcard.com/badge/github.com/sholdee/crd-schema-publisher" alt="Go Report Card"></a>
+  <a href="https://www.codefactor.io/repository/github/sholdee/crd-schema-publisher"><img src="https://www.codefactor.io/repository/github/sholdee/crd-schema-publisher/badge" alt="CodeFactor"></a>
   <a href="https://github.com/sholdee/crd-schema-publisher/actions/workflows/ci.yaml"><img src="https://github.com/sholdee/crd-schema-publisher/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
   <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/sholdee/crd-schema-publisher" alt="Go Version"></a>

--- a/extractor/build.go
+++ b/extractor/build.go
@@ -216,7 +216,7 @@ func ValidateOutputDir(outputDir string) error {
 		if isFilesystemRoot(resolved) {
 			return fmt.Errorf("OUTPUT_DIR %q resolves to filesystem root", outputDir)
 		}
-		if err == nil && cwd != "" {
+		if cwd != "" {
 			if resolvedCWD, cwdErr := resolvePath(cwd); cwdErr == nil && samePath(resolved, resolvedCWD) {
 				return fmt.Errorf("OUTPUT_DIR %q resolves to the current working directory", outputDir)
 			}


### PR DESCRIPTION
Two small follow-ups to #212:

- **README badge**: the CodeFactor badge-swap commit was pushed to the PR branch after the squash merge landed, so main still had the retired (gray) Go Report Card badge. This applies the swap.
- **`extractor/build.go`**: removes a tautological `err == nil` inside a block already guarded by `err == nil` on the `resolvePath` result (gopls `nilness` finding). No behavior change — the `os.Getwd()` failure case this clause appears to have targeted is already handled by the `cwd != ""` half of the condition.

`go test ./extractor/` and `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)