### PR TITLE
fix: migrate CRD ListWatch to context-aware functions

### DIFF
--- a/watcher/lifecycle.go
+++ b/watcher/lifecycle.go
@@ -37,16 +37,16 @@ func newSiteReadyChecker(outputDir string) func() bool {
 
 func runLeader(ctx context.Context, cfg Config) {
 	trigger := make(chan struct{}, 1)
-	controller := newCRDController(ctx, cfg, trigger)
+	controller := newCRDController(cfg, trigger)
 	runLeaderWithController(ctx, cfg, trigger, controller)
 }
 
-func newCRDController(ctx context.Context, cfg Config, trigger chan struct{}) cache.Controller {
+func newCRDController(cfg Config, trigger chan struct{}) cache.Controller {
 	lw := &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (k8sruntime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (k8sruntime.Object, error) {
 			return cfg.Client.ApiextensionsV1().CustomResourceDefinitions().List(ctx, opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return cfg.Client.ApiextensionsV1().CustomResourceDefinitions().Watch(ctx, opts)
 		},
 	}


### PR DESCRIPTION
## Root cause

`.github/workflows/test.yml` runs golangci-lint-action with no `version:` input, so it floats `latest`. golangci-lint v2.13.1 (released Aug 20) bundles staticcheck v0.8.0, which newly flags **SA1019** on the deprecated `cache.ListWatch` fields `ListFunc`/`WatchFunc` used in `watcher/lifecycle.go:46,49`. That broke every PR in the repo at once (example failing run: https://github.com/sholdee/crd-schema-publisher/actions/runs/32840322168), and main would fail the same way on its next run.

## What this change does

Migrates `newCRDController` to client-go's context-aware replacements (`ListWithContextFunc` / `WatchFuncWithContext` — the names are asymmetric by upstream design). The closures now use the per-call `ctx` supplied by the informer machinery (derived from its stop channel) instead of the closed-over outer context, and the now-unused `ctx` parameter of `newCRDController` is dropped.

Validated locally: `go build ./...`, `go test ./...` (all green), and golangci-lint **v2.13.1** reports 0 issues.

With this merged, CI goes green repo-wide — the open renovate PRs will pass on rebase/rerun. A follow-up PR pins the golangci-lint version in CI and puts it under renovate management so 'latest' drift can't break all PRs at once again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)