### PR TITLE
ci: pin golangci-lint to v2.13.1, update govulncheck to v1.7.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -115,7 +115,8 @@
         'go install golang\\.org/x/vuln/cmd/govulncheck@v(?<currentValue>[\\d.]+)',
       ],
       depNameTemplate: 'golang/vuln',
-      datasourceTemplate: 'github-releases',
+      datasourceTemplate: 'github-tags',
+      extractVersionTemplate: '^v(?<version>.+)$',
       versioningTemplate: 'semver',
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,6 +78,7 @@
         'rhysd/actionlint',
         'markdownlint-cli2',
         'golang/vuln',
+        'golangci/golangci-lint',
         'yannh/kubeconform',
         'helm/helm',
         'kubernetes/kubernetes',
@@ -126,6 +127,17 @@
       ],
       datasourceTemplate: 'npm',
       versioningTemplate: 'npm',
+    },
+    {
+      customType: 'regex',
+      description: ['Process golangci-lint versions in CI workflows'],
+      managerFilePatterns: ['/\\.github/workflows/.*\\.ya?ml$/'],
+      matchStrings: [
+        'uses: golangci/golangci-lint-action@[^\\n]+\\n\\s+with:\\n\\s+version: v(?<currentValue>[\\d.]+)',
+      ],
+      depNameTemplate: 'golangci/golangci-lint',
+      datasourceTemplate: 'github-releases',
+      versioningTemplate: 'semver',
     },
     {
       customType: 'regex',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,5 @@ jobs:
 
       - name: Vulnerability check
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           govulncheck ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.13.1
 
       - name: Verify dependencies
         run: go mod verify


### PR DESCRIPTION
## Root cause

The Lint step in `.github/workflows/test.yml` ran golangci-lint-action with no `version:` input, which floats `latest`. When golangci-lint v2.13 shipped on Aug 20 (bundling staticcheck v0.8.0 with new SA1019 findings), every PR in the repo went red simultaneously — with no change in the repo to review or bisect (example failing run: https://github.com/sholdee/crd-schema-publisher/actions/runs/32840322168). Pinning back to v2.12.2 is not viable long-term since it refuses go 1.27 modules.

## What this change does

- Pins the golangci-lint-action `version:` input to **v2.13.1**.
- Adds a renovate `customManager` (github-releases datasource, mirroring the existing setup-helm/setup-kubectl/kind entries) so the pin is renovate-managed — future lint upgrades arrive as ordinary reviewable renovate PRs whose own CI run shows any new findings, instead of ambient breakage across all open PRs.
- Adds `golangci/golangci-lint` to the existing 'Automerge minor/patch CI tool updates' packageRule, matching how actionlint and the other pinned CI tools are treated (automerge only fires on green CI, so a lint bump that introduces findings stays open for review).

Validated locally: actionlint clean on the workflow, `renovate-config-validator` passes on the json5, and the customManager regex verified (with node) to match the new `version: v2.13.1` line, extracting `2.13.1`.

Note: #248 fixes the current SA1019 findings themselves (deprecated `cache.ListWatch` fields); this PR prevents recurrence of the drift. The two are kept separate per repo convention — workflow-file changes never ride along with app code.

## Addendum: govulncheck v1.7.0

After rebasing onto main (which now includes the Go 1.27 toolchain bump from #243), CI exposed a second stale pin: `govulncheck@v1.1.4` panics on Go 1.27 code (`unexpected expr: *ast.KeyValueExpr` in x/tools v0.29.0's SSA builder) — the same latent bug just fixed in adguard-exporter#133. This PR now also:

- bumps the pin to `govulncheck@v1.7.0` (verified locally: analyzes this module cleanly as linux/amd64)
- switches the renovate custom manager for golang/vuln from `github-releases` to `github-tags` with `extractVersionTemplate` — golang/vuln stopped publishing GitHub releases after v1.1.4, which is why renovate never proposed v1.2–v1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)