### PR TITLE
chore: resolve CodeFactor findings (builtin shadowing, self-assignment, JS complexity)

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -277,22 +277,22 @@ func appendAllOfSchema(dst map[string]interface{}, schema interface{}) {
 }
 
 func copySchemaExcept(schema map[string]interface{}, omit string) map[string]interface{} {
-	copy := make(map[string]interface{}, len(schema))
+	out := make(map[string]interface{}, len(schema))
 	for k, v := range schema {
 		if k == omit {
 			continue
 		}
-		copy[k] = v
+		out[k] = v
 	}
-	return copy
+	return out
 }
 
 func copySchema(schema map[string]interface{}) map[string]interface{} {
-	copy := make(map[string]interface{}, len(schema))
+	out := make(map[string]interface{}, len(schema))
 	for k, v := range schema {
-		copy[k] = v
+		out[k] = v
 	}
-	return copy
+	return out
 }
 
 func replaceSchema(dst, src map[string]interface{}) {

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -565,8 +565,8 @@ func TestBuildRenderPropertiesResolvesArrayItemRefsWithoutRecursingForever(t *te
 func TestConstraints(t *testing.T) {
 	minLen := int64(1)
 	maxLen := int64(255)
-	min := 0.0
-	max := 100.0
+	minVal := 0.0
+	maxVal := 100.0
 
 	tests := []struct {
 		name     string
@@ -577,7 +577,7 @@ func TestConstraints(t *testing.T) {
 		{"pattern", &SchemaNode{Pattern: "^[a-z]+$"}, []string{"pattern: ^[a-z]+$"}},
 		{"format", &SchemaNode{Format: "date-time"}, []string{"format: date-time"}},
 		{"min/max length", &SchemaNode{MinLength: &minLen, MaxLength: &maxLen}, []string{"minLength: 1", "maxLength: 255"}},
-		{"min/max value", &SchemaNode{Minimum: &min, Maximum: &max}, []string{"minimum: 0", "maximum: 100"}},
+		{"min/max value", &SchemaNode{Minimum: &minVal, Maximum: &maxVal}, []string{"minimum: 0", "maximum: 100"}},
 		{"no constraints", &SchemaNode{Type: "string"}, nil},
 	}
 	for _, tt := range tests {
@@ -596,12 +596,12 @@ func TestConstraints(t *testing.T) {
 }
 
 func TestConstraints_OneOfBranchConstraints(t *testing.T) {
-	min := 1.0
-	max := 65535.0
+	minVal := 1.0
+	maxVal := 65535.0
 	node := &SchemaNode{
 		OneOf: []*SchemaNode{
 			{Type: "string", Pattern: "^[a-z]+$"},
-			{Type: "integer", Minimum: &min, Maximum: &max},
+			{Type: "integer", Minimum: &minVal, Maximum: &maxVal},
 			{Type: "null"},
 		},
 	}
@@ -756,9 +756,9 @@ func TestRenderSchema_BasicOutput(t *testing.T) {
 		{"bestCompletionForQuery(query)", "autocomplete suggestion lookup"},
 		{"return bestCompletionForPaths(query, currentSuggestions());", "default autocomplete uses shared path suggestions"},
 		{"ghostSuffixForCompletion(input.value, completion)", "inline ghost suffix calculation"},
-		{"if (e.key === '.' && document.activeElement === input", "dot key interception in search input"},
+		{"'.': dotAdvanceKey,", "dot key interception in search input"},
 		{"var dotAdvance = dotAdvanceForPathSearch(input.value, currentSuggestions());", "dot key uses shared path advance"},
-		{"var pathLikeQuery = isPathLikeQuery(input.value, currentSuggestions());", "dot interception is limited to actual path-like queries"},
+		{"if (!isPathLikeQuery(input.value, currentSuggestions())) {", "dot interception is limited to actual path-like queries"},
 		{"var learnedPathSearchStorageKey = 'crd-schema-publisher:path-search-learned';", "path search learning is persisted in local storage"},
 		{"function hasLearnedPathSearch()", "path search learned-state helper exists"},
 		{"function markPathSearchLearned(rawQuery)", "path search learned-state writer exists"},
@@ -766,16 +766,17 @@ func TestRenderSchema_BasicOutput(t *testing.T) {
 		{"if (queryState.segments.length < 2) {", "learned-state requires at least two path segments"},
 		{"localStorage.setItem(learnedPathSearchStorageKey, '1');", "learned path search is persisted per browser"},
 		{"setSearchStatus(hasLearnedPathSearch() ? '' : (searchStatus.dataset.emptyMessage || ''), false);", "empty hint is suppressed after learning"},
-		{"if (pathLikeQuery) {", "invalid dot positions are only blocked in path mode"},
-		{"if (input.selectionStart === input.value.length && input.selectionEnd === input.value.length) {", "dot interception only applies at the end of the query"},
+		{"function dotAdvanceKey(e){", "invalid dot positions are only blocked in path mode"},
+		{"if (caretAtInputEnd()) {", "dot interception only applies at the end of the query"},
 		{"clearSearchState();", "initial empty state is applied on page load"},
 		{"trimPathSearch(input.value)", "path-aware escape trimming"},
-		{"if ((e.key === 'Tab' || e.key === 'ArrowRight') && document.activeElement === input)", "tab and right arrow share autocomplete acceptance"},
-		{"var caretAtEnd = input.selectionStart === input.value.length && input.selectionEnd === input.value.length;", "autocomplete acceptance computes caret-at-end once"},
-		{"if (!caretAtEnd) {", "tab and right arrow only accept completion at end of input"},
-		{"e.key === 'ArrowDown' && document.activeElement === input", "arrow down completion browsing"},
-		{"e.key === 'ArrowUp' && document.activeElement === input", "arrow up completion browsing"},
-		{"e.key === '/'", "slash keyboard shortcut"},
+		{"Tab: acceptCompletionKey,", "tab shares autocomplete acceptance"},
+		{"ArrowRight: acceptCompletionKey,", "right arrow shares autocomplete acceptance"},
+		{"return input.selectionStart === input.value.length && input.selectionEnd === input.value.length;", "caret-at-end helper is computed in one place"},
+		{"if (document.activeElement !== input || !caretAtInputEnd()) {", "tab and right arrow only accept completion at end of input"},
+		{"ArrowDown: function(e){ cycleCompletionKey(e, 1); },", "arrow down completion browsing"},
+		{"ArrowUp: function(e){ cycleCompletionKey(e, -1); },", "arrow up completion browsing"},
+		{"'/': focusSearchKey,", "slash keyboard shortcut"},
 		{"toggleTheme", "theme toggle function"},
 		{`aria-pressed="false"`, "theme toggle exposes pressed state"},
 		{"favicon.svg", "favicon link"},

--- a/theme/index_page.test.js
+++ b/theme/index_page.test.js
@@ -276,7 +276,6 @@ function loadIndexPageScript({
     __calls: calls,
   };
   context.window.document = context.document;
-  context.window.scrollTo = context.window.scrollTo;
   context.window.SchemaSearch = {};
 
   vm.runInNewContext(script, context, { filename: 'index_page.js' });

--- a/theme/schema_page.js
+++ b/theme/schema_page.js
@@ -267,84 +267,100 @@
     applySearch('');
     input.focus();
   });
+  function caretAtInputEnd(){
+    return input.selectionStart === input.value.length && input.selectionEnd === input.value.length;
+  }
+  function cycleCompletionKey(e, delta){
+    if (document.activeElement !== input) {
+      return;
+    }
+    if (completionCandidates.length) {
+      e.preventDefault();
+      if (completionIndex < 0) {
+        completionIndex = delta > 0 ? 0 : completionCandidates.length - 1;
+      } else {
+        completionIndex = (completionIndex + delta + completionCandidates.length) % completionCandidates.length;
+      }
+      updateGhostSuggestion(input.value);
+    }
+  }
+  function acceptCompletionKey(e){
+    if (document.activeElement !== input || !caretAtInputEnd()) {
+      return;
+    }
+    var completion = selectedCompletion() || bestCompletionForQuery(input.value);
+    if (completion) {
+      e.preventDefault();
+      input.value = completion;
+      applySearch(completion);
+    }
+  }
+  function dotAdvanceKey(e){
+    if (document.activeElement !== input || e.ctrlKey || e.metaKey || e.altKey) {
+      return;
+    }
+    if (!isPathLikeQuery(input.value, currentSuggestions())) {
+      return;
+    }
+    if (caretAtInputEnd()) {
+      e.preventDefault();
+      var dotAdvance = dotAdvanceForPathSearch(input.value, currentSuggestions());
+      if (dotAdvance) {
+        input.value = dotAdvance;
+        applySearch(dotAdvance);
+      }
+    }
+  }
+  function focusSearchKey(e){
+    if (e.ctrlKey || e.metaKey || document.activeElement === input) {
+      return;
+    }
+    e.preventDefault();
+    input.focus();
+  }
+  function escapeKey(e){
+    e.preventDefault();
+    if (input.value) {
+      var trimmed = trimPathSearch(input.value);
+      if (trimmed !== input.value) {
+        input.value = trimmed;
+        applySearch(trimmed);
+      } else {
+        input.value = '';
+        applySearch('');
+        input.blur();
+      }
+      return;
+    }
+    var hadOpen = false;
+    visibleRows().forEach(function(row){
+      if (row.tagName === 'DETAILS' && row.hasAttribute('open')) {
+        hadOpen = true;
+        row.removeAttribute('open');
+      }
+    });
+    if (hadOpen) {
+      return;
+    }
+    if (document.activeElement && document.activeElement !== document.body) {
+      document.activeElement.blur();
+      return;
+    }
+    location.href = document.body.dataset.basePath + '/';
+  }
+  var searchKeyHandlers = {
+    ArrowDown: function(e){ cycleCompletionKey(e, 1); },
+    ArrowUp: function(e){ cycleCompletionKey(e, -1); },
+    Tab: acceptCompletionKey,
+    ArrowRight: acceptCompletionKey,
+    '.': dotAdvanceKey,
+    '/': focusSearchKey,
+    Escape: escapeKey,
+  };
   document.addEventListener('keydown', function(e){
-    if (e.key === 'ArrowDown' && document.activeElement === input) {
-      if (completionCandidates.length) {
-        e.preventDefault();
-        completionIndex = completionIndex < 0 ? 0 : (completionIndex + 1) % completionCandidates.length;
-        updateGhostSuggestion(input.value);
-      }
-      return;
-    }
-    if (e.key === 'ArrowUp' && document.activeElement === input) {
-      if (completionCandidates.length) {
-        e.preventDefault();
-        completionIndex = completionIndex < 0 ? completionCandidates.length - 1 : (completionIndex - 1 + completionCandidates.length) % completionCandidates.length;
-        updateGhostSuggestion(input.value);
-      }
-      return;
-    }
-    if ((e.key === 'Tab' || e.key === 'ArrowRight') && document.activeElement === input) {
-      var caretAtEnd = input.selectionStart === input.value.length && input.selectionEnd === input.value.length;
-      if (!caretAtEnd) {
-        return;
-      }
-      var completion = selectedCompletion() || bestCompletionForQuery(input.value);
-      if (completion) {
-        e.preventDefault();
-        input.value = completion;
-        applySearch(completion);
-      }
-      return;
-    }
-    if (e.key === '.' && document.activeElement === input && !e.ctrlKey && !e.metaKey && !e.altKey) {
-      var pathLikeQuery = isPathLikeQuery(input.value, currentSuggestions());
-      if (pathLikeQuery) {
-        if (input.selectionStart === input.value.length && input.selectionEnd === input.value.length) {
-          e.preventDefault();
-          var dotAdvance = dotAdvanceForPathSearch(input.value, currentSuggestions());
-          if (dotAdvance) {
-            input.value = dotAdvance;
-            applySearch(dotAdvance);
-          }
-        }
-        return;
-      }
-    }
-    if (e.key === '/' && !e.ctrlKey && !e.metaKey && document.activeElement !== input) {
-      e.preventDefault();
-      input.focus();
-      return;
-    }
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      if (input.value) {
-        var trimmed = trimPathSearch(input.value);
-        if (trimmed !== input.value) {
-          input.value = trimmed;
-          applySearch(trimmed);
-        } else {
-          input.value = '';
-          applySearch('');
-          input.blur();
-        }
-        return;
-      }
-      var hadOpen = false;
-      visibleRows().forEach(function(row){
-        if (row.tagName === 'DETAILS' && row.hasAttribute('open')) {
-          hadOpen = true;
-          row.removeAttribute('open');
-        }
-      });
-      if (hadOpen) {
-        return;
-      }
-      if (document.activeElement && document.activeElement !== document.body) {
-        document.activeElement.blur();
-        return;
-      }
-      location.href = document.body.dataset.basePath + '/';
+    var handler = Object.prototype.hasOwnProperty.call(searchKeyHandlers, e.key) ? searchKeyHandlers[e.key] : null;
+    if (handler) {
+      handler(e);
     }
   });
   (function(){

--- a/theme/schema_search.js
+++ b/theme/schema_search.js
@@ -55,28 +55,23 @@
     return pathState.segments[lastIndex].toLowerCase().indexOf(queryState.segments[lastIndex].toLowerCase()) === 0;
   }
 
-  function completionForSuggestion(rawQuery, suggestion) {
+  function parseCompletionQuery(rawQuery) {
     var query = (rawQuery || '').trim();
-    suggestion = (suggestion || '').trim();
-    if (!query || !suggestion) {
-      return '';
+    if (!query) {
+      return null;
     }
-
     var leadingDot = query.indexOf('.') === 0;
     var normalized = leadingDot ? query.slice(1) : query;
-    if (!leadingDot && normalized.indexOf('.') === -1) {
-      return '';
+    if (!normalized || (!leadingDot && normalized.indexOf('.') === -1)) {
+      return null;
     }
-    if (!normalized) {
-      return '';
-    }
+    return { leadingDot: leadingDot, parts: normalized.split('.') };
+  }
 
-    var queryParts = normalized.split('.');
-    var suggestionParts = suggestion.split('.');
+  function completeQueryAgainstSuggestion(queryParts, suggestionParts) {
     if (suggestionParts.length < queryParts.length) {
       return '';
     }
-
     for (var i = 0; i < queryParts.length - 1; i++) {
       if (queryParts[i].toLowerCase() !== suggestionParts[i].toLowerCase()) {
         return '';
@@ -89,8 +84,7 @@
     if (lastQuery.toLowerCase() === lastSuggestion.toLowerCase() && suggestionParts.length > queryParts.length) {
       var boundaryParts = queryParts.slice();
       boundaryParts[lastIndex] = lastSuggestion;
-      var boundaryResult = boundaryParts.join('.') + '.';
-      return leadingDot ? '.' + boundaryResult : boundaryResult;
+      return boundaryParts.join('.') + '.';
     }
     if (lastSuggestion.toLowerCase().indexOf(lastQuery.toLowerCase()) !== 0) {
       return '';
@@ -104,9 +98,20 @@
     } else {
       return '';
     }
+    return completed.join('.');
+  }
 
-    var result = completed.join('.');
-    return leadingDot ? '.' + result : result;
+  function completionForSuggestion(rawQuery, suggestion) {
+    suggestion = (suggestion || '').trim();
+    var parsed = parseCompletionQuery(rawQuery);
+    if (!parsed || !suggestion) {
+      return '';
+    }
+    var result = completeQueryAgainstSuggestion(parsed.parts, suggestion.split('.'));
+    if (!result) {
+      return '';
+    }
+    return parsed.leadingDot ? '.' + result : result;
   }
 
   function completionCandidatesForPaths(rawQuery, suggestions) {

--- a/watcher/lifecycle.go
+++ b/watcher/lifecycle.go
@@ -53,7 +53,7 @@ func newCRDController(ctx context.Context, cfg Config, trigger chan struct{}) ca
 
 	notify := cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { signalTrigger(trigger) },
-		UpdateFunc: func(old, new interface{}) { signalTrigger(trigger) },
+		UpdateFunc: func(_, _ interface{}) { signalTrigger(trigger) },
 		DeleteFunc: func(obj interface{}) { signalTrigger(trigger) },
 	}
 


### PR DESCRIPTION
Fixes all 10 issues on CodeFactor's list:

- **Built-in shadowing (6, Go)** — `min`/`max` → `minVal`/`maxVal` in `renderer/renderer_test.go` (×4), `copy` → `out` in `converter/converter.go`'s two copy helpers, and the unused `old, new` params in `watcher/lifecycle.go`'s `UpdateFunc` → `_, _`.
- **Self-assignment (1, JS)** — deleted `context.window.scrollTo = context.window.scrollTo;` in `theme/index_page.test.js`; the real stub is already defined in the window literal (matching `schema_page.test.js`).
- **Complex Method (2, JS)** —
  - `theme/schema_page.js` keydown listener (complexity 30) → key-map dispatch (`searchKeyHandlers`) over per-key handler functions, each embedding its own focus/modifier guards. Fall-through behavior of the original chain was a no-op in all non-matching cases, so dispatch is behavior-equivalent.
  - `theme/schema_search.js` `completionForSuggestion` (complexity 19) → split into `parseCompletionQuery` + `completeQueryAgainstSuggestion`.

`renderer/renderer_test.go`'s HTML assertions on verbatim JS shapes were updated to anchor on the refactored markers (this is also what caught the refactor in the first place — the full Go suite runs the theme JS through the renderer).

Verification: `go test ./...` exit 0, `node --test` theme + docs-site suites 91/91, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)